### PR TITLE
feat: admin content bypass endpoint for moderator review

### DIFF
--- a/scripts/test-admin-content-bypass.sh
+++ b/scripts/test-admin-content-bypass.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# ABOUTME: Integration test for admin content bypass endpoint
+# ABOUTME: Tests GET /admin/api/blob/{hash}/content auth, routing, and moderation bypass
+#
+# Requires: fastly compute serve running on $BASE_URL (default http://127.0.0.1:7676)
+# KV store must have test blobs (kv-store-data.json) and secrets (secrets-store-data.json)
+
+set -e
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:7676}"
+ADMIN_TOKEN="${ADMIN_TOKEN:-test-admin-token-local}"
+
+# Test hashes matching kv-store-data.json fixtures
+BANNED_HASH="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+ACTIVE_HASH="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+MISSING_HASH="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+PASS=0
+FAIL=0
+
+assert_http_code() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+
+    if [ "$actual" = "$expected" ]; then
+        echo "  PASS: $description (HTTP $actual)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $description (expected HTTP $expected, got HTTP $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_body_contains() {
+    local description="$1"
+    local expected="$2"
+    local body="$3"
+
+    if echo "$body" | grep -q "$expected"; then
+        echo "  PASS: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $description (expected body to contain '$expected', got: $body)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "Admin Content Bypass Endpoint Tests"
+echo "===================================="
+echo "Base URL: $BASE_URL"
+echo ""
+
+# ------------------------------------------------------------------
+echo "1. Auth enforcement"
+# ------------------------------------------------------------------
+
+CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    "$BASE_URL/admin/api/blob/$BANNED_HASH/content")
+assert_http_code "No auth returns 401" "401" "$CODE"
+
+CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer wrong-token" \
+    "$BASE_URL/admin/api/blob/$BANNED_HASH/content")
+assert_http_code "Wrong token returns 401" "401" "$CODE"
+
+# ------------------------------------------------------------------
+echo ""
+echo "2. Moderation bypass (banned blob)"
+# ------------------------------------------------------------------
+
+# Public endpoint blocks banned content at moderation check
+BODY=$(curl -s "$BASE_URL/$BANNED_HASH")
+assert_body_contains "Public endpoint blocks banned blob at moderation" \
+    '"error":"Blob not found"' "$BODY"
+
+# Admin bypass gets past moderation (fails at GCS download, not moderation)
+BODY=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+    "$BASE_URL/admin/api/blob/$BANNED_HASH/content")
+assert_body_contains "Admin bypass passes moderation, fails at storage" \
+    '"error":"Blob not found in any storage"' "$BODY"
+
+# ------------------------------------------------------------------
+echo ""
+echo "3. Active blob (both endpoints reach storage)"
+# ------------------------------------------------------------------
+
+BODY=$(curl -s "$BASE_URL/$ACTIVE_HASH")
+assert_body_contains "Public endpoint for active blob reaches storage" \
+    '"error":"Blob not found in any storage"' "$BODY"
+
+BODY=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+    "$BASE_URL/admin/api/blob/$ACTIVE_HASH/content")
+assert_body_contains "Admin bypass for active blob reaches storage" \
+    '"error":"Blob not found in any storage"' "$BODY"
+
+# ------------------------------------------------------------------
+echo ""
+echo "4. Nonexistent blob"
+# ------------------------------------------------------------------
+
+CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer $ADMIN_TOKEN" \
+    "$BASE_URL/admin/api/blob/$MISSING_HASH/content")
+assert_http_code "Nonexistent blob returns 404" "404" "$CODE"
+
+BODY=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+    "$BASE_URL/admin/api/blob/$MISSING_HASH/content")
+assert_body_contains "Nonexistent blob error from metadata lookup" \
+    '"error":"Blob not found"' "$BODY"
+
+# ------------------------------------------------------------------
+echo ""
+echo "5. Routing: metadata endpoint unaffected"
+# ------------------------------------------------------------------
+
+BODY=$(curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+    "$BASE_URL/admin/api/blob/$BANNED_HASH")
+assert_body_contains "Metadata endpoint returns JSON with sha256" \
+    '"sha256":"aaaa' "$BODY"
+assert_body_contains "Metadata endpoint shows banned status" \
+    '"status":"banned"' "$BODY"
+
+# ------------------------------------------------------------------
+echo ""
+echo "===================================="
+echo "Results: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,16 @@ fn handle_request(req: Request) -> Result<Response> {
             let pubkey = p.strip_prefix("/admin/api/user/").unwrap_or("");
             admin::handle_admin_user_blobs(req, pubkey)
         }
