### PR TITLE
fix: handle QUARANTINE moderation action

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2617,11 +2617,11 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
     // Map action to BlobStatus
     let new_status = match action.to_uppercase().as_str() {
         "BLOCK" | "BAN" | "PERMANENT_BAN" => BlobStatus::Banned,
-        "RESTRICT" | "AGE_RESTRICTED" => BlobStatus::Restricted,
+        "RESTRICT" | "AGE_RESTRICTED" | "QUARANTINE" => BlobStatus::Restricted,
         "APPROVE" | "SAFE" => BlobStatus::Active,
         _ => {
             return Err(BlossomError::BadRequest(format!(
-                "Unknown action: {}. Expected BLOCK, RESTRICT, or APPROVE",
+                "Unknown action: {}. Expected BLOCK, RESTRICT, QUARANTINE, or APPROVE",
                 action
             )));
         }


### PR DESCRIPTION
## Summary
- Add `QUARANTINE` to the `/admin/moderate` webhook action map, mapping it to `Restricted` (shadow-restricted) status
- AI-generated content detected by HiveAI (99.99% AI score) was classified as `QUARANTINE` but Blossom rejected it as an unknown action, leaving content publicly accessible in `pending` status
- Companion PR: https://github.com/divinevideo/divine-moderation-service/pull/29 (forwards QUARANTINE to Blossom webhook)

## What happened
1. HiveAI detected AI-generated content → moderation service set action `QUARANTINE`
2. Moderation service's `notifyBlossom()` excluded QUARANTINE from webhook allowlist (fixed in companion PR)
3. Even if it had been forwarded, Blossom would have rejected it as "Unknown action" (fixed here)
4. Content stayed in `pending` status and was served publicly

## Test plan
- [x] Verified `QUARANTINE` webhook returns 200 with `status: restricted`
- [x] Already deployed to Fastly Compute v229

🤖 Generated with [Claude Code](https://claude.com/claude-code)