### PR TITLE
fix: forward Range headers for quality variant endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed HTTP Range request handling for quality variant endpoints (`/{hash}/720p`, `/{hash}/480p`)
+  - iOS AVPlayer `CoreMediaErrorDomain -12939` ("byte range length mismatch") caused by returning full file instead of requested byte range
+  - Quality variant handler now forwards client `Range` header to GCS and returns proper `206 Partial Content` responses
+  - Fixes video playback on iOS for transcoded quality variants
+
 ### Added
 - MIME type inference from file extension when metadata is missing
   - Supports video (mp4, webm, mov, avi, mkv, ogv), image (jpg, png, gif, webp, svg, avif), and audio (mp3, wav, ogg, flac, m4a) formats


### PR DESCRIPTION
## Summary
- Quality variant endpoints (`/{hash}/720p`, `/{hash}/480p`) were ignoring the client `Range` header, always returning the full file
- iOS AVPlayer sends `Range: bytes=0-1` as a probe and rejects responses where `Content-Length` doesn't match (`CoreMediaErrorDomain -12939`)
- Now forwards the `Range` header to GCS and properly handles `206 Partial Content` responses

## Test plan
- [x] `curl -H "Range: bytes=0-1"` returns `206` with `Content-Length: 2` and `Content-Range` header
- [x] Mid-file range (`bytes=1000-1999`) returns correct partial content
- [x] No Range header still returns full `200` response
- [ ] iOS AVPlayer playback of `/720p` URLs

Already deployed to production (Fastly version 197) and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)