### PR TITLE
fix: preserve soft-deleted blobs and recover missing media recovery paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,15 @@ All notable changes to this project will be documented in this file.
   - Audit logging via Cloud Run → Google Cloud Logging (structured JSON with `service=divine-blossom, component=audit` labels)
   - Re-upload tracking: first uploader is owner, subsequent uploaders tracked in refs list
   - Tombstone system: legally removed content blocked from re-upload (returns 403)
-  - Admin force-delete endpoint (`POST /admin/api/delete`) with reason, legal hold, and full audit trail
-  - Cleans up GCS blobs, KV metadata, thumbnails, and all user lists on admin delete
+  - Admin soft-delete endpoint (`POST /admin/api/delete`) with reason, legal hold, and full audit trail
+  - Admin restore endpoint (`POST /admin/api/restore`) to recover soft-deleted blobs and re-index them
+  - Admin soft-delete now preserves storage, marks the blob `deleted`, and removes it from public serving/indexes
+
+### Fixed
+- Broken derivative recovery when the canonical blob is missing but HLS still exists
+  - Cloud Run thumbnail generation now falls back to HLS transport streams
+  - Cloud Run transcode/transcript jobs now fall back to HLS transport streams
+  - Allows thumbnails and VTTs to be regenerated for already-broken uploads without violating content-addressed raw blob semantics
 
 ### Fixed
 - Fixed HTTP Range request handling for quality variant endpoints (`/{hash}/720p`, `/{hash}/480p`)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Client → Fastly Compute (Rust WASM) → GCS (blobs) + Fastly KV (metadata)
 - **WebVTT transcripts**: Stable transcript URL at `/<sha256>.vtt` with async generation
 - **Provenance & audit**: Cryptographic proof of upload/delete authorship with Cloud Logging audit trail
 - **Tombstones**: Legal hold prevents re-upload of removed content
-- **Admin force-delete**: DMCA/legal removal with full audit trail
+- **Admin soft-delete**: DMCA/legal removal with full audit trail while preserving recoverable storage
+- **Admin restore**: Re-index and restore previously soft-deleted blobs
 
 ## Setup
 
@@ -107,7 +108,7 @@ fastly compute publish
 |--------|------|------|-------------|
 | `PUT` | `/upload` | Required | Upload blob |
 | `HEAD` | `/upload` | None | Get upload requirements |
-| `DELETE` | `/<sha256>` | Required | Delete blob |
+| `DELETE` | `/<sha256>` | Required | Permanently delete your own blob |
 | `GET` | `/list/<pubkey>` | Optional | List user's blobs |
 
 ### Provenance & Admin
@@ -115,7 +116,8 @@ fastly compute publish
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/<sha256>/provenance` | None | Get provenance info (owner, uploaders, auth events) |
-| `POST` | `/admin/api/delete` | Admin | Force-delete blob with audit trail and optional legal hold |
+| `POST` | `/admin/api/delete` | Admin | Soft-delete blob, remove it from public serving/indexes, and optionally set legal hold |
+| `POST` | `/admin/api/restore` | Admin | Restore a soft-deleted blob to `active`, `pending`, or `restricted` |
 
 ### Provenance
 
@@ -136,13 +138,29 @@ Every upload and delete stores the signed Nostr auth event (kind 24242) in KV as
 
 All uploads and deletes are logged to Google Cloud Logging via the Cloud Run upload service. Each audit entry includes: action, SHA-256, actor pubkey, timestamp, the signed auth event, and a metadata snapshot. Logs are queryable via Cloud Logging with labels `service=divine-blossom, component=audit`.
 
-### Admin Force-Delete
+### Delete Semantics
+
+- `DELETE /<sha256>` is a direct user delete and permanently removes the canonical blob.
+- `POST /admin/api/delete` is an admin soft-delete. It marks the blob as `deleted`, stops all public serving, removes it from user/recent indexes, and preserves the stored blob so it can be recovered later.
+- `POST /admin/api/restore` restores a soft-deleted blob and re-indexes it.
+- `legal_hold: true` sets a tombstone that prevents re-upload of the same hash even if the stored blob is preserved.
+
+### Admin Soft-Delete
 
 ```bash
 curl -X POST https://media.divine.video/admin/api/delete \
   -H "Authorization: Bearer <admin_token>" \
   -H "Content-Type: application/json" \
   -d '{"sha256": "abc123...", "reason": "DMCA #1234", "legal_hold": true}'
