### PR TITLE
feat: trigger moderation scan on video upload

### DIFF
--- a/fastly.toml.example
+++ b/fastly.toml.example
@@ -36,6 +36,9 @@ language = "rust"
     [local_server.backends.cloud_run_upload]
     url = "https://blossom-upload-rust-149672065768.us-central1.run.app"
 
+    [local_server.backends.moderation_api]
+    url = "https://moderation-api.divine.video"
+
     [local_server.backends.r2_storage]
     url = "https://YOUR_R2_BUCKET.r2.cloudflarestorage.com"
 
@@ -63,6 +66,9 @@ language = "rust"
 
         [local_server.secret_stores.blossom_secrets.contents.gcs_secret_key]
         plaintext = "YOUR_GCS_SECRET_KEY"
+
+        [local_server.secret_stores.blossom_secrets.contents.moderation_api_token]
+        plaintext = "YOUR_MODERATION_API_BEARER_TOKEN"
 
 [setup]
 
@@ -107,6 +113,11 @@ language = "rust"
     [setup.backends.cloud_run_upload]
     description = "Cloud Run upload/migration service"
     address = "blossom-upload-rust-149672065768.us-central1.run.app"
+    port = 443
+
+    [setup.backends.moderation_api]
+    description = "Divine moderation API (CF Worker)"
+    address = "moderation-api.divine.video"
     port = 443
 
     [setup.backends.r2_storage]


### PR DESCRIPTION
Adds fire-and-forget POST to `divine-moderation-api` on video upload.

## Changes
- Add `moderation_api` backend to `fastly.toml.example`
- Add `moderation_api_token` to secret store config
- Add `trigger_moderation_scan()` function (async, non-blocking)
- Call it from both upload paths for video MIME types

## How it works
1. Video upload completes → blossom POSTs to `moderation-api.divine.video/api/v1/scan`
2. Moderation API queues on CF Queue
3. `divine-moderation-service` runs Hive AI analysis
4. Results flow back via existing `/admin/moderate` webhook

## Setup required
1. Add `moderation_api` backend in Fastly service config
2. Add `moderation_api_token` to blossom's secret store
3. Set `BLOSSOM_WEBHOOK_URL` + `BLOSSOM_WEBHOOK_SECRET` on divine-moderation-service

Related: https://github.com/divinevideo/divine-moderation-api