+        (Method::GET, p)
+            if p.starts_with("/admin/api/blob/") && p.ends_with("/content") =>
+        {
+            let hash = p
+                .strip_prefix("/admin/api/blob/")
+                .unwrap_or("")
+                .strip_suffix("/content")
+                .unwrap_or("");
+            admin::handle_admin_blob_content(req, hash)
+        }
         (Method::GET, p) if p.starts_with("/admin/api/blob/") => {
             let hash = p.strip_prefix("/admin/api/blob/").unwrap_or("");
             admin::handle_admin_blob_detail(req, hash)


### PR DESCRIPTION
## Summary

- Adds `GET /admin/api/blob/{hash}/content` endpoint that serves blob binary content regardless of moderation status (Banned, Restricted, etc.)
- Requires admin auth (Bearer token or session cookie), same as all other `/admin/api/` endpoints
- Sets `X-Moderation-Status` response header so callers know the blob's current state
- Handles Range requests (206 Partial Content) for video streaming
- Includes integration test script (`scripts/test-admin-content-bypass.sh`)

## Why

The moderation pipeline in divine-moderation-service auto-notifies Blossom via webhook for all AI classifications. Blossom immediately marks content as Banned or Restricted, which causes all GET endpoints to return 404. The `/admin/review` queue in divine-moderation-service exists specifically for human review of AI-flagged content, but every flagged video is invisible by the time it appears in the queue. Moderators see black rectangles instead of the content they need to review.

This endpoint lets divine-moderation-service proxy content through admin auth for the review queue, so moderators can actually see what they're moderating.

## Changes

| File | What |
|------|------|
| `src/admin.rs` | New `handle_admin_blob_content()` handler (42 lines) |
| `src/main.rs` | Route registration before existing `/admin/api/blob/` metadata route |
| `scripts/test-admin-content-bypass.sh` | Integration tests (10 assertions) |

## What this does NOT change

- Public GET endpoints still enforce moderation status
- Existing admin metadata endpoint (`/admin/api/blob/{hash}`) unchanged
- Webhook auth unchanged

## Consumer (separate PR, after this ships)

divine-moderation-service `/admin/video/` proxy adds a second fetch tier:
1. CDN (`media.divine.video/{sha256}`) for non-blocked content
2. Admin bypass (`media.divine.video/admin/api/blob/{sha256}/content` with Bearer token) for blocked content
3. R2 fallback (legacy)

Requires adding `BLOSSOM_ADMIN_TOKEN` as a secret on divine-moderation-service. The token already exists in Blossom's Secret Store as `admin_token`.

## Test plan

- [x] `fastly compute build` passes
- [x] Integration tests: 10/10 pass against `fastly compute serve`
  - Auth enforcement (no auth, wrong token)
  - Moderation bypass (banned blob passes metadata, reaches storage)
  - Active blob parity (both public and admin reach storage)
  - Nonexistent blob handling
  - Routing (metadata endpoint unaffected)
- [ ] Production deploy by Rabble after review

### Running tests locally

```bash
# Set up fixtures
cp kv-store-data.json.example kv-store-data.json  # or populate with test blob entries
echo '{"admin_token":"test-admin-token-local"}' > secrets-store-data.json

# Start local server
fastly compute serve &

# Run tests
scripts/test-admin-content-bypass.sh
```