+```
+
+### Admin Restore
+
+```bash
+curl -X POST https://media.divine.video/admin/api/restore \
+  -H "Authorization: Bearer <admin_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"sha256": "abc123...", "status": "active"}'
 ```
 
 When `legal_hold: true`, a tombstone is set preventing re-upload of the removed content (returns 403).

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -449,9 +449,9 @@ async fn process_transcode(
     let temp_dir = TempDir::new()?;
     let temp_path = temp_dir.path();
 
-    // Download original video from GCS
-    let input_path = temp_path.join("input.mp4");
-    let download_result = download_from_gcs(
+    // Download the original blob, or fall back to the best available HLS transport stream.
+    let input_path = temp_path.join("input_media");
+    let download_result = download_best_available_media_to_path(
         &state.gcs_client,
         &state.config.gcs_bucket,
         &hash,
@@ -459,10 +459,13 @@ async fn process_transcode(
     )
     .await;
 
-    if let Err(e) = download_result {
-        send_status_webhook(&state.config, &hash, "failed", None, None).await;
-        return Err(e);
-    }
+    let source_object = match download_result {
+        Ok(source_object) => source_object,
+        Err(e) => {
+            send_status_webhook(&state.config, &hash, "failed", None, None).await;
+            return Err(e);
+        }
+    };
 
     info!("Downloaded video to {:?}", input_path);
 
@@ -470,13 +473,16 @@ async fn process_transcode(
     let mut source_metadata = match get_source_object_metadata(
         &state.gcs_client,
         &state.config.gcs_bucket,
-        &hash,
+        &source_object,
     )
     .await
     {
         Ok(meta) => meta,
         Err(e) => {
-            warn!("Failed to load source metadata for {}: {}", hash, e);
+            warn!(
+                "Failed to load source metadata for {} via {}: {}",
+                hash, source_object, e
+            );
             SourceObjectMetadata::default()
         }
     };
@@ -618,7 +624,7 @@ async fn process_transcribe(
     let temp_path = temp_dir.path();
 
     let input_path = temp_path.join("input_media");
-    if let Err(e) = download_from_gcs(
+    if let Err(e) = download_best_available_media_to_path(
         &state.gcs_client,
         &state.config.gcs_bucket,
         &hash,
@@ -812,6 +818,14 @@ async fn check_gcs_exists(client: &GcsClient, bucket: &str, object: &str) -> Res
     }
 }
 
+fn media_source_candidates(hash: &str) -> [String; 3] {
+    [
+        hash.to_string(),
+        format!("{}/hls/stream_720p.ts", hash),
+        format!("{}/hls/stream_480p.ts", hash),
+    ]
+}
+
 async fn download_from_gcs(
     client: &GcsClient,
     bucket: &str,
@@ -832,6 +846,38 @@ async fn download_from_gcs(
 
     tokio::fs::write(output_path, &data).await?;
     Ok(())
+}
+
+async fn download_best_available_media_to_path(
+    client: &GcsClient,
+    bucket: &str,
+    hash: &str,
+    output_path: &Path,
+) -> Result<String> {
+    let mut failures = Vec::new();
+
+    for object in media_source_candidates(hash) {
+        match download_from_gcs(client, bucket, &object, output_path).await {
+            Ok(()) => {
+                if object == hash {
+                    return Ok(object);
+                }
+
+                warn!(
+                    "Original blob missing for {}, using fallback media source {}",
+                    hash, object
+                );
+                return Ok(object);
+            }
+            Err(e) => failures.push(format!("{}: {}", object, e)),
+        }
+    }
+
+    Err(anyhow!(
+        "No recoverable media source found for {} ({})",
+        hash,
+        failures.join(" | ")
+    ))
 }
 
 /// Extract mono 16kHz PCM WAV audio for transcription.
@@ -1367,7 +1413,7 @@ async fn finalize_transcript(
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_transcript_to_vtt, parse_audio_analysis_output,
+        media_source_candidates, normalize_transcript_to_vtt, parse_audio_analysis_output,
         should_drop_low_signal_transcript, transcript_drop_reason, transcription_response_format,
         AudioAnalysis, ParsedVtt, TranscriptConfidence, TranscriptDropReason,
     };
@@ -1523,6 +1569,17 @@ mod tests {
             transcript_drop_reason(&analysis, &parsed_vtt),
             Some(TranscriptDropReason::LowProviderConfidence)
         );
+    }
+
+    #[test]
+    fn media_source_candidates_prefer_original_then_hls_variants() {
+        let hash =
+            "5b48aa1fcf30af61243ac9307eb98b7fa22df1c58573c3ca5d1b14fc30099929";
+        let candidates = media_source_candidates(hash);
+
+        assert_eq!(candidates[0], hash);
+        assert_eq!(candidates[1], format!("{}/hls/stream_720p.ts", hash));
+        assert_eq!(candidates[2], format!("{}/hls/stream_480p.ts", hash));
     }
 }
 

--- a/cloud-run-upload/src/main.rs
+++ b/cloud-run-upload/src/main.rs
@@ -38,7 +38,7 @@ use std::{
 use tempfile::NamedTempFile;
 use tower::Service;
 use tower_http::cors::{Any, CorsLayer};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 // Configuration
 struct Config {
@@ -506,6 +506,55 @@ async fn extract_and_upload_thumbnail(
     Ok(format!("{}/{}.jpg", cdn_base_url, hash))
 }
 
+fn media_source_candidates(hash: &str) -> [String; 3] {
+    [
+        hash.to_string(),
+        format!("{}/hls/stream_720p.ts", hash),
+        format!("{}/hls/stream_480p.ts", hash),
+    ]
+}
+
+async fn download_best_available_media_bytes(
+    client: &GcsClient,
+    bucket: &str,
+    hash: &str,
+) -> Result<(Vec<u8>, String)> {
+    let mut failures = Vec::new();
+
+    for object in media_source_candidates(hash) {
+        match client
+            .download_object(
+                &GetObjectRequest {
+                    bucket: bucket.to_string(),
+                    object: object.clone(),
+                    ..Default::default()
+                },
+                &DownloadRange::default(),
+            )
+            .await
+        {
+            Ok(data) => {
+                if object == hash {
+                    return Ok((data, object));
+                }
+
+                warn!(
+                    "Original blob missing for {}, using fallback media source {} for thumbnail generation",
+                    hash, object
+                );
+                return Ok((data, object));
+            }
+            Err(e) => failures.push(format!("{}: {}", object, e)),
+        }
+    }
+
+    Err(anyhow!(
+        "No recoverable media source found for {} ({})",
+        hash,
+        failures.join(" | ")
+    ))
+}
+
 /// On-demand thumbnail generation endpoint
 /// Downloads video from GCS, generates thumbnail, stores it, returns the image
 async fn handle_thumbnail_generate(
@@ -563,20 +612,15 @@ async fn handle_thumbnail_generate(
         }
     }
 
-    // Download the video from GCS
-    let video_data = match state
-        .gcs_client
-        .download_object(
-            &GetObjectRequest {
-                bucket: state.config.gcs_bucket.clone(),
-                object: hash.clone(),
-                ..Default::default()
-            },
-            &DownloadRange::default(),
-        )
-        .await
+    // Download the original blob, or fall back to the best available HLS transport stream.
+    let (video_data, source_object) = match download_best_available_media_bytes(
+        &state.gcs_client,
+        &state.config.gcs_bucket,
+        &hash,
+    )
+    .await
     {
-        Ok(data) => data,
+        Ok(result) => result,
         Err(e) => {
             error!("Failed to download video {}: {}", hash, e);
             return (
@@ -590,6 +634,13 @@ async fn handle_thumbnail_generate(
                 .into_response();
         }
     };
+
+    if source_object != hash {
+        warn!(
+            "Generating thumbnail for {} from fallback source {}",
+            hash, source_object
+        );
+    }
 
     // Generate thumbnail
     let thumb_result = match thumbnail::extract_thumbnail(&video_data) {
@@ -784,7 +835,7 @@ async fn probe_video_dimensions(video_bytes: &[u8]) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::new_temp_media_path;
+    use super::{media_source_candidates, new_temp_media_path};
 
     #[test]
     fn temp_media_paths_are_unique_per_request() {
@@ -796,6 +847,17 @@ mod tests {
         assert_ne!(first_path, second_path);
         assert!(first_path.ends_with(".mp4"));
         assert!(second_path.ends_with(".mp4"));
+    }
+
+    #[test]
+    fn media_source_candidates_prefer_original_then_hls_variants() {
+        let hash =
+            "5b48aa1fcf30af61243ac9307eb98b7fa22df1c58573c3ca5d1b14fc30099929";
+        let candidates = media_source_candidates(hash);
+
+        assert_eq!(candidates[0], hash);
+        assert_eq!(candidates[1], format!("{}/hls/stream_720p.ts", hash));
+        assert_eq!(candidates[2], format!("{}/hls/stream_480p.ts", hash));
     }
 }
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -4,9 +4,9 @@
 use crate::blossom::{BlobMetadata, BlobStatus, GlobalStats, RecentIndex, UserIndex};
 use crate::error::{BlossomError, Result};
 use crate::metadata::{
-    get_blob_metadata, get_global_stats, get_recent_index, get_user_blobs, get_user_index,
-    replace_global_stats, replace_recent_index, replace_user_index, update_blob_status,
-    update_stats_on_status_change,
+    add_to_recent_index, add_to_user_list, get_blob_metadata, get_blob_refs, get_global_stats,
+    get_recent_index, get_user_blobs, get_user_index, replace_global_stats, replace_recent_index,
+    replace_user_index, update_blob_status, update_stats_on_status_change,
 };
 use crate::storage::download_blob_with_fallback;
 use fastly::http::{header, Method, StatusCode};
@@ -731,6 +731,35 @@ struct ModerateRequest {
     action: String,
 }
 
+#[derive(Deserialize)]
+struct RestoreRequest {
+    sha256: String,
+    #[serde(default)]
+    status: Option<String>,
+}
+
+fn restore_soft_deleted_blob(hash: &str, metadata: &BlobMetadata, new_status: BlobStatus) -> Result<()> {
+    if new_status == BlobStatus::Deleted {
+        return Err(BlossomError::BadRequest(
+            "Restore target status cannot be deleted".into(),
+        ));
+    }
+
+    update_blob_status(hash, new_status)?;
+    let _ = update_stats_on_status_change(metadata.status, new_status);
+
+    let _ = add_to_user_list(&metadata.owner, hash);
+    if let Ok(refs) = get_blob_refs(hash) {
+        for pubkey in &refs {
+            let _ = add_to_user_list(pubkey, hash);
+        }
+    }
+    let _ = add_to_recent_index(hash);
+    crate::purge_vcl_cache(hash);
+
+    Ok(())
+}
+
 pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
     validate_admin_auth(&req)?;
 
@@ -764,22 +793,73 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
         }
     };
 
-    // Update blob status
-    update_blob_status(&moderate_req.sha256, new_status)?;
-
-    // Purge VCL cache so moderation takes effect immediately
     if old_status != new_status {
-        crate::purge_vcl_cache(&moderate_req.sha256);
+        if old_status == BlobStatus::Deleted {
+            restore_soft_deleted_blob(&moderate_req.sha256, &metadata, new_status)?;
+        } else {
+            update_blob_status(&moderate_req.sha256, new_status)?;
+            crate::purge_vcl_cache(&moderate_req.sha256);
+            let _ = update_stats_on_status_change(old_status, new_status);
+        }
     }
-
-    // Update global stats for the status change
-    if old_status != new_status {
-        let _ = update_stats_on_status_change(old_status, new_status);
-    }
-
     let response = serde_json::json!({
         "success": true,
         "sha256": moderate_req.sha256,
+        "old_status": format!("{:?}", old_status).to_lowercase(),
+        "new_status": format!("{:?}", new_status).to_lowercase()
+    });
+
+    json_response(StatusCode::OK, &response)
+}
+
+/// POST /admin/api/restore - Restore a previously soft-deleted blob
+pub fn handle_admin_restore_action(mut req: Request) -> Result<Response> {
+    validate_admin_auth(&req)?;
+
+    let body = req.take_body().into_string();
+    let restore_req: RestoreRequest = serde_json::from_str(&body)
+        .map_err(|e| BlossomError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    if restore_req.sha256.len() != 64
+        || !restore_req.sha256.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
+    }
+
+    let metadata = get_blob_metadata(&restore_req.sha256)?
+        .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
+    let old_status = metadata.status;
+
+    if old_status != BlobStatus::Deleted {
+        return Err(BlossomError::BadRequest(
+            "Blob is not soft-deleted".into(),
+        ));
+    }
+
+    let new_status = match restore_req
+        .status
+        .as_deref()
+        .unwrap_or("active")
+        .to_uppercase()
+        .as_str()
+    {
+        "APPROVE" | "ACTIVE" => BlobStatus::Active,
+        "PENDING" => BlobStatus::Pending,
+        "RESTRICT" | "RESTRICTED" => BlobStatus::Restricted,
+        other => {
+            return Err(BlossomError::BadRequest(format!(
+                "Unknown restore status: {}",
+                other
+            )))
+        }
+    };
+
+    restore_soft_deleted_blob(&restore_req.sha256, &metadata, new_status)?;
+
+    let response = serde_json::json!({
+        "success": true,
+        "restored": true,
+        "sha256": restore_req.sha256,
         "old_status": format!("{:?}", old_status).to_lowercase(),
         "new_status": format!("{:?}", new_status).to_lowercase()
     });
@@ -1382,17 +1462,25 @@ const ADMIN_HTML: &str = r#"<!DOCTYPE html>
                                     <td><span class="status status-${b.status}">${b.status}</span></td>
                                     <td><span class="pubkey" onclick="showUserBlobs('${b.owner}')">${b.owner.substring(0,12)}...</span></td>
                                     <td><span class="date">${new Date(b.uploaded).toLocaleDateString()}</span></td>
-                                    <td class="actions">
-                                        <button class="btn btn-approve" onclick="moderate('${b.sha256}','approve')">OK</button>
-                                        <button class="btn btn-restrict" onclick="moderate('${b.sha256}','restrict')">R</button>
-                                        <button class="btn btn-ban" onclick="moderate('${b.sha256}','ban')">X</button>
-                                    </td>
+                                    <td class="actions">${renderBlobActions(b)}</td>
                                 </tr>
                             `).join('')}
                         </tbody>
                     </table>
                 </div>
                 ${pagination ? renderPagination(pagination) : ''}
