### PR TITLE
fix: validate both admin_token and webhook_secret independently

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -49,52 +49,43 @@ pub fn validate_admin_auth(req: &Request) -> Result<()> {
     ))
 }
 
-/// Validate Bearer token from Authorization header
+/// Validate Bearer token from Authorization header.
+/// Accepts either admin_token or webhook_secret from the Fastly Secret Store.
+/// Both are checked independently — webhook_secret is used by divine-moderation-service.
 pub fn validate_bearer_token(req: &Request) -> Result<()> {
-    let expected_token: Option<String> = fastly::secret_store::SecretStore::open("blossom_secrets")
-        .ok()
-        .and_then(|store| {
-            store
-                .get("admin_token")
-                .map(|secret| {
-                    String::from_utf8(secret.plaintext().to_vec())
-                        .unwrap_or_default()
-                        .trim()
-                        .to_string()
-                })
-                .filter(|s| !s.is_empty())
-                .or_else(|| {
-                    store
-                        .get("webhook_secret")
-                        .map(|secret| {
-                            String::from_utf8(secret.plaintext().to_vec())
-                                .unwrap_or_default()
-                                .trim()
-                                .to_string()
-                        })
-                        .filter(|s| !s.is_empty())
-                })
-        });
-
-    let auth_header = req
+    let provided = req
         .get_header(header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string());
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| BlossomError::AuthRequired("Admin authentication required".into()))?;
 
-    match (expected_token, auth_header) {
-        (Some(expected), Some(header)) if header.starts_with("Bearer ") => {
-            let provided = header.strip_prefix("Bearer ").unwrap_or("").trim();
-            if provided == expected {
-                Ok(())
-            } else {
-                Err(BlossomError::Forbidden("Invalid admin token".into()))
-            }
+    let store = fastly::secret_store::SecretStore::open("blossom_secrets")
+        .map_err(|_| BlossomError::Forbidden("Secret store not available".into()))?;
+
+    // Accept admin_token
+    if let Some(secret) = store.get("admin_token") {
+        let token = String::from_utf8(secret.plaintext().to_vec())
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if !token.is_empty() && provided == token {
+            return Ok(());
         }
-        (Some(_), _) => Err(BlossomError::AuthRequired(
-            "Admin authentication required".into(),
-        )),
-        (None, _) => Err(BlossomError::Forbidden("Admin token not configured".into())),
     }
+
+    // Accept webhook_secret (used by divine-moderation-service)
+    if let Some(secret) = store.get("webhook_secret") {
+        let token = String::from_utf8(secret.plaintext().to_vec())
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if !token.is_empty() && provided == token {
+            return Ok(());
+        }
+    }
+
+    Err(BlossomError::Forbidden("Invalid admin token".into()))
 }
 
 /// Extract session token from Cookie header


### PR DESCRIPTION
## Summary

`validate_bearer_token()` uses an `or_else` fallback chain that only checks `webhook_secret` when `admin_token` is absent from the Secret Store. Since both exist, `webhook_secret` is never reached. This was fixed in PR #10 but reintroduced in 1cb3ee8.

divine-moderation-service (Cloudflare Worker) authenticates with `webhook_secret` to fetch blocked video content via `/admin/api/blob/{hash}/content`. Without both tokens checked, the review queue shows black rectangles for blocked videos.

Two tokens exist because `admin_token` is in the Fastly Secret Store for Blossom's admin UI and `webhook_secret` is a separate value held by divine-moderation-service on Cloudflare. Consolidating to one token would couple secret rotation across platforms. Checking both independently is the right fix.

## Test plan

- [ ] `fastly compute build` clean
- [ ] Deploy to Fastly, confirm `/admin/review` displays blocked video content