+            `;
+        }
+
+        function renderBlobActions(blob) {
+            if (blob.status === 'deleted') {
+                return `<button class="btn btn-approve" onclick="restoreBlob('${blob.sha256}')">Restore</button>`;
+            }
+
+            return `
+                <button class="btn btn-approve" onclick="moderate('${blob.sha256}','approve')">OK</button>
+                <button class="btn btn-restrict" onclick="moderate('${blob.sha256}','restrict')">R</button>
+                <button class="btn btn-ban" onclick="moderate('${blob.sha256}','ban')">X</button>
             `;
         }
 
@@ -1455,6 +1543,22 @@ const ADMIN_HTML: &str = r#"<!DOCTYPE html>
             }
         }
 
+        async function restoreBlob(sha256, status = 'active') {
+            try {
+                const resp = await fetch('/admin/api/restore', {
+                    method: 'POST',
+                    headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ sha256, status })
+                });
+                if (!resp.ok) throw new Error('Restore failed');
+                await resp.json();
+                loadStats();
+                loadTabContent(currentOffset);
+            } catch (e) {
+                showError(e.message);
+            }
+        }
+
         async function showBlobDetail(hash) {
             const panel = document.getElementById('detailPanel');
             const content = document.getElementById('detailContent');
@@ -1470,6 +1574,14 @@ const ADMIN_HTML: &str = r#"<!DOCTYPE html>
                 const isImage = blob.type?.startsWith('image');
                 const thumbUrl = blob.thumbnail || (isVideo ? '/' + blob.sha256 + '.jpg' : null);
                 const previewUrl = isImage ? '/' + blob.sha256 : thumbUrl;
+
+                const actionButtons = blob.status === 'deleted'
+                    ? `<button class="btn btn-approve" onclick="restoreBlob('${blob.sha256}');closeDetail()">Restore</button>`
+                    : `
+                        <button class="btn btn-approve" onclick="moderate('${blob.sha256}','approve');closeDetail()">Approve</button>
+                        <button class="btn btn-restrict" onclick="moderate('${blob.sha256}','restrict');closeDetail()">Restrict</button>
+                        <button class="btn btn-ban" onclick="moderate('${blob.sha256}','ban');closeDetail()">Ban</button>
+                    `;
 
                 content.innerHTML = `
                     ${isVideo ? `<video src="/${blob.sha256}" class="detail-preview" controls poster="${thumbUrl}" style="max-width:100%"></video>` : (previewUrl ? `<img src="${previewUrl}" class="detail-preview">` : '')}
@@ -1504,9 +1616,7 @@ const ADMIN_HTML: &str = r#"<!DOCTYPE html>
                     </div>
                     ` : ''}
                     <div class="actions" style="margin-top:1rem">
-                        <button class="btn btn-approve" onclick="moderate('${blob.sha256}','approve');closeDetail()">Approve</button>
-                        <button class="btn btn-restrict" onclick="moderate('${blob.sha256}','restrict');closeDetail()">Restrict</button>
-                        <button class="btn btn-ban" onclick="moderate('${blob.sha256}','ban');closeDetail()">Ban</button>
+                        ${actionButtons}
                     </div>
                     <div style="margin-top:1rem">
                         <a href="/${blob.sha256}" target="_blank" class="btn btn-approve">View File</a>

--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -78,6 +78,18 @@ pub enum BlobStatus {
     Pending,
     /// Permanently banned by moderation - not accessible to anyone
     Banned,
+    /// Soft-deleted internally; preserved in storage but never served publicly
+    Deleted,
+}
+
+impl BlobStatus {
+    pub fn blocks_public_access(self) -> bool {
+        matches!(self, BlobStatus::Banned | BlobStatus::Deleted)
+    }
+
+    pub fn requires_owner_auth(self) -> bool {
+        matches!(self, BlobStatus::Restricted)
+    }
 }
 
 /// Transcode status for video blobs

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use crate::metadata::{
     get_subtitle_job_by_hash, get_tombstone, put_auth_event, put_blob_metadata, put_subtitle_job,
     put_tombstone, set_subtitle_job_id_for_hash, list_blobs_with_metadata,
     remove_from_recent_index, remove_from_user_list, update_blob_status, update_stats_on_add,
-    update_stats_on_remove,
+    update_stats_on_remove, update_stats_on_status_change,
 };
 use crate::storage::{
     blob_exists, current_timestamp, delete_blob as storage_delete, download_blob_with_fallback,
@@ -168,6 +168,7 @@ fn handle_request(req: Request) -> Result<Response> {
         }
         (Method::POST, "/admin/api/moderate") => admin::handle_admin_moderate_action(req),
         (Method::POST, "/admin/api/delete") => handle_admin_force_delete(req),
+        (Method::POST, "/admin/api/restore") => admin::handle_admin_restore_action(req),
         (Method::POST, "/admin/api/backfill") => admin::handle_admin_backfill(req),
         (Method::POST, "/admin/api/backfill-vtt") => handle_admin_backfill_vtt(req),
 
@@ -188,10 +189,10 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         // Check parent video's moderation status - thumbnails inherit video access rules
         let mut is_restricted = false;
         if let Ok(Some(meta)) = get_blob_metadata(video_hash) {
-            if meta.status == BlobStatus::Banned {
+            if meta.status.blocks_public_access() {
                 return Err(BlossomError::NotFound("Blob not found".into()));
             }
-            if meta.status == BlobStatus::Restricted {
+            if meta.status.requires_owner_auth() {
                 // Check if requester is owner
                 if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
                     if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
@@ -247,14 +248,13 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
 
     if let Some(ref meta) = metadata {
-        if !is_admin {
-            // Handle banned content - no access for anyone
-            if meta.status == BlobStatus::Banned {
-                return Err(BlossomError::NotFound("Blob not found".into()));
-            }
+        if meta.status.blocks_public_access() {
+            return Err(BlossomError::NotFound("Blob not found".into()));
+        }
 
+        if !is_admin {
             // Handle restricted content
-            if meta.status == BlobStatus::Restricted {
+            if meta.status.requires_owner_auth() {
                 // Check if requester is owner
                 if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
                     if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
@@ -386,7 +386,7 @@ fn handle_head_blob(path: &str) -> Result<Response> {
         get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     // Don't reveal restricted or banned content exists
-    if metadata.status == BlobStatus::Restricted || metadata.status == BlobStatus::Banned {
+    if metadata.status.requires_owner_auth() || metadata.status.blocks_public_access() {
         return Err(BlossomError::NotFound("Blob not found".into()));
     }
 
@@ -423,12 +423,12 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
 
     if let Some(ref meta) = metadata {
         // Handle banned content
-        if meta.status == BlobStatus::Banned {
+        if meta.status.blocks_public_access() {
             return Err(BlossomError::NotFound("Content not found".into()));
         }
 
         // Handle restricted content
-        if meta.status == BlobStatus::Restricted {
+        if meta.status.requires_owner_auth() {
             if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
                 if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
                     return Err(BlossomError::NotFound("Content not found".into()));
@@ -528,7 +528,7 @@ fn handle_head_hls_master(path: &str) -> Result<Response> {
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
     // Don't reveal restricted/banned content
-    if metadata.status == BlobStatus::Restricted || metadata.status == BlobStatus::Banned {
+    if metadata.status.requires_owner_auth() || metadata.status.blocks_public_access() {
         return Err(BlossomError::NotFound("Content not found".into()));
     }
 
@@ -621,7 +621,7 @@ fn handle_get_hls_content(_req: Request, path: &str) -> Result<Response> {
 
             if let Some(ref meta) = metadata {
                 // Handle banned content
-                if meta.status == BlobStatus::Banned {
+                if meta.status.blocks_public_access() {
                     return Err(BlossomError::NotFound("Content not found".into()));
                 }
 
@@ -852,11 +852,11 @@ fn serve_transcript_by_hash(req: Option<&Request>, hash: &str, can_trigger: bool
     let metadata = get_blob_metadata(hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-    if metadata.status == BlobStatus::Banned {
+    if metadata.status.blocks_public_access() {
         return Err(BlossomError::NotFound("Content not found".into()));
     }
 
-    if metadata.status == BlobStatus::Restricted {
+    if metadata.status.requires_owner_auth() {
         if let Some(request) = req {
             if let Ok(Some(auth)) = optional_auth(request, AuthAction::List) {
                 if auth.pubkey.to_lowercase() != metadata.owner.to_lowercase() {
@@ -953,7 +953,7 @@ fn handle_head_transcript_by_hash(hash: &str) -> Result<Response> {
     let metadata = get_blob_metadata(hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-    if metadata.status == BlobStatus::Restricted || metadata.status == BlobStatus::Banned {
+    if metadata.status.requires_owner_auth() || metadata.status.blocks_public_access() {
         return Err(BlossomError::NotFound("Content not found".into()));
     }
 
@@ -1292,10 +1292,10 @@ fn handle_get_quality_variant(req: Request, path: &str) -> Result<Response> {
     // Check metadata for access control
     let metadata = get_blob_metadata(&hash)?;
     if let Some(ref meta) = metadata {
-        if meta.status == BlobStatus::Banned {
+        if meta.status.blocks_public_access() {
             return Err(BlossomError::NotFound("Content not found".into()));
         }
-        if meta.status == BlobStatus::Restricted {
+        if meta.status.requires_owner_auth() {
             if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
                 if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
                     return Err(BlossomError::NotFound("Content not found".into()));
@@ -1367,7 +1367,7 @@ fn handle_head_quality_variant(path: &str) -> Result<Response> {
     let metadata = get_blob_metadata(&hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-    if metadata.status == BlobStatus::Banned || metadata.status == BlobStatus::Restricted {
+    if metadata.status.blocks_public_access() || metadata.status.requires_owner_auth() {
         return Err(BlossomError::NotFound("Content not found".into()));
     }
 
@@ -2042,7 +2042,8 @@ fn handle_get_provenance(path: &str) -> Result<Response> {
     Ok(resp)
 }
 
-/// POST /admin/api/delete - Admin force-delete for legal/DMCA compliance
+/// POST /admin/api/delete - Admin soft-delete for legal/DMCA compliance
+/// Preserves storage unless the blob has no metadata record to gate public access with.
 fn handle_admin_force_delete(req: Request) -> Result<Response> {
     // Validate admin auth
     admin::validate_admin_auth(&req)?;
@@ -2084,14 +2085,18 @@ fn handle_admin_force_delete(req: Request) -> Result<Response> {
         Some(reason),
     );
 
-    // Delete from GCS (main blob)
-    let _ = storage_delete(&hash);
-
-    // Delete thumbnail
-    let _ = storage_delete(&format!("{}.jpg", hash));
-
-    // Delete KV metadata
-    let _ = delete_blob_metadata(&hash);
+    let preserved = if let Some(ref meta) = metadata {
+        if meta.status != BlobStatus::Deleted {
+            update_blob_status(&hash, BlobStatus::Deleted)?;
+            let _ = update_stats_on_status_change(meta.status, BlobStatus::Deleted);
+        }
+        true
+    } else {
+        // Without metadata there is no status gate, so fall back to hard delete.
+        let _ = storage_delete(&hash);
+        let _ = storage_delete(&format!("{}.jpg", hash));
+        false
+    };
 
     // Remove from ALL users' lists (owner + all refs)
     if let Some(ref meta) = metadata {
@@ -2103,9 +2108,11 @@ fn handle_admin_force_delete(req: Request) -> Result<Response> {
         }
     }
 
-    // Update stats
-    if let Some(meta) = metadata {
-        let _ = update_stats_on_remove(&meta);
+    // Update stats for the hard-delete fallback only.
+    if !preserved {
+        if let Some(meta) = metadata {
+            let _ = update_stats_on_remove(&meta);
+        }
     }
     let _ = remove_from_recent_index(&hash);
 
@@ -2114,13 +2121,17 @@ fn handle_admin_force_delete(req: Request) -> Result<Response> {
         let _ = put_tombstone(&hash, reason);
     }
 
+    purge_vcl_cache(&hash);
+
     eprintln!(
-        "[ADMIN DELETE] hash={} reason={} legal_hold={}",
-        hash, reason, legal_hold
+        "[ADMIN DELETE] hash={} reason={} legal_hold={} preserved={}",
+        hash, reason, legal_hold, preserved
     );
 
     let result = serde_json::json!({
         "deleted": true,
+        "soft_deleted": preserved,
+        "preserved": preserved,
         "sha256": hash,
         "legal_hold": legal_hold,
     });
@@ -3203,7 +3214,7 @@ fn handle_landing_page() -> Response {
                 <span class="method method-delete">DELETE</span>
                 <div class="endpoint-info">
                     <span class="endpoint-path">/&lt;sha256&gt;</span>
-                    <p class="endpoint-desc">Delete a blob. Requires Nostr authentication and ownership. <em>(BUD-02)</em></p>
+                    <p class="endpoint-desc">Permanently delete your own blob. Requires Nostr authentication and ownership. <em>(BUD-02)</em></p>
                 </div>
             </div>
             <div class="endpoint">
@@ -3252,6 +3263,10 @@ fn handle_landing_page() -> Response {
                 <div class="feature">
                     <h3>GCS Storage</h3>
                     <p>Reliable blob storage backed by Google Cloud Storage.</p>
+                </div>
+                <div class="feature">
+                    <h3>Soft Delete Recovery</h3>
+                    <p>Admin deletes preserve stored media as internal soft-deletes, with explicit restore support for recovery and legal workflows.</p>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- preserve admin deletes as soft-deleted blobs that are removed from public serving but retained for restore
- add an explicit admin restore endpoint and admin UI restore actions that re-index preserved blobs
- recover thumbnails, transcripts, and transcode inputs from existing HLS transport streams when the canonical blob is missing
- document the new delete and restore semantics in the README, changelog, and public API docs

## Testing
- cargo test (cloud-run-upload)
- cargo test (cloud-run-transcoder)
- cargo +1.93.0 test --locked (repo root)