### PR TITLE
Fix subtitle transcription reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ fastly compute publish
 | `HEAD` | `/<sha256>.vtt` | Check transcript status/existence |
 | `GET` | `/<sha256>/VTT` | Alias for transcript retrieval |
 
+`GET /<sha256>.vtt` returns `202 Accepted` with `Retry-After` while transcription is still running or cooling down after a retryable provider failure. Clients should poll again instead of treating that response as "no subtitles".
+
 ### Subtitle Jobs API
 
 | Method | Path | Description |
@@ -164,6 +166,30 @@ curl -X POST https://media.divine.video/admin/api/restore \
 ```
 
 When `legal_hold: true`, a tombstone is set preventing re-upload of the removed content (returns 403).
+
+## Transcript Recovery
+
+Use the repo-level backfill wrapper to inspect or enqueue missing transcripts through the existing `/admin/api/backfill-vtt` endpoint.
+
+Dry-run the recent upload window without triggering work:
+
+```bash
+ADMIN_BEARER_TOKEN=<webhook_or_admin_token> \
+bash scripts/backfill_missing_transcripts.sh --dry-run --limit 20
+```
+
+Enqueue the recent backfill at a controlled pace after Cloud Run and Blossom fixes are deployed:
+
+```bash
+ADMIN_BEARER_TOKEN=<webhook_or_admin_token> \
+bash scripts/backfill_missing_transcripts.sh --limit 200 --sleep 2
+```
+
+Notes:
+- Set either `ADMIN_BEARER_TOKEN` or `ADMIN_COOKIE`.
+- `--scope recent` is the default and scans the rolling recent-upload index first.
+- Use `--scope users` for a full corpus sweep when the recent window is not enough.
+- `--reset-processing` requeues blobs stuck in `processing`, and `--force-retranscribe` reruns blobs marked `complete`.
 
 ## Authentication
 

--- a/cloud-run-transcoder/deploy.sh
+++ b/cloud-run-transcoder/deploy.sh
@@ -1,63 +1,42 @@
 #!/bin/bash
-# ABOUTME: Deploy divine-transcoder to Cloud Run using the current production CPU shape by default
-# ABOUTME: GPU deployment remains opt-in via USE_GPU=true for projects with approved GPU quota
+# ABOUTME: Deploy divine-transcoder to Cloud Run with GPU support
+# ABOUTME: Requires L4 GPU quota to be approved in your GCP project
 
-set -euo pipefail
+set -e
 
 PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project)}"
 REGION="${REGION:-us-central1}"
-SERVICE_NAME="${SERVICE_NAME:-divine-transcoder}"
-IMAGE_REPO="gcr.io/${PROJECT_ID}/${SERVICE_NAME}"
-IMAGE_TAG="${IMAGE_TAG:-latest}"
-IMAGE="${IMAGE_REPO}:${IMAGE_TAG}"
+SERVICE_NAME="divine-transcoder"
+IMAGE="gcr.io/${PROJECT_ID}/${SERVICE_NAME}"
 
-USE_GPU="${USE_GPU:-false}"
-CPU="${CPU:-4}"
-MEMORY="${MEMORY:-}"
-MAX_INSTANCES="${MAX_INSTANCES:-10}"
-CONCURRENCY="${CONCURRENCY:-320}"
-TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-900}"
-MIN_INSTANCES="${MIN_INSTANCES:-}"
-GPU_COUNT="${GPU_COUNT:-1}"
-GPU_TYPE="${GPU_TYPE:-nvidia-l4}"
-
-if [[ "${USE_GPU}" == "true" ]]; then
-  MEMORY="${MEMORY:-16Gi}"
-  MIN_INSTANCES="${MIN_INSTANCES:-1}"
-else
-  MEMORY="${MEMORY:-8Gi}"
-fi
-
-echo "Building and pushing Docker image ${IMAGE}..."
+echo "Building and pushing Docker image..."
 docker build --platform linux/amd64 -t "${IMAGE}" .
 docker push "${IMAGE}"
 
-deploy_args=(
-  --image "${IMAGE}"
-  --region "${REGION}"
-  --cpu "${CPU}"
-  --memory "${MEMORY}"
-  --max-instances "${MAX_INSTANCES}"
-  --concurrency "${CONCURRENCY}"
-  --timeout "${TIMEOUT_SECONDS}"
-  --no-cpu-throttling
-  --set-env-vars "GCS_BUCKET=divine-blossom-media,WEBHOOK_URL=https://media.divine.video/admin/transcode-status,TRANSCRIPT_WEBHOOK_URL=https://media.divine.video/admin/transcript-status,TRANSCRIPTION_API_URL=https://api.openai.com/v1/audio/transcriptions,TRANSCRIPTION_MODEL=whisper-1"
-  --set-secrets "WEBHOOK_SECRET=webhook_secret:latest,TRANSCRIPTION_API_KEY=openai_api_key:latest"
+echo "Deploying to Cloud Run with GPU..."
+gcloud run deploy "${SERVICE_NAME}" \
+  --image "${IMAGE}" \
+  --region "${REGION}" \
+  --gpu 1 \
+  --gpu-type nvidia-l4 \
+  --cpu 4 \
+  --memory 16Gi \
+  --concurrency 8 \
+  --min-instances 1 \
+  --max-instances 10 \
+  --no-cpu-throttling \
+  --set-env-vars "GCS_BUCKET=divine-blossom-media" \
+  --set-env-vars "WEBHOOK_URL=https://media.divine.video/admin/transcode-status" \
+  --set-env-vars "TRANSCRIPT_WEBHOOK_URL=https://media.divine.video/admin/transcript-status" \
+  --set-env-vars "TRANSCRIPTION_API_URL=https://api.openai.com/v1/audio/transcriptions" \
+  --set-env-vars "TRANSCRIPTION_MODEL=whisper-1" \
+  --set-env-vars "TRANSCRIPTION_MAX_IN_FLIGHT=4" \
+  --set-env-vars "TRANSCRIPTION_MAX_RETRIES=3" \
+  --set-env-vars "TRANSCRIPTION_RETRY_BASE_MS=1000" \
+  --set-env-vars "TRANSCRIPTION_RETRY_MAX_MS=15000" \
+  --set-env-vars "TRANSCRIPTION_RETRY_TOTAL_MS=30000" \
+  --set-secrets "WEBHOOK_SECRET=webhook_secret:latest,TRANSCRIPTION_API_KEY=openai_api_key:latest" \
   --allow-unauthenticated
-)
 
-if [[ -n "${MIN_INSTANCES}" ]]; then
-  deploy_args+=(--min-instances "${MIN_INSTANCES}")
-fi
-
-if [[ "${USE_GPU}" == "true" ]]; then
-  deploy_args+=(--gpu "${GPU_COUNT}" --gpu-type "${GPU_TYPE}")
-  echo "Deploying to Cloud Run with GPU support..."
-else
-  echo "Deploying to Cloud Run with CPU defaults..."
-fi
-
-gcloud run deploy "${SERVICE_NAME}" "${deploy_args[@]}"
-
-echo "Done. Service URL:"
+echo "Done! Service URL:"
 gcloud run services describe "${SERVICE_NAME}" --region "${REGION}" --format='value(status.url)'

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -13,6 +13,7 @@ use bytes::Bytes;
 use google_cloud_storage::{
     client::{Client as GcsClient, ClientConfig},
     http::objects::{
+        delete::DeleteObjectRequest,
         download::Range as DownloadRange,
         get::GetObjectRequest,
         patch::PatchObjectRequest,
@@ -23,9 +24,16 @@ use google_cloud_storage::{
 use hyper_util::rt::TokioIo;
 use hyper_util::server::conn::auto::Builder;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, env, path::Path, sync::Arc};
+use std::{
+    collections::HashMap,
+    env,
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
 use tempfile::TempDir;
 use tokio::process::Command;
+use tokio::sync::Semaphore;
 use tower::Service;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::{error, info, warn};
@@ -47,44 +55,88 @@ struct Config {
     transcription_model: String,
     /// URL of the Fastly edge service for transcript status webhook callbacks
     transcript_webhook_url: Option<String>,
+    transcription_max_in_flight: usize,
+    transcription_max_retries: u32,
+    transcription_retry_base_ms: u64,
+    transcription_retry_max_ms: u64,
+    transcription_retry_total_ms: u64,
 }
 
 impl Config {
     fn from_env() -> Self {
+        Self::from_lookup(|key| env::var(key).ok())
+    }
+
+    fn from_lookup<F>(mut lookup: F) -> Self
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        fn parse_value<F, T>(lookup: &mut F, key: &str, default: T) -> T
+        where
+            F: FnMut(&str) -> Option<String>,
+            T: std::str::FromStr,
+        {
+            lookup(key)
+                .and_then(|value| value.parse::<T>().ok())
+                .unwrap_or(default)
+        }
+
+        fn parse_bool<F>(lookup: &mut F, key: &str, default: bool) -> bool
+        where
+            F: FnMut(&str) -> Option<String>,
+        {
+            lookup(key)
+                .map(|value| {
+                    let normalized = value.to_ascii_lowercase();
+                    normalized == "true" || normalized == "1"
+                })
+                .unwrap_or(default)
+        }
+
         // Check if GPU is explicitly enabled via env var (more reliable than checking NVIDIA_VISIBLE_DEVICES)
         // Set USE_GPU=true when deploying with actual GPU support
-        let use_gpu = env::var("USE_GPU")
-            .map(|v| v.to_lowercase() == "true" || v == "1")
-            .unwrap_or(false);
-
         Self {
-            gcs_bucket: env::var("GCS_BUCKET")
-                .unwrap_or_else(|_| "divine-blossom-media".to_string()),
-            port: env::var("PORT")
-                .unwrap_or_else(|_| "8080".to_string())
-                .parse()
-                .unwrap_or(8080),
-            use_gpu,
+            gcs_bucket: lookup("GCS_BUCKET").unwrap_or_else(|| "divine-blossom-media".to_string()),
+            port: parse_value(&mut lookup, "PORT", 8080),
+            use_gpu: parse_bool(&mut lookup, "USE_GPU", false),
             // Webhook URL for status updates (e.g., https://media.divine.video/admin/transcode-status)
-            webhook_url: env::var("WEBHOOK_URL").ok(),
+            webhook_url: lookup("WEBHOOK_URL"),
             // Secret for webhook authentication
-            webhook_secret: env::var("WEBHOOK_SECRET").ok(),
+            webhook_secret: lookup("WEBHOOK_SECRET"),
             // Transcription provider URL (defaults to OpenAI transcription endpoint)
-            transcription_api_url: env::var("TRANSCRIPTION_API_URL")
-                .ok()
-                .or_else(|| env::var("OPENAI_API_URL").ok())
+            transcription_api_url: lookup("TRANSCRIPTION_API_URL")
+                .or_else(|| lookup("OPENAI_API_URL"))
                 .or_else(|| Some("https://api.openai.com/v1/audio/transcriptions".to_string())),
             // Provider auth token
-            transcription_api_key: env::var("TRANSCRIPTION_API_KEY")
-                .ok()
-                .or_else(|| env::var("OPENAI_API_KEY").ok()),
+            transcription_api_key: lookup("TRANSCRIPTION_API_KEY")
+                .or_else(|| lookup("OPENAI_API_KEY")),
             // Provider model
-            transcription_model: env::var("TRANSCRIPTION_MODEL")
-                .ok()
-                .or_else(|| env::var("OPENAI_MODEL").ok())
+            transcription_model: lookup("TRANSCRIPTION_MODEL")
+                .or_else(|| lookup("OPENAI_MODEL"))
                 .unwrap_or_else(|| "whisper-1".to_string()),
             // Transcript webhook URL (defaults to same host + /admin/transcript-status)
-            transcript_webhook_url: env::var("TRANSCRIPT_WEBHOOK_URL").ok(),
+            transcript_webhook_url: lookup("TRANSCRIPT_WEBHOOK_URL"),
+            transcription_max_in_flight: parse_value(&mut lookup, "TRANSCRIPTION_MAX_IN_FLIGHT", 4)
+                .max(1),
+            transcription_max_retries: parse_value(&mut lookup, "TRANSCRIPTION_MAX_RETRIES", 3),
+            transcription_retry_base_ms: parse_value(
+                &mut lookup,
+                "TRANSCRIPTION_RETRY_BASE_MS",
+                1_000,
+            )
+            .max(1),
+            transcription_retry_max_ms: parse_value(
+                &mut lookup,
+                "TRANSCRIPTION_RETRY_MAX_MS",
+                15_000,
+            )
+            .max(1),
+            transcription_retry_total_ms: parse_value(
+                &mut lookup,
+                "TRANSCRIPTION_RETRY_TOTAL_MS",
+                30_000,
+            )
+            .max(1_000),
         }
     }
 }
@@ -93,6 +145,7 @@ impl Config {
 struct AppState {
     gcs_client: GcsClient,
     config: Config,
+    provider_semaphore: Arc<Semaphore>,
 }
 
 // Transcode request
@@ -164,6 +217,115 @@ struct TranscriptConfidence {
     average_logprob: f64,
     low_confidence_token_ratio: f64,
     token_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderFailure {
+    status_code: Option<u16>,
+    retry_after: Option<Duration>,
+    body: String,
+    timed_out: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ProviderError {
+    failure: ProviderFailure,
+    exhausted_retryable: bool,
+    attempts: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum TranscriptLockStatus {
+    Processing,
+    CoolingDown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct TranscriptLockState {
+    status: TranscriptLockStatus,
+    started_at_epoch_secs: u64,
+    cooldown_until_epoch_secs: Option<u64>,
+    error_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TranscriptLockAction {
+    StartWork,
+    AlreadyProcessing,
+    ReclaimStaleLock,
+    CoolingDown,
+}
+
+#[derive(Debug, Clone)]
+struct TranscriptLockHandle {
+    path: String,
+    generation: i64,
+}
+
+impl ProviderError {
+    fn error_code(&self) -> &'static str {
+        if self.exhausted_retryable {
+            "provider_rate_limited"
+        } else {
+            "provider_failed"
+        }
+    }
+
+    fn retry_after(&self) -> Option<Duration> {
+        self.failure.retry_after
+    }
+}
+
+impl std::fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let suffix = if self.exhausted_retryable {
+            " after exhausting retries"
+        } else {
+            ""
+        };
+        match self.failure.status_code {
+            Some(status) => write!(
+                f,
+                "Transcription provider returned {}{}: {}",
+                status, suffix, self.failure.body
+            ),
+            None => write!(
+                f,
+                "Transcription provider request failed{}: {}",
+                suffix, self.failure.body
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ProviderError {}
+
+fn decide_transcript_lock_action(
+    now_epoch_secs: u64,
+    existing: Option<&TranscriptLockState>,
+    stale_after_secs: u64,
+) -> TranscriptLockAction {
+    let Some(existing) = existing else {
+        return TranscriptLockAction::StartWork;
+    };
+
+    match existing.status {
+        TranscriptLockStatus::CoolingDown
+            if existing
+                .cooldown_until_epoch_secs
+                .map(|cooldown_until| cooldown_until > now_epoch_secs)
+                .unwrap_or(false) =>
+        {
+            TranscriptLockAction::CoolingDown
+        }
+        TranscriptLockStatus::Processing
+            if now_epoch_secs.saturating_sub(existing.started_at_epoch_secs) < stale_after_secs =>
+        {
+            TranscriptLockAction::AlreadyProcessing
+        }
+        _ => TranscriptLockAction::ReclaimStaleLock,
+    }
 }
 
 impl TranscriptConfidence {
@@ -303,8 +465,13 @@ async fn main() -> Result<()> {
     // Initialize GCS client
     let gcs_config = ClientConfig::default().with_auth().await?;
     let gcs_client = GcsClient::new(gcs_config);
+    let provider_semaphore = Arc::new(Semaphore::new(config.transcription_max_in_flight));
 
-    let state = Arc::new(AppState { gcs_client, config });
+    let state = Arc::new(AppState {
+        gcs_client,
+        config,
+        provider_semaphore,
+    });
 
     // CORS configuration
     let cors = CorsLayer::new()
@@ -449,9 +616,9 @@ async fn process_transcode(
     let temp_dir = TempDir::new()?;
     let temp_path = temp_dir.path();
 
-    // Download the original blob, or fall back to the best available HLS transport stream.
-    let input_path = temp_path.join("input_media");
-    let download_result = download_best_available_media_to_path(
+    // Download original video from GCS
+    let input_path = temp_path.join("input.mp4");
+    let download_result = download_from_gcs(
         &state.gcs_client,
         &state.config.gcs_bucket,
         &hash,
@@ -459,13 +626,10 @@ async fn process_transcode(
     )
     .await;
 
-    let source_object = match download_result {
-        Ok(source_object) => source_object,
-        Err(e) => {
-            send_status_webhook(&state.config, &hash, "failed", None, None).await;
-            return Err(e);
-        }
-    };
+    if let Err(e) = download_result {
+        send_status_webhook(&state.config, &hash, "failed", None, None).await;
+        return Err(e);
+    }
 
     info!("Downloaded video to {:?}", input_path);
 
@@ -473,24 +637,13 @@ async fn process_transcode(
     let mut source_metadata = match get_source_object_metadata(
         &state.gcs_client,
         &state.config.gcs_bucket,
-<<<<<<< HEAD
-        &source_object,
-=======
         &hash,
->>>>>>> ee3a7d5 (fix: reject low-confidence phantom transcripts)
     )
     .await
     {
         Ok(meta) => meta,
         Err(e) => {
-<<<<<<< HEAD
-            warn!(
-                "Failed to load source metadata for {} via {}: {}",
-                hash, source_object, e
-            );
-=======
             warn!("Failed to load source metadata for {}: {}", hash, e);
->>>>>>> ee3a7d5 (fix: reject low-confidence phantom transcripts)
             SourceObjectMetadata::default()
         }
     };
@@ -604,6 +757,7 @@ async fn process_transcribe(
             None,
             None,
             None,
+            None,
         )
         .await;
         return Ok(TranscribeResponse {
@@ -613,6 +767,38 @@ async fn process_transcribe(
             transcript_confidence: None,
         });
     }
+
+    let transcript_lock = match acquire_transcript_lock(
+        &state.gcs_client,
+        &state.config.gcs_bucket,
+        &hash,
+        900,
+    )
+    .await?
+    {
+        Ok(handle) => handle,
+        Err(TranscriptLockAction::AlreadyProcessing) => {
+            info!("Transcript already processing for {}, skipping duplicate request", hash);
+            return Ok(TranscribeResponse {
+                hash,
+                status: "already_processing".to_string(),
+                vtt_path,
+                transcript_confidence: None,
+            });
+        }
+        Err(TranscriptLockAction::CoolingDown) => {
+            info!("Transcript cooldown active for {}, skipping duplicate request", hash);
+            return Ok(TranscribeResponse {
+                hash,
+                status: "cooling_down".to_string(),
+                vtt_path,
+                transcript_confidence: None,
+            });
+        }
+        Err(TranscriptLockAction::StartWork | TranscriptLockAction::ReclaimStaleLock) => {
+            unreachable!("acquire_transcript_lock resolves start/reclaim internally")
+        }
+    };
 
     send_transcript_status_webhook(
         &state.config,
@@ -625,6 +811,7 @@ async fn process_transcribe(
         None,
         None,
         None,
+        None,
     )
     .await;
 
@@ -632,20 +819,27 @@ async fn process_transcribe(
     let temp_path = temp_dir.path();
 
     let input_path = temp_path.join("input_media");
-    if let Err(e) = download_best_available_media_to_path(
+    if let Err(e) = download_from_gcs(
         &state.gcs_client,
         &state.config.gcs_bucket,
         &hash,
         &input_path,
-    )
-    .await
+        )
+        .await
     {
+        if let Err(lock_error) =
+            delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
+                .await
+        {
+            warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+        }
         send_transcript_status_webhook(
             &state.config,
             &hash,
             "failed",
             job_id.as_deref(),
             requested_lang.as_deref(),
+            None,
             None,
             None,
             None,
@@ -662,7 +856,7 @@ async fn process_transcribe(
             hash
         );
         let parsed_vtt = ParsedVtt::empty(0);
-        return finalize_transcript(
+        let result = finalize_transcript(
             &state,
             &hash,
             job_id.as_deref(),
@@ -671,16 +865,30 @@ async fn process_transcribe(
             &vtt_path,
         )
         .await;
+        if let Err(lock_error) =
+            delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
+                .await
+        {
+            warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+        }
+        return result;
     }
 
     let audio_path = temp_path.join("transcribe.wav");
     if let Err(e) = extract_audio_for_transcription(&input_path, &audio_path).await {
+        if let Err(lock_error) =
+            delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
+                .await
+        {
+            warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+        }
         send_transcript_status_webhook(
             &state.config,
             &hash,
             "failed",
             job_id.as_deref(),
             requested_lang.as_deref(),
+            None,
             None,
             None,
             None,
@@ -714,7 +922,7 @@ async fn process_transcribe(
             audio_analysis.max_volume_db
         );
         let parsed_vtt = ParsedVtt::empty(audio_analysis.duration_ms);
-        return finalize_transcript(
+        let result = finalize_transcript(
             &state,
             &hash,
             job_id.as_deref(),
@@ -723,40 +931,107 @@ async fn process_transcribe(
             &vtt_path,
         )
         .await;
+        if let Err(lock_error) =
+            delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
+                .await
+        {
+            warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+        }
+        return result;
     }
 
-    let raw_output =
-        match transcribe_audio_via_provider(&state.config, &audio_path, requested_lang.as_deref())
-            .await
-        {
-            Ok(output) => output,
-            Err(e) => {
-                send_transcript_status_webhook(
-                    &state.config,
-                    &hash,
-                    "failed",
-                    job_id.as_deref(),
-                    requested_lang.as_deref(),
-                    None,
-                    None,
-                    None,
-                    Some("provider_failed"),
-                    Some(&e.to_string()),
-                )
-                .await;
-                return Err(e);
-            }
-        };
+    let provider_wait_started = Instant::now();
+    let provider_permit = state
+        .provider_semaphore
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|e| anyhow!("Provider semaphore closed: {}", e))?;
+    let provider_wait_ms = provider_wait_started
+        .elapsed()
+        .as_millis()
+        .min(u64::MAX as u128) as u64;
+    let in_flight = state
+        .config
+        .transcription_max_in_flight
+        .saturating_sub(state.provider_semaphore.available_permits());
+    info!(
+        hash,
+        in_flight,
+        provider_wait_ms,
+        "Acquired transcription provider permit"
+    );
 
-    let parsed_vtt = match normalize_transcript_to_vtt(&raw_output) {
-        Ok(vtt) => vtt,
+    let raw_output = match transcribe_audio_via_provider(
+        &state.config,
+        &audio_path,
+        requested_lang.as_deref(),
+    )
+    .await
+    {
+        Ok(output) => output,
         Err(e) => {
+            drop(provider_permit);
+            if e.exhausted_retryable {
+                let retry_after = e
+                    .retry_after()
+                    .unwrap_or_else(|| Duration::from_millis(state.config.transcription_retry_max_ms));
+                if let Err(lock_error) = write_transcript_cooldown(
+                    &state.gcs_client,
+                    &state.config.gcs_bucket,
+                    &hash,
+                    &transcript_lock,
+                    retry_after,
+                    e.error_code(),
+                )
+                .await
+                {
+                    warn!("Failed to persist transcript cooldown for {}: {}", hash, lock_error);
+                }
+            } else if let Err(lock_error) = delete_transcript_lock(
+                &state.gcs_client,
+                &state.config.gcs_bucket,
+                &transcript_lock,
+            )
+            .await
+            {
+                warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+            }
             send_transcript_status_webhook(
                 &state.config,
                 &hash,
                 "failed",
                 job_id.as_deref(),
                 requested_lang.as_deref(),
+                None,
+                None,
+                None,
+                e.retry_after().map(|duration| duration.as_secs().max(1)),
+                Some(e.error_code()),
+                Some(&e.to_string()),
+            )
+            .await;
+            return Err(e.into());
+        }
+    };
+    drop(provider_permit);
+
+    let parsed_vtt = match normalize_transcript_to_vtt(&raw_output) {
+        Ok(vtt) => vtt,
+        Err(e) => {
+            if let Err(lock_error) =
+                delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
+                    .await
+            {
+                warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+            }
+            send_transcript_status_webhook(
+                &state.config,
+                &hash,
+                "failed",
+                job_id.as_deref(),
+                requested_lang.as_deref(),
+                None,
                 None,
                 None,
                 None,
@@ -801,7 +1076,7 @@ async fn process_transcribe(
         None => parsed_vtt,
     };
 
-    finalize_transcript(
+    let result = finalize_transcript(
         &state,
         &hash,
         job_id.as_deref(),
@@ -809,7 +1084,13 @@ async fn process_transcribe(
         parsed_vtt,
         &vtt_path,
     )
-    .await
+    .await;
+    if let Err(lock_error) =
+        delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock).await
+    {
+        warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+    }
+    result
 }
 
 async fn check_gcs_exists(client: &GcsClient, bucket: &str, object: &str) -> Result<bool> {
@@ -824,14 +1105,6 @@ async fn check_gcs_exists(client: &GcsClient, bucket: &str, object: &str) -> Res
         Ok(_) => Ok(true),
         Err(_) => Ok(false),
     }
-}
-
-fn media_source_candidates(hash: &str) -> [String; 3] {
-    [
-        hash.to_string(),
-        format!("{}/hls/stream_720p.ts", hash),
-        format!("{}/hls/stream_480p.ts", hash),
-    ]
 }
 
 async fn download_from_gcs(
@@ -854,38 +1127,6 @@ async fn download_from_gcs(
 
     tokio::fs::write(output_path, &data).await?;
     Ok(())
-}
-
-async fn download_best_available_media_to_path(
-    client: &GcsClient,
-    bucket: &str,
-    hash: &str,
-    output_path: &Path,
-) -> Result<String> {
-    let mut failures = Vec::new();
-
-    for object in media_source_candidates(hash) {
-        match download_from_gcs(client, bucket, &object, output_path).await {
-            Ok(()) => {
-                if object == hash {
-                    return Ok(object);
-                }
-
-                warn!(
-                    "Original blob missing for {}, using fallback media source {}",
-                    hash, object
-                );
-                return Ok(object);
-            }
-            Err(e) => failures.push(format!("{}: {}", object, e)),
-        }
-    }
-
-    Err(anyhow!(
-        "No recoverable media source found for {} ({})",
-        hash,
-        failures.join(" | ")
-    ))
 }
 
 /// Extract mono 16kHz PCM WAV audio for transcription.
@@ -1032,20 +1273,248 @@ fn parse_volume_db(input: &str) -> Option<f64> {
     value.parse::<f64>().ok()
 }
 
-/// Call a configured transcription provider and return raw response text.
-async fn transcribe_audio_via_provider(
+fn parse_retry_after_header(value: Option<&str>) -> Option<Duration> {
+    let seconds = value?.trim().parse::<u64>().ok()?;
+    Some(Duration::from_secs(seconds))
+}
+
+fn parse_provider_status(
+    status_code: Option<u16>,
+    retry_after_header: Option<&str>,
+    body: &str,
+    timed_out: bool,
+) -> ProviderFailure {
+    ProviderFailure {
+        status_code,
+        retry_after: parse_retry_after_header(retry_after_header),
+        body: body.to_string(),
+        timed_out,
+    }
+}
+
+fn is_retryable_provider_failure(failure: &ProviderFailure) -> bool {
+    failure.timed_out
+        || matches!(failure.status_code, Some(429 | 500 | 502 | 503 | 504))
+}
+
+fn retry_delay_for_attempt(
+    attempt: u32,
+    base_delay_ms: u64,
+    max_delay_ms: u64,
+    retry_after: Option<Duration>,
+    jitter_ratio: f64,
+) -> Duration {
+    let exponential = base_delay_ms
+        .saturating_mul(2u64.saturating_pow(attempt))
+        .min(max_delay_ms);
+    let requested_delay = retry_after
+        .map(|duration| duration.as_millis().min(u64::MAX as u128) as u64)
+        .unwrap_or(exponential)
+        .min(max_delay_ms);
+    if requested_delay >= max_delay_ms {
+        return Duration::from_millis(max_delay_ms.max(1));
+    }
+    let clamped_ratio = jitter_ratio.clamp(0.0, 1.0);
+    let jittered = ((requested_delay as f64) * (0.75 + (0.25 * clamped_ratio))).round() as u64;
+    Duration::from_millis(jittered.max(1))
+}
+
+fn retry_jitter_ratio() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| f64::from(duration.subsec_micros()) / 1_000_000.0)
+        .unwrap_or(0.5)
+}
+
+fn current_epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn transcript_lock_path(hash: &str) -> String {
+    format!("{}/vtt/.lock", hash)
+}
+
+async fn fetch_transcript_lock(
+    client: &GcsClient,
+    bucket: &str,
+    hash: &str,
+) -> Result<Option<(TranscriptLockState, i64)>> {
+    let path = transcript_lock_path(hash);
+    let object = match client
+        .get_object(&GetObjectRequest {
+            bucket: bucket.to_string(),
+            object: path.clone(),
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(object) => object,
+        Err(_) => return Ok(None),
+    };
+
+    let raw = client
+        .download_object(
+            &GetObjectRequest {
+                bucket: bucket.to_string(),
+                object: path,
+                ..Default::default()
+            },
+            &DownloadRange::default(),
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to download transcript lock: {}", e))?;
+    let state = serde_json::from_slice::<TranscriptLockState>(&raw)
+        .map_err(|e| anyhow!("Failed to parse transcript lock: {}", e))?;
+
+    Ok(Some((state, object.generation)))
+}
+
+async fn write_transcript_lock(
+    client: &GcsClient,
+    bucket: &str,
+    hash: &str,
+    state: &TranscriptLockState,
+    if_generation_match: Option<i64>,
+) -> Result<TranscriptLockHandle> {
+    let path = transcript_lock_path(hash);
+    let mut media = Media::new(path.clone());
+    media.content_type = "application/json".into();
+    let upload = client
+        .upload_object(
+            &UploadObjectRequest {
+                bucket: bucket.to_string(),
+                if_generation_match,
+                ..Default::default()
+            },
+            Bytes::from(
+                serde_json::to_vec(state)
+                    .map_err(|e| anyhow!("Failed to serialize transcript lock: {}", e))?,
+            ),
+            &UploadType::Simple(media),
+        )
+        .await
+        .map_err(|e| anyhow!("Failed to write transcript lock: {}", e))?;
+
+    Ok(TranscriptLockHandle {
+        path,
+        generation: upload.generation,
+    })
+}
+
+async fn delete_transcript_lock(
+    client: &GcsClient,
+    bucket: &str,
+    handle: &TranscriptLockHandle,
+) -> Result<()> {
+    client
+        .delete_object(&DeleteObjectRequest {
+            bucket: bucket.to_string(),
+            object: handle.path.clone(),
+            if_generation_match: Some(handle.generation),
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| anyhow!("Failed to delete transcript lock: {}", e))?;
+    Ok(())
+}
+
+async fn acquire_transcript_lock(
+    client: &GcsClient,
+    bucket: &str,
+    hash: &str,
+    stale_after_secs: u64,
+) -> Result<std::result::Result<TranscriptLockHandle, TranscriptLockAction>> {
+    let processing_state = TranscriptLockState {
+        status: TranscriptLockStatus::Processing,
+        started_at_epoch_secs: current_epoch_secs(),
+        cooldown_until_epoch_secs: None,
+        error_code: None,
+    };
+
+    match write_transcript_lock(client, bucket, hash, &processing_state, Some(0)).await {
+        Ok(handle) => return Ok(Ok(handle)),
+        Err(write_error) => {
+            let Some((existing, generation)) = fetch_transcript_lock(client, bucket, hash).await?
+            else {
+                return Err(write_error);
+            };
+            let action = decide_transcript_lock_action(
+                current_epoch_secs(),
+                Some(&existing),
+                stale_after_secs,
+            );
+            if action != TranscriptLockAction::ReclaimStaleLock {
+                return Ok(Err(action));
+            }
+
+            let stale_handle = TranscriptLockHandle {
+                path: transcript_lock_path(hash),
+                generation,
+            };
+            delete_transcript_lock(client, bucket, &stale_handle).await?;
+            write_transcript_lock(client, bucket, hash, &processing_state, Some(0))
+                .await
+                .map(Ok)
+        }
+    }
+}
+
+async fn write_transcript_cooldown(
+    client: &GcsClient,
+    bucket: &str,
+    hash: &str,
+    handle: &TranscriptLockHandle,
+    retry_after: Duration,
+    error_code: &str,
+) -> Result<()> {
+    let now = current_epoch_secs();
+    let retry_after_secs = retry_after.as_secs().max(1);
+    let cooldown_state = TranscriptLockState {
+        status: TranscriptLockStatus::CoolingDown,
+        started_at_epoch_secs: now,
+        cooldown_until_epoch_secs: Some(now.saturating_add(retry_after_secs)),
+        error_code: Some(error_code.to_string()),
+    };
+
+    write_transcript_lock(
+        client,
+        bucket,
+        hash,
+        &cooldown_state,
+        Some(handle.generation),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn transcribe_audio_via_provider_once(
     config: &Config,
     audio_path: &Path,
     language: Option<&str>,
-) -> Result<String> {
+) -> std::result::Result<String, ProviderFailure> {
     let api_url = config
         .transcription_api_url
         .as_ref()
-        .ok_or_else(|| anyhow!("TRANSCRIPTION_API_URL is not configured"))?;
+        .ok_or_else(|| {
+            parse_provider_status(
+                None,
+                None,
+                "TRANSCRIPTION_API_URL is not configured",
+                false,
+            )
+        })?;
 
-    let audio_bytes = tokio::fs::read(audio_path)
-        .await
-        .map_err(|e| anyhow!("Failed to read extracted audio: {}", e))?;
+    let audio_bytes = tokio::fs::read(audio_path).await.map_err(|e| {
+        parse_provider_status(
+            None,
+            None,
+            &format!("Failed to read extracted audio: {}", e),
+            false,
+        )
+    })?;
     let filename = audio_path
         .file_name()
         .and_then(|f| f.to_str())
@@ -1055,7 +1524,14 @@ async fn transcribe_audio_via_provider(
     let file_part = reqwest::multipart::Part::bytes(audio_bytes)
         .file_name(filename)
         .mime_str("audio/wav")
-        .map_err(|e| anyhow!("Failed to build multipart audio part: {}", e))?;
+        .map_err(|e| {
+            parse_provider_status(
+                None,
+                None,
+                &format!("Failed to build multipart audio part: {}", e),
+                false,
+            )
+        })?;
 
     let response_format = transcription_response_format(&config.transcription_model);
     let mut form = reqwest::multipart::Form::new()
@@ -1078,26 +1554,102 @@ async fn transcribe_audio_via_provider(
         request = request.bearer_auth(api_key);
     }
 
-    let response = request
-        .send()
-        .await
-        .map_err(|e| anyhow!("Failed to call transcription provider: {}", e))?;
+    let response = request.send().await.map_err(|e| {
+        parse_provider_status(
+            None,
+            None,
+            &format!("Failed to call transcription provider: {}", e),
+            e.is_timeout(),
+        )
+    })?;
 
     let status = response.status();
-    let body = response
-        .text()
-        .await
-        .map_err(|e| anyhow!("Failed to read transcription response: {}", e))?;
+    let retry_after_header = response
+        .headers()
+        .get("retry-after")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.to_string());
+    let body = response.text().await.map_err(|e| {
+        parse_provider_status(
+            Some(status.as_u16()),
+            retry_after_header.as_deref(),
+            &format!("Failed to read transcription response: {}", e),
+            e.is_timeout(),
+        )
+    })?;
 
     if !status.is_success() {
-        return Err(anyhow!(
-            "Transcription provider returned {}: {}",
-            status,
-            body
+        return Err(parse_provider_status(
+            Some(status.as_u16()),
+            retry_after_header.as_deref(),
+            &body,
+            false,
         ));
     }
 
     Ok(body)
+}
+
+/// Call a configured transcription provider and return raw response text.
+async fn transcribe_audio_via_provider(
+    config: &Config,
+    audio_path: &Path,
+    language: Option<&str>,
+) -> std::result::Result<String, ProviderError> {
+    let started = Instant::now();
+    let mut attempt: u32 = 0;
+
+    loop {
+        match transcribe_audio_via_provider_once(config, audio_path, language).await {
+            Ok(body) => return Ok(body),
+            Err(failure) if !is_retryable_provider_failure(&failure) => {
+                return Err(ProviderError {
+                    failure,
+                    exhausted_retryable: false,
+                    attempts: attempt.saturating_add(1),
+                });
+            }
+            Err(failure) => {
+                if attempt >= config.transcription_max_retries {
+                    return Err(ProviderError {
+                        failure,
+                        exhausted_retryable: true,
+                        attempts: attempt.saturating_add(1),
+                    });
+                }
+
+                let delay = retry_delay_for_attempt(
+                    attempt,
+                    config.transcription_retry_base_ms,
+                    config.transcription_retry_max_ms,
+                    failure.retry_after,
+                    retry_jitter_ratio(),
+                );
+                let waited_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+                let next_wait_ms = delay.as_millis().min(u64::MAX as u128) as u64;
+                if waited_ms.saturating_add(next_wait_ms) > config.transcription_retry_total_ms {
+                    return Err(ProviderError {
+                        failure,
+                        exhausted_retryable: true,
+                        attempts: attempt.saturating_add(1),
+                    });
+                }
+
+                warn!(
+                    attempt = attempt.saturating_add(1),
+                    delay_ms = next_wait_ms,
+                    retry_after_ms = failure
+                        .retry_after
+                        .map(|duration| duration.as_millis().min(u64::MAX as u128) as u64),
+                    status_code = failure.status_code,
+                    timed_out = failure.timed_out,
+                    "Retrying transcription provider call"
+                );
+                tokio::time::sleep(delay).await;
+                attempt = attempt.saturating_add(1);
+            }
+        }
+    }
 }
 
 fn transcription_supports_logprobs(model: &str) -> bool {
@@ -1389,6 +1941,7 @@ async fn finalize_transcript(
             Some(parsed_vtt.duration_ms),
             Some(parsed_vtt.cue_count),
             parsed_vtt.confidence,
+            None,
             Some("upload_failed"),
             Some(&e.to_string()),
         )
@@ -1407,6 +1960,7 @@ async fn finalize_transcript(
         parsed_vtt.confidence,
         None,
         None,
+        None,
     )
     .await;
 
@@ -1421,14 +1975,13 @@ async fn finalize_transcript(
 #[cfg(test)]
 mod tests {
     use super::{
-<<<<<<< HEAD
-        media_source_candidates, normalize_transcript_to_vtt, parse_audio_analysis_output,
-=======
-        normalize_transcript_to_vtt, parse_audio_analysis_output,
->>>>>>> ee3a7d5 (fix: reject low-confidence phantom transcripts)
+        decide_transcript_lock_action, is_retryable_provider_failure, normalize_transcript_to_vtt,
+        parse_audio_analysis_output, parse_provider_status, retry_delay_for_attempt,
         should_drop_low_signal_transcript, transcript_drop_reason, transcription_response_format,
-        AudioAnalysis, ParsedVtt, TranscriptConfidence, TranscriptDropReason,
+        AudioAnalysis, Config, ParsedVtt, TranscriptConfidence, TranscriptDropReason,
+        TranscriptLockAction, TranscriptLockState, TranscriptLockStatus,
     };
+    use std::time::Duration;
 
     #[test]
     fn gpt_transcribe_uses_json_response_format() {
@@ -1582,20 +2135,119 @@ mod tests {
             Some(TranscriptDropReason::LowProviderConfidence)
         );
     }
-<<<<<<< HEAD
 
     #[test]
-    fn media_source_candidates_prefer_original_then_hls_variants() {
-        let hash =
-            "5b48aa1fcf30af61243ac9307eb98b7fa22df1c58573c3ca5d1b14fc30099929";
-        let candidates = media_source_candidates(hash);
+    fn classifies_rate_limited_provider_responses_as_retryable() {
+        let failure = parse_provider_status(
+            Some(429),
+            Some("12"),
+            "rate limit exceeded",
+            false,
+        );
 
-        assert_eq!(candidates[0], hash);
-        assert_eq!(candidates[1], format!("{}/hls/stream_720p.ts", hash));
-        assert_eq!(candidates[2], format!("{}/hls/stream_480p.ts", hash));
+        assert_eq!(failure.status_code, Some(429));
+        assert_eq!(failure.retry_after, Some(Duration::from_secs(12)));
+        assert_eq!(failure.body, "rate limit exceeded");
+        assert!(is_retryable_provider_failure(&failure));
     }
-=======
->>>>>>> ee3a7d5 (fix: reject low-confidence phantom transcripts)
+
+    #[test]
+    fn classifies_transient_5xx_provider_responses_as_retryable() {
+        for status in [500, 502, 503, 504] {
+            let failure = parse_provider_status(Some(status), None, "temporary failure", false);
+
+            assert_eq!(failure.status_code, Some(status));
+            assert!(is_retryable_provider_failure(&failure));
+        }
+    }
+
+    #[test]
+    fn classifies_bad_request_provider_responses_as_non_retryable() {
+        let failure = parse_provider_status(Some(400), None, "invalid request", false);
+
+        assert_eq!(failure.status_code, Some(400));
+        assert!(!is_retryable_provider_failure(&failure));
+    }
+
+    #[test]
+    fn caps_exponential_backoff_at_maximum_delay() {
+        assert_eq!(
+            retry_delay_for_attempt(0, 1_000, 5_000, None, 0.0),
+            Duration::from_millis(750)
+        );
+        assert_eq!(
+            retry_delay_for_attempt(3, 1_000, 5_000, None, 0.0),
+            Duration::from_millis(5_000)
+        );
+        assert_eq!(
+            retry_delay_for_attempt(2, 1_000, 5_000, Some(Duration::from_secs(10)), 0.0),
+            Duration::from_millis(5_000)
+        );
+    }
+
+    #[test]
+    fn config_defaults_provider_retry_settings() {
+        let config = Config::from_lookup(|_| None);
+
+        assert_eq!(config.transcription_max_in_flight, 4);
+        assert_eq!(config.transcription_max_retries, 3);
+        assert_eq!(config.transcription_retry_base_ms, 1_000);
+        assert_eq!(config.transcription_retry_max_ms, 15_000);
+    }
+
+    #[test]
+    fn config_parses_provider_retry_settings_from_env() {
+        let config = Config::from_lookup(|key| match key {
+            "TRANSCRIPTION_MAX_IN_FLIGHT" => Some("7".to_string()),
+            "TRANSCRIPTION_MAX_RETRIES" => Some("5".to_string()),
+            "TRANSCRIPTION_RETRY_BASE_MS" => Some("250".to_string()),
+            "TRANSCRIPTION_RETRY_MAX_MS" => Some("4000".to_string()),
+            _ => None,
+        });
+
+        assert_eq!(config.transcription_max_in_flight, 7);
+        assert_eq!(config.transcription_max_retries, 5);
+        assert_eq!(config.transcription_retry_base_ms, 250);
+        assert_eq!(config.transcription_retry_max_ms, 4_000);
+    }
+
+    #[test]
+    fn lock_state_without_existing_lock_starts_work() {
+        assert_eq!(
+            decide_transcript_lock_action(1_000, None, 600),
+            TranscriptLockAction::StartWork
+        );
+    }
+
+    #[test]
+    fn lock_state_with_fresh_processing_lock_returns_already_processing() {
+        let existing = TranscriptLockState {
+            status: TranscriptLockStatus::Processing,
+            started_at_epoch_secs: 1_000,
+            cooldown_until_epoch_secs: None,
+            error_code: None,
+        };
+
+        assert_eq!(
+            decide_transcript_lock_action(1_300, Some(&existing), 600),
+            TranscriptLockAction::AlreadyProcessing
+        );
+    }
+
+    #[test]
+    fn lock_state_with_stale_processing_lock_can_be_reclaimed() {
+        let existing = TranscriptLockState {
+            status: TranscriptLockStatus::Processing,
+            started_at_epoch_secs: 1_000,
+            cooldown_until_epoch_secs: None,
+            error_code: None,
+        };
+
+        assert_eq!(
+            decide_transcript_lock_action(1_700, Some(&existing), 600),
+            TranscriptLockAction::ReclaimStaleLock
+        );
+    }
 }
 
 fn summarize_vtt(vtt: &str) -> (u32, u64) {
@@ -2323,6 +2975,7 @@ async fn send_transcript_status_webhook(
     duration_ms: Option<u64>,
     cue_count: Option<u32>,
     transcript_confidence: Option<TranscriptConfidence>,
+    retry_after_secs: Option<u64>,
     error_code: Option<&str>,
     error_message: Option<&str>,
 ) {
@@ -2356,6 +3009,9 @@ async fn send_transcript_status_webhook(
     }
     if let Some(confidence) = transcript_confidence {
         payload["transcript_confidence"] = serde_json::json!(confidence);
+    }
+    if let Some(retry_after_secs) = retry_after_secs {
+        payload["retry_after"] = serde_json::json!(retry_after_secs);
     }
     if let Some(code) = error_code {
         payload["error_code"] = serde_json::json!(code);

--- a/scripts/backfill_missing_transcripts.sh
+++ b/scripts/backfill_missing_transcripts.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# ABOUTME: Backfill missing transcript VTTs through the Blossom admin API
+# ABOUTME: Supports recent-scope dry runs and bounded enqueueing with pacing
+
+set -euo pipefail
+
+ADMIN_URL="${ADMIN_URL:-https://media.divine.video}"
+SCOPE="${SCOPE:-recent}"
+OFFSET=0
+LIMIT=50
+MAX_TRIGGERS="${MAX_TRIGGERS:-10}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-2}"
+DRY_RUN=false
+RESET_PROCESSING=false
+FORCE_RETRANSCRIBE=false
+
+usage() {
+    cat <<'EOF'
+Usage: backfill_missing_transcripts.sh [options]
+
+Options:
+  --dry-run               List candidate hashes without enqueueing transcription
+  --limit N               Batch size per request (default: 50)
+  --offset N              Starting offset within the selected scope (default: 0)
+  --scope recent|users    Enumerate the recent index or the full user index (default: recent)
+  --max-triggers N        Max enqueue operations per API request (default: 10)
+  --sleep N               Delay in seconds between batches (default: 2)
+  --reset-processing      Requeue blobs stuck in processing
+  --force-retranscribe    Requeue blobs currently marked complete
+  --admin-url URL         Blossom base URL (default: $ADMIN_URL)
+  -h, --help              Show this help text
+
+Authentication:
+  Set either ADMIN_BEARER_TOKEN or ADMIN_COOKIE.
+
+Examples:
+  ADMIN_BEARER_TOKEN=... bash scripts/backfill_missing_transcripts.sh --dry-run --limit 20
+  ADMIN_BEARER_TOKEN=... bash scripts/backfill_missing_transcripts.sh --limit 200 --sleep 2
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --limit)
+            LIMIT="${2:?missing value for --limit}"
+            shift 2
+            ;;
+        --offset)
+            OFFSET="${2:?missing value for --offset}"
+            shift 2
+            ;;
+        --scope)
+            SCOPE="${2:?missing value for --scope}"
+            shift 2
+            ;;
+        --max-triggers)
+            MAX_TRIGGERS="${2:?missing value for --max-triggers}"
+            shift 2
+            ;;
+        --sleep)
+            SLEEP_SECONDS="${2:?missing value for --sleep}"
+            shift 2
+            ;;
+        --reset-processing)
+            RESET_PROCESSING=true
+            shift
+            ;;
+        --force-retranscribe)
+            FORCE_RETRANSCRIBE=true
+            shift
+            ;;
+        --admin-url)
+            ADMIN_URL="${2:?missing value for --admin-url}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${ADMIN_BEARER_TOKEN:-}" && -z "${ADMIN_COOKIE:-}" ]]; then
+    echo "Set ADMIN_BEARER_TOKEN or ADMIN_COOKIE before running this script." >&2
+    exit 1
+fi
+
+if [[ "$SCOPE" != "recent" && "$SCOPE" != "users" ]]; then
+    echo "--scope must be 'recent' or 'users'." >&2
+    exit 1
+fi
+
+request_backfill() {
+    local offset="$1"
+    local url="${ADMIN_URL}/admin/api/backfill-vtt?offset=${offset}&limit=${LIMIT}&scope=${SCOPE}&dry_run=${DRY_RUN}&max_triggers=${MAX_TRIGGERS}&reset_processing=${RESET_PROCESSING}&force_retranscribe=${FORCE_RETRANSCRIBE}"
+    local curl_args=(
+        -sS
+        -X POST
+        "$url"
+    )
+
+    if [[ -n "${ADMIN_BEARER_TOKEN:-}" ]]; then
+        curl_args+=(-H "Authorization: Bearer ${ADMIN_BEARER_TOKEN}")
+    else
+        curl_args+=(-H "Cookie: session=${ADMIN_COOKIE}")
+    fi
+
+    curl "${curl_args[@]}"
+}
+
+parse_json_field() {
+    local json="$1"
+    local expression="$2"
+    printf '%s' "$json" | python3 -c "import json,sys; data=json.load(sys.stdin); print(${expression})"
+}
+
+print_candidates() {
+    local json="$1"
+    printf '%s' "$json" | python3 -c '
+import json
+import sys
+
+data = json.load(sys.stdin)
+candidates = data.get("results", {}).get("candidates", [])
+if not candidates:
+    print("  (no eligible hashes in this batch)")
+    raise SystemExit(0)
+
+for candidate in candidates:
+    status = candidate.get("transcript_status") or "missing"
+    retry_after = candidate.get("cooldown_remaining_secs")
+    suffix = f" cooldown={retry_after}s" if retry_after is not None else ""
+    print(
+        f"  {candidate['sha256']} uploaded={candidate.get('uploaded')} "
+        f"owner={candidate.get('owner')} status={status}{suffix}"
+    )
+'
+}
+
+total_triggered=0
+total_duplicates=0
+total_complete=0
+total_cooling_down=0
+total_errors=0
+
+echo "=== Transcript backfill ==="
+echo "Server: $ADMIN_URL"
+echo "Scope: $SCOPE"
+echo "Batch size: $LIMIT"
+echo "Dry run: $DRY_RUN"
+echo ""
+
+while true; do
+    echo "[$(date '+%H:%M:%S')] Processing scope=$SCOPE offset=$OFFSET..."
+    response="$(request_backfill "$OFFSET")"
+
+    has_more="$(parse_json_field "$response" "data['batch']['has_more']")"
+    next_offset="$(parse_json_field "$response" "data['batch']['next_offset'] or ''")"
+    processed_hashes="$(parse_json_field "$response" "data['batch'].get('processed_hashes', 0)")"
+    triggered="$(parse_json_field "$response" "data['results']['triggered']")"
+    already_processing="$(parse_json_field "$response" "data['results']['already_processing']")"
+    already_complete="$(parse_json_field "$response" "data['results']['already_complete']")"
+    cooling_down="$(parse_json_field "$response" "data['results'].get('cooling_down', 0)")"
+    errors="$(parse_json_field "$response" "data['results']['errors']")"
+
+    total_triggered=$((total_triggered + triggered))
+    total_duplicates=$((total_duplicates + already_processing))
+    total_complete=$((total_complete + already_complete))
+    total_cooling_down=$((total_cooling_down + cooling_down))
+    total_errors=$((total_errors + errors))
+
+    echo "  Processed hashes: $processed_hashes"
+    echo "  Triggered: $triggered | In progress: $already_processing | Already complete: $already_complete | Cooling down: $cooling_down | Errors: $errors"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        echo "  Candidates:"
+        print_candidates "$response"
+    fi
+
+    if [[ "$has_more" == "False" || -z "$next_offset" || "$DRY_RUN" == "true" ]]; then
+        break
+    fi
+
+    OFFSET="$next_offset"
+    sleep "$SLEEP_SECONDS"
+done
+
+echo ""
+echo "=== Summary ==="
+echo "Triggered: $total_triggered"
+echo "Duplicates/in progress: $total_duplicates"
+echo "Already complete: $total_complete"
+echo "Cooling down: $total_cooling_down"
+echo "Errors: $total_errors"

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -4,9 +4,9 @@
 use crate::blossom::{BlobMetadata, BlobStatus, GlobalStats, RecentIndex, UserIndex};
 use crate::error::{BlossomError, Result};
 use crate::metadata::{
-    add_to_recent_index, add_to_user_list, get_blob_metadata, get_blob_refs, get_global_stats,
-    get_recent_index, get_user_blobs, get_user_index, replace_global_stats, replace_recent_index,
-    replace_user_index, update_blob_status, update_stats_on_status_change,
+    get_blob_metadata, get_global_stats, get_recent_index, get_user_blobs, get_user_index,
+    replace_global_stats, replace_recent_index, replace_user_index, update_blob_status,
+    update_stats_on_status_change,
 };
 use crate::storage::download_blob_with_fallback;
 use fastly::http::{header, Method, StatusCode};
@@ -688,8 +688,8 @@ pub fn handle_admin_blob_content(req: Request, hash: &str) -> Result<Response> {
     validate_admin_auth(&req)?;
 
     // Verify blob exists in metadata (but don't check moderation status)
-    let metadata = get_blob_metadata(hash)?
-        .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
+    let metadata =
+        get_blob_metadata(hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     // Get Range header for partial content support
     let range = req
@@ -731,35 +731,6 @@ struct ModerateRequest {
     action: String,
 }
 
-#[derive(Deserialize)]
-struct RestoreRequest {
-    sha256: String,
-    #[serde(default)]
-    status: Option<String>,
-}
-
-fn restore_soft_deleted_blob(hash: &str, metadata: &BlobMetadata, new_status: BlobStatus) -> Result<()> {
-    if new_status == BlobStatus::Deleted {
-        return Err(BlossomError::BadRequest(
-            "Restore target status cannot be deleted".into(),
-        ));
-    }
-
-    update_blob_status(hash, new_status)?;
-    let _ = update_stats_on_status_change(metadata.status, new_status);
-
-    let _ = add_to_user_list(&metadata.owner, hash);
-    if let Ok(refs) = get_blob_refs(hash) {
-        for pubkey in &refs {
-            let _ = add_to_user_list(pubkey, hash);
-        }
-    }
-    let _ = add_to_recent_index(hash);
-    crate::purge_vcl_cache(hash);
-
-    Ok(())
-}
-
 pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
     validate_admin_auth(&req)?;
 
@@ -793,15 +764,19 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
         }
     };
 
+    // Update blob status
+    update_blob_status(&moderate_req.sha256, new_status)?;
+
+    // Purge VCL cache so moderation takes effect immediately
     if old_status != new_status {
-        if old_status == BlobStatus::Deleted {
-            restore_soft_deleted_blob(&moderate_req.sha256, &metadata, new_status)?;
-        } else {
-            update_blob_status(&moderate_req.sha256, new_status)?;
-            crate::purge_vcl_cache(&moderate_req.sha256);
-            let _ = update_stats_on_status_change(old_status, new_status);
-        }
+        crate::purge_vcl_cache(&moderate_req.sha256);
     }
+
+    // Update global stats for the status change
+    if old_status != new_status {
+        let _ = update_stats_on_status_change(old_status, new_status);
+    }
+
     let response = serde_json::json!({
         "success": true,
         "sha256": moderate_req.sha256,
@@ -812,56 +787,134 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
     json_response(StatusCode::OK, &response)
 }
 
-/// POST /admin/api/restore - Restore a previously soft-deleted blob
-pub fn handle_admin_restore_action(mut req: Request) -> Result<Response> {
+/// POST /admin/api/bulk-approve - Approve all banned/restricted blobs in a batch
+/// Body: {"hashes": ["hash1", "hash2", ...]} or {"approve_all_flagged": true}
+/// When approve_all_flagged is true, hashes is used as the list to scan
+pub fn handle_admin_bulk_approve(mut req: Request) -> Result<Response> {
     validate_admin_auth(&req)?;
 
     let body = req.take_body().into_string();
-    let restore_req: RestoreRequest = serde_json::from_str(&body)
+    let payload: serde_json::Value = serde_json::from_str(&body)
         .map_err(|e| BlossomError::BadRequest(format!("Invalid JSON: {}", e)))?;
 
-    if restore_req.sha256.len() != 64
-        || !restore_req.sha256.chars().all(|c| c.is_ascii_hexdigit())
-    {
-        return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
+    let hashes: Vec<String> = payload["hashes"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // skip_purge=true skips per-blob VCL purge (caller should do purge --all after)
+    let skip_purge = payload["skip_purge"].as_bool().unwrap_or(false);
+
+    if hashes.is_empty() {
+        return Err(BlossomError::BadRequest("No hashes provided".into()));
     }
 
-    let metadata = get_blob_metadata(&restore_req.sha256)?
-        .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
-    let old_status = metadata.status;
+    let mut approved = 0u32;
+    let mut already_ok = 0u32;
+    let mut not_found = 0u32;
+    let mut errors = 0u32;
+    let mut approved_hashes: Vec<String> = Vec::new();
 
-    if old_status != BlobStatus::Deleted {
-        return Err(BlossomError::BadRequest(
-            "Blob is not soft-deleted".into(),
-        ));
-    }
-
-    let new_status = match restore_req
-        .status
-        .as_deref()
-        .unwrap_or("active")
-        .to_uppercase()
-        .as_str()
-    {
-        "APPROVE" | "ACTIVE" => BlobStatus::Active,
-        "PENDING" => BlobStatus::Pending,
-        "RESTRICT" | "RESTRICTED" => BlobStatus::Restricted,
-        other => {
-            return Err(BlossomError::BadRequest(format!(
-                "Unknown restore status: {}",
-                other
-            )))
+    for hash in &hashes {
+        if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+            errors += 1;
+            continue;
         }
-    };
 
-    restore_soft_deleted_blob(&restore_req.sha256, &metadata, new_status)?;
+        match get_blob_metadata(hash) {
+            Ok(Some(meta)) => {
+                if meta.status == BlobStatus::Banned || meta.status == BlobStatus::Restricted {
+                    match update_blob_status(hash, BlobStatus::Active) {
+                        Ok(()) => {
+                            if !skip_purge {
+                                let _ = update_stats_on_status_change(meta.status, BlobStatus::Active);
+                                crate::purge_vcl_cache(hash);
+                            }
+                            approved += 1;
+                            approved_hashes.push(hash.clone());
+                        }
+                        Err(_) => errors += 1,
+                    }
+                } else {
+                    already_ok += 1;
+                }
+            }
+            Ok(None) => not_found += 1,
+            Err(_) => errors += 1,
+        }
+    }
+
+    eprintln!(
+        "[ADMIN] Bulk approve: {} approved, {} already_ok, {} not_found, {} errors (of {} hashes)",
+        approved, already_ok, not_found, errors, hashes.len()
+    );
 
     let response = serde_json::json!({
         "success": true,
-        "restored": true,
-        "sha256": restore_req.sha256,
-        "old_status": format!("{:?}", old_status).to_lowercase(),
-        "new_status": format!("{:?}", new_status).to_lowercase()
+        "total": hashes.len(),
+        "approved": approved,
+        "already_ok": already_ok,
+        "not_found": not_found,
+        "errors": errors,
+        "approved_hashes": approved_hashes,
+    });
+
+    json_response(StatusCode::OK, &response)
+}
+
+/// POST /admin/api/scan-flagged - Scan a batch of hashes and return banned/restricted ones
+/// Body: {"hashes": ["hash1", "hash2", ...]}
+/// Returns which ones are banned/restricted without changing them
+pub fn handle_admin_scan_flagged(mut req: Request) -> Result<Response> {
+    validate_admin_auth(&req)?;
+
+    let body = req.take_body().into_string();
+    let payload: serde_json::Value = serde_json::from_str(&body)
+        .map_err(|e| BlossomError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    let hashes: Vec<String> = payload["hashes"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut banned: Vec<String> = Vec::new();
+    let mut restricted: Vec<String> = Vec::new();
+    let mut active = 0u32;
+    let mut pending = 0u32;
+    let mut not_found = 0u32;
+
+    for hash in &hashes {
+        if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+            continue;
+        }
+        match get_blob_metadata(hash) {
+            Ok(Some(meta)) => match meta.status {
+                BlobStatus::Banned => banned.push(hash.clone()),
+                BlobStatus::Restricted => restricted.push(hash.clone()),
+                BlobStatus::Active => active += 1,
+                BlobStatus::Pending => pending += 1,
+                BlobStatus::Deleted => not_found += 1,
+            },
+            Ok(None) => not_found += 1,
+            Err(_) => not_found += 1,
+        }
+    }
+
+    let response = serde_json::json!({
+        "total_scanned": hashes.len(),
+        "banned": banned,
+        "restricted": restricted,
+        "active": active,
+        "pending": pending,
+        "not_found": not_found,
     });
 
     json_response(StatusCode::OK, &response)
@@ -1462,25 +1515,17 @@ const ADMIN_HTML: &str = r#"<!DOCTYPE html>
                                     <td><span class="status status-${b.status}">${b.status}</span></td>
                                     <td><span class="pubkey" onclick="showUserBlobs('${b.owner}')">${b.owner.substring(0,12)}...</span></td>
                                     <td><span class="date">${new Date(b.uploaded).toLocaleDateString()}</span></td>
-                                    <td class="actions">${renderBlobActions(b)}</td>
+                                    <td class="actions">
+                                        <button class="btn btn-approve" onclick="moderate('${b.sha256}','approve')">OK</button>
+                                        <button class="btn btn-restrict" onclick="moderate('${b.sha256}','restrict')">R</button>
+                                        <button class="btn btn-ban" onclick="moderate('${b.sha256}','ban')">X</button>
+                                    </td>
                                 </tr>
                             `).join('')}
                         </tbody>
                     </table>
                 </div>
                 ${pagination ? renderPagination(pagination) : ''}
-            `;
-        }
-
-        function renderBlobActions(blob) {
-            if (blob.status === 'deleted') {
-                return `<button class="btn btn-approve" onclick="restoreBlob('${blob.sha256}')">Restore</button>`;
-            }
-
-            return `
-                <button class="btn btn-approve" onclick="moderate('${blob.sha256}','approve')">OK</button>
-                <button class="btn btn-restrict" onclick="moderate('${blob.sha256}','restrict')">R</button>
-                <button class="btn btn-ban" onclick="moderate('${blob.sha256}','ban')">X</button>
             `;
         }
 
@@ -1543,22 +1588,6 @@ const ADMIN_HTML: &str = r#"<!DOCTYPE html>
             }
         }
 
-        async function restoreBlob(sha256, status = 'active') {
-            try {
-                const resp = await fetch('/admin/api/restore', {
-                    method: 'POST',
-                    headers: { ...authHeaders(), 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ sha256, status })
-                });
-                if (!resp.ok) throw new Error('Restore failed');
-                await resp.json();
-                loadStats();
-                loadTabContent(currentOffset);
-            } catch (e) {
-                showError(e.message);
-            }
-        }
-
         async function showBlobDetail(hash) {
             const panel = document.getElementById('detailPanel');
             const content = document.getElementById('detailContent');
@@ -1574,14 +1603,6 @@ const ADMIN_HTML: &str = r#"<!DOCTYPE html>
                 const isImage = blob.type?.startsWith('image');
                 const thumbUrl = blob.thumbnail || (isVideo ? '/' + blob.sha256 + '.jpg' : null);
                 const previewUrl = isImage ? '/' + blob.sha256 : thumbUrl;
-
-                const actionButtons = blob.status === 'deleted'
-                    ? `<button class="btn btn-approve" onclick="restoreBlob('${blob.sha256}');closeDetail()">Restore</button>`
-                    : `
-                        <button class="btn btn-approve" onclick="moderate('${blob.sha256}','approve');closeDetail()">Approve</button>
-                        <button class="btn btn-restrict" onclick="moderate('${blob.sha256}','restrict');closeDetail()">Restrict</button>
-                        <button class="btn btn-ban" onclick="moderate('${blob.sha256}','ban');closeDetail()">Ban</button>
-                    `;
 
                 content.innerHTML = `
                     ${isVideo ? `<video src="/${blob.sha256}" class="detail-preview" controls poster="${thumbUrl}" style="max-width:100%"></video>` : (previewUrl ? `<img src="${previewUrl}" class="detail-preview">` : '')}
@@ -1616,7 +1637,9 @@ const ADMIN_HTML: &str = r#"<!DOCTYPE html>
                     </div>
                     ` : ''}
                     <div class="actions" style="margin-top:1rem">
-                        ${actionButtons}
+                        <button class="btn btn-approve" onclick="moderate('${blob.sha256}','approve');closeDetail()">Approve</button>
+                        <button class="btn btn-restrict" onclick="moderate('${blob.sha256}','restrict');closeDetail()">Restrict</button>
+                        <button class="btn btn-ban" onclick="moderate('${blob.sha256}','ban');closeDetail()">Ban</button>
                     </div>
                     <div style="margin-top:1rem">
                         <a href="/${blob.sha256}" target="_blank" class="btn btn-approve">View File</a>

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -22,9 +22,9 @@ pub fn validate_auth(req: &Request, required_action: AuthAction) -> Result<Bloss
         .map_err(|_| BlossomError::AuthInvalid("Invalid authorization header".into()))?;
 
     // Parse "Nostr <base64>" format
-    let base64_event = auth_header
-        .strip_prefix("Nostr ")
-        .ok_or_else(|| BlossomError::AuthInvalid("Authorization must start with 'Nostr '".into()))?;
+    let base64_event = auth_header.strip_prefix("Nostr ").ok_or_else(|| {
+        BlossomError::AuthInvalid("Authorization must start with 'Nostr '".into())
+    })?;
 
     // Decode base64
     let event_json = BASE64

--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -64,6 +64,18 @@ pub struct BlobMetadata {
     /// Transcript status for audio/video transcription
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transcript_status: Option<TranscriptStatus>,
+    /// Stable error code from the last transcript attempt
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript_error_code: Option<String>,
+    /// Human-readable error message from the last transcript attempt
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript_error_message: Option<String>,
+    /// ISO timestamp for the most recent transcript attempt
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript_last_attempt_at: Option<String>,
+    /// UNIX timestamp after which transcript generation may be retried
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript_retry_after: Option<u64>,
 }
 
 /// Moderation status for blobs
@@ -470,6 +482,11 @@ impl UserIndex {
     /// Check if a pubkey exists
     pub fn contains(&self, pubkey: &str) -> bool {
         self.pubkeys.contains(&pubkey.to_string())
+    }
+
+    /// Remove a pubkey from the index
+    pub fn remove(&mut self, pubkey: &str) {
+        self.pubkeys.retain(|p| p != pubkey);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,20 +18,13 @@ use crate::blossom::{
 use crate::error::{BlossomError, Result};
 use crate::metadata::{
     add_to_blob_refs, add_to_recent_index, add_to_user_index, add_to_user_list, check_ownership,
-<<<<<<< HEAD
-    delete_blob_metadata, get_auth_event, get_blob_metadata, get_blob_refs, get_subtitle_job,
-    get_subtitle_job_by_hash, get_tombstone, put_auth_event, put_blob_metadata, put_subtitle_job,
-    put_tombstone, set_subtitle_job_id_for_hash, list_blobs_with_metadata,
-    remove_from_recent_index, remove_from_user_list, update_blob_status, update_stats_on_add,
-    update_stats_on_remove, update_stats_on_status_change,
-=======
     delete_auth_events, delete_blob_metadata, delete_blob_refs, delete_subtitle_data,
     delete_user_list, get_auth_event, get_blob_metadata, get_blob_refs, get_subtitle_job,
     get_subtitle_job_by_hash, get_tombstone, get_user_blobs, list_blobs_with_metadata,
     put_auth_event, put_blob_metadata, put_subtitle_job, put_tombstone, remove_from_blob_refs,
     remove_from_recent_index, remove_from_user_index, remove_from_user_list,
     set_subtitle_job_id_for_hash, update_blob_status, update_stats_on_add, update_stats_on_remove,
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
+    TranscriptMetadataUpdate,
 };
 use crate::storage::{
     blob_exists, current_timestamp, delete_blob as storage_delete, download_blob_with_fallback,
@@ -179,11 +172,7 @@ fn handle_request(req: Request) -> Result<Response> {
         (Method::POST, "/admin/api/bulk-approve") => admin::handle_admin_bulk_approve(req),
         (Method::POST, "/admin/api/scan-flagged") => admin::handle_admin_scan_flagged(req),
         (Method::POST, "/admin/api/delete") => handle_admin_force_delete(req),
-<<<<<<< HEAD
-        (Method::POST, "/admin/api/restore") => admin::handle_admin_restore_action(req),
-=======
         (Method::POST, "/admin/api/vanish") => handle_admin_vanish(req),
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
         (Method::POST, "/admin/api/backfill") => admin::handle_admin_backfill(req),
         (Method::POST, "/admin/api/backfill-vtt") => handle_admin_backfill_vtt(req),
 
@@ -207,21 +196,8 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         // Check parent video's moderation status - thumbnails inherit video access rules
         let mut is_restricted = false;
         if let Ok(Some(meta)) = get_blob_metadata(video_hash) {
-<<<<<<< HEAD
-            if meta.status.blocks_public_access() {
-                return Err(BlossomError::NotFound("Blob not found".into()));
-            }
-            if meta.status.requires_owner_auth() {
-                // Check if requester is owner
-                if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
-                    if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
-                        return Err(BlossomError::NotFound("Blob not found".into()));
-                    }
-                } else {
-=======
             if !is_admin {
                 if meta.status == BlobStatus::Banned {
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
                     return Err(BlossomError::NotFound("Blob not found".into()));
                 }
                 if meta.status == BlobStatus::Restricted {
@@ -281,13 +257,14 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
 
     if let Some(ref meta) = metadata {
-        if meta.status.blocks_public_access() {
-            return Err(BlossomError::NotFound("Blob not found".into()));
-        }
-
         if !is_admin {
+            // Handle banned content - no access for anyone
+            if meta.status == BlobStatus::Banned {
+                return Err(BlossomError::NotFound("Blob not found".into()));
+            }
+
             // Handle restricted content
-            if meta.status.requires_owner_auth() {
+            if meta.status == BlobStatus::Restricted {
                 // Check if requester is owner
                 if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
                     if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
@@ -419,7 +396,7 @@ fn handle_head_blob(path: &str) -> Result<Response> {
         get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     // Don't reveal restricted or banned content exists
-    if metadata.status.requires_owner_auth() || metadata.status.blocks_public_access() {
+    if metadata.status == BlobStatus::Restricted || metadata.status == BlobStatus::Banned {
         return Err(BlossomError::NotFound("Blob not found".into()));
     }
 
@@ -454,18 +431,6 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
     // Check metadata for access control
     let metadata = get_blob_metadata(&hash)?;
 
-<<<<<<< HEAD
-    if let Some(ref meta) = metadata {
-        // Handle banned content
-        if meta.status.blocks_public_access() {
-            return Err(BlossomError::NotFound("Content not found".into()));
-        }
-
-        // Handle restricted content
-        if meta.status.requires_owner_auth() {
-            if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
-                if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
-=======
     // Admin Bearer token bypasses moderation checks (used by moderation service proxy)
     let is_admin = admin::validate_bearer_token(&req).is_ok();
 
@@ -483,7 +448,6 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
                         return Err(BlossomError::NotFound("Content not found".into()));
                     }
                 } else {
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
                     return Err(BlossomError::NotFound("Content not found".into()));
                 }
             }
@@ -583,13 +547,8 @@ fn handle_head_hls_master(path: &str) -> Result<Response> {
     let metadata = get_blob_metadata(&hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-<<<<<<< HEAD
-    // Don't reveal restricted/banned content
-    if metadata.status.requires_owner_auth() || metadata.status.blocks_public_access() {
-=======
     // Don't reveal restricted/banned content (HEAD has no req, no admin bypass)
     if metadata.status == BlobStatus::Restricted || metadata.status == BlobStatus::Banned {
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
         return Err(BlossomError::NotFound("Content not found".into()));
     }
 
@@ -683,11 +642,7 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
 
             if let Some(ref meta) = metadata {
                 // Handle banned content
-<<<<<<< HEAD
-                if meta.status.blocks_public_access() {
-=======
                 if !is_admin && meta.status == BlobStatus::Banned {
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
                     return Err(BlossomError::NotFound("Content not found".into()));
                 }
 
@@ -928,6 +883,113 @@ fn purge_transcript_content_cache(hash: &str) {
     let _ = simple_cache::purge(cache_key);
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedTranscriptStatusWebhook {
+    sha256: String,
+    status: TranscriptStatus,
+    job_id: Option<String>,
+    language: Option<String>,
+    duration_ms: Option<u64>,
+    cue_count: Option<u32>,
+    error_code: Option<String>,
+    error_message: Option<String>,
+    retry_after_epoch_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TranscriptPendingState {
+    InProgress,
+    CoolingDown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TranscriptFetchAction {
+    Accepted {
+        state: TranscriptPendingState,
+        retry_after_secs: u64,
+    },
+    Trigger {
+        retry_after_secs: u64,
+        should_repair: bool,
+    },
+}
+
+fn parse_optional_retry_after_epoch(
+    payload: &serde_json::Value,
+    now_epoch_secs: u64,
+) -> Option<u64> {
+    let retry_after_secs = payload["retry_after"]
+        .as_u64()
+        .or_else(|| payload["retry_after"].as_str().and_then(|value| value.parse().ok()))?;
+    Some(now_epoch_secs.saturating_add(retry_after_secs))
+}
+
+fn parse_transcript_status_webhook_payload(
+    payload: &serde_json::Value,
+    now_epoch_secs: u64,
+) -> Result<ParsedTranscriptStatusWebhook> {
+    let sha256 = payload["sha256"]
+        .as_str()
+        .ok_or_else(|| BlossomError::BadRequest("Missing 'sha256' field".into()))?
+        .to_string();
+
+    let status_str = payload["status"]
+        .as_str()
+        .ok_or_else(|| BlossomError::BadRequest("Missing 'status' field".into()))?;
+
+    let status = match status_str.to_lowercase().as_str() {
+        "pending" => TranscriptStatus::Pending,
+        "processing" => TranscriptStatus::Processing,
+        "complete" | "completed" | "ready" => TranscriptStatus::Complete,
+        "failed" | "error" => TranscriptStatus::Failed,
+        _ => {
+            return Err(BlossomError::BadRequest(format!(
+                "Unknown status: {}. Expected pending, processing, complete, or failed",
+                status_str
+            )));
+        }
+    };
+
+    Ok(ParsedTranscriptStatusWebhook {
+        sha256,
+        status,
+        job_id: payload["job_id"].as_str().map(|s| s.to_string()),
+        language: payload["language"].as_str().map(|s| s.to_string()),
+        duration_ms: payload["duration_ms"].as_u64(),
+        cue_count: payload["cue_count"].as_u64().map(|value| value as u32),
+        error_code: payload["error_code"].as_str().map(|s| s.to_string()),
+        error_message: payload["error_message"].as_str().map(|s| s.to_string()),
+        retry_after_epoch_secs: parse_optional_retry_after_epoch(payload, now_epoch_secs),
+    })
+}
+
+fn decide_transcript_fetch_action(
+    status: Option<TranscriptStatus>,
+    retry_after_epoch_secs: Option<u64>,
+    now_epoch_secs: u64,
+) -> TranscriptFetchAction {
+    if matches!(status, Some(TranscriptStatus::Processing)) {
+        return TranscriptFetchAction::Accepted {
+            state: TranscriptPendingState::InProgress,
+            retry_after_secs: 5,
+        };
+    }
+
+    if let Some(retry_after_epoch_secs) = retry_after_epoch_secs {
+        if retry_after_epoch_secs > now_epoch_secs {
+            return TranscriptFetchAction::Accepted {
+                state: TranscriptPendingState::CoolingDown,
+                retry_after_secs: retry_after_epoch_secs.saturating_sub(now_epoch_secs).max(1),
+            };
+        }
+    }
+
+    TranscriptFetchAction::Trigger {
+        retry_after_secs: 10,
+        should_repair: matches!(status, Some(TranscriptStatus::Complete)),
+    }
+}
+
 fn serve_transcript_by_hash(
     req: Option<&Request>,
     hash: &str,
@@ -936,16 +998,6 @@ fn serve_transcript_by_hash(
     let metadata = get_blob_metadata(hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-<<<<<<< HEAD
-    if metadata.status.blocks_public_access() {
-        return Err(BlossomError::NotFound("Content not found".into()));
-    }
-
-    if metadata.status.requires_owner_auth() {
-        if let Some(request) = req {
-            if let Ok(Some(auth)) = optional_auth(request, AuthAction::List) {
-                if auth.pubkey.to_lowercase() != metadata.owner.to_lowercase() {
-=======
     // Admin Bearer token bypasses moderation checks
     let is_admin = req
         .map(|r| admin::validate_bearer_token(r).is_ok())
@@ -963,7 +1015,6 @@ fn serve_transcript_by_hash(
                         return Err(BlossomError::NotFound("Content not found".into()));
                     }
                 } else {
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
                     return Err(BlossomError::NotFound("Content not found".into()));
                 }
             } else {
@@ -989,30 +1040,58 @@ fn serve_transcript_by_hash(
         }
         Err(BlossomError::NotFound(_)) if can_trigger => {
             // Transcript does not exist yet. Trigger transcription if needed.
-            match metadata.transcript_status {
-                Some(TranscriptStatus::Processing) => {
+            match decide_transcript_fetch_action(
+                metadata.transcript_status,
+                metadata.transcript_retry_after,
+                unix_timestamp_secs(),
+            ) {
+                TranscriptFetchAction::Accepted {
+                    state,
+                    retry_after_secs,
+                } => {
                     let mut resp = Response::from_status(StatusCode::ACCEPTED);
-                    resp.set_header("Retry-After", "5");
+                    resp.set_header("Retry-After", retry_after_secs.to_string());
                     resp.set_header("Content-Type", "application/json");
-                    resp.set_body(
-                        r#"{"status":"processing","message":"Transcript generation in progress"}"#,
-                    );
+                    let body = match state {
+                        TranscriptPendingState::InProgress => {
+                            r#"{"status":"in_progress","message":"Transcript generation in progress"}"#
+                        }
+                        TranscriptPendingState::CoolingDown => {
+                            r#"{"status":"cooling_down","message":"Transcript generation cooling down before retry"}"#
+                        }
+                    };
+                    resp.set_body(body);
                     add_no_cache_headers(&mut resp);
                     add_cors_headers(&mut resp);
                     Ok(resp)
                 }
-                Some(TranscriptStatus::Complete)
-                | Some(TranscriptStatus::Failed)
-                | Some(TranscriptStatus::Pending)
-                | None => {
+                TranscriptFetchAction::Trigger {
+                    retry_after_secs,
+                    should_repair,
+                } => {
                     use crate::metadata::update_transcript_status;
-                    let _ = update_transcript_status(hash, TranscriptStatus::Processing);
+                    let _ = update_transcript_status(
+                        hash,
+                        TranscriptStatus::Processing,
+                        TranscriptMetadataUpdate {
+                            last_attempt_at: Some(current_timestamp()),
+                            ..Default::default()
+                        },
+                    );
                     let _ = trigger_on_demand_transcription(hash, &metadata.owner, None, None);
 
                     let mut resp = Response::from_status(StatusCode::ACCEPTED);
-                    resp.set_header("Retry-After", "10");
+                    resp.set_header("Retry-After", retry_after_secs.to_string());
                     resp.set_header("Content-Type", "application/json");
-                    resp.set_body(r#"{"status":"processing","message":"Transcript generation started, please retry in 10 seconds"}"#);
+                    if should_repair {
+                        resp.set_body(
+                            r#"{"status":"repairing","message":"Transcript repair started, please retry soon"}"#,
+                        );
+                    } else {
+                        resp.set_body(
+                            r#"{"status":"processing","message":"Transcript generation started, please retry soon"}"#,
+                        );
+                    }
                     add_no_cache_headers(&mut resp);
                     add_cors_headers(&mut resp);
                     Ok(resp)
@@ -1055,7 +1134,7 @@ fn handle_head_transcript_by_hash(hash: &str) -> Result<Response> {
     let metadata = get_blob_metadata(hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-    if metadata.status.requires_owner_auth() || metadata.status.blocks_public_access() {
+    if metadata.status == BlobStatus::Restricted || metadata.status == BlobStatus::Banned {
         return Err(BlossomError::NotFound("Content not found".into()));
     }
 
@@ -1151,7 +1230,14 @@ fn dispatch_subtitle_job(job: &mut SubtitleJob, owner: &str) -> Result<()> {
     job.error_message = None;
     put_subtitle_job(job)?;
     let _ =
-        crate::metadata::update_transcript_status(&job.video_sha256, TranscriptStatus::Processing);
+        crate::metadata::update_transcript_status(
+            &job.video_sha256,
+            TranscriptStatus::Processing,
+            TranscriptMetadataUpdate {
+                last_attempt_at: Some(current_timestamp()),
+                ..Default::default()
+            },
+        );
 
     let lang_for_provider = job
         .language
@@ -1402,14 +1488,6 @@ fn handle_get_quality_variant(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     let metadata = get_blob_metadata(&hash)?;
     if let Some(ref meta) = metadata {
-<<<<<<< HEAD
-        if meta.status.blocks_public_access() {
-            return Err(BlossomError::NotFound("Content not found".into()));
-        }
-        if meta.status.requires_owner_auth() {
-            if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
-                if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
-=======
         if !is_admin {
             if meta.status == BlobStatus::Banned {
                 return Err(BlossomError::NotFound("Content not found".into()));
@@ -1420,7 +1498,6 @@ fn handle_get_quality_variant(req: Request, path: &str) -> Result<Response> {
                         return Err(BlossomError::NotFound("Content not found".into()));
                     }
                 } else {
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
                     return Err(BlossomError::NotFound("Content not found".into()));
                 }
             }
@@ -1488,7 +1565,7 @@ fn handle_head_quality_variant(path: &str) -> Result<Response> {
     let metadata = get_blob_metadata(&hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-    if metadata.status.blocks_public_access() || metadata.status.requires_owner_auth() {
+    if metadata.status == BlobStatus::Banned || metadata.status == BlobStatus::Restricted {
         return Err(BlossomError::NotFound("Content not found".into()));
     }
 
@@ -1759,6 +1836,10 @@ fn handle_upload(mut req: Request) -> Result<Response> {
         } else {
             None
         },
+        transcript_error_code: None,
+        transcript_error_message: None,
+        transcript_last_attempt_at: None,
+        transcript_retry_after: None,
     };
 
     put_blob_metadata(&metadata)?;
@@ -1925,6 +2006,10 @@ fn handle_cloud_run_proxy(
         } else {
             None
         },
+        transcript_error_code: None,
+        transcript_error_message: None,
+        transcript_last_attempt_at: None,
+        transcript_retry_after: None,
     };
 
     put_blob_metadata(&metadata)?;
@@ -2235,13 +2320,8 @@ fn handle_get_provenance(path: &str) -> Result<Response> {
     Ok(resp)
 }
 
-<<<<<<< HEAD
-/// POST /admin/api/delete - Admin soft-delete for legal/DMCA compliance
-/// Preserves storage unless the blob has no metadata record to gate public access with.
-=======
 /// POST /admin/api/delete - Admin force-delete for legal/DMCA compliance
 /// Full cleanup: main blob + thumbnail + HLS + VTT + all KV artifacts + VCL cache purge
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
 fn handle_admin_force_delete(req: Request) -> Result<Response> {
     // Validate admin auth
     admin::validate_admin_auth(&req)?;
@@ -2281,27 +2361,12 @@ fn handle_admin_force_delete(req: Request) -> Result<Response> {
         Some(reason),
     );
 
-<<<<<<< HEAD
-    let preserved = if let Some(ref meta) = metadata {
-        if meta.status != BlobStatus::Deleted {
-            update_blob_status(&hash, BlobStatus::Deleted)?;
-            let _ = update_stats_on_status_change(meta.status, BlobStatus::Deleted);
-        }
-        true
-    } else {
-        // Without metadata there is no status gate, so fall back to hard delete.
-        let _ = storage_delete(&hash);
-        let _ = storage_delete(&format!("{}.jpg", hash));
-        false
-    };
-=======
     // Delete from GCS (main blob + all artifacts)
     let _ = storage_delete(&hash);
     delete_blob_gcs_artifacts(&hash);
 
     // Delete KV metadata
     let _ = delete_blob_metadata(&hash);
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
 
     // Remove from ALL users' lists (owner + all refs)
     if let Some(ref meta) = metadata {
@@ -2313,20 +2378,12 @@ fn handle_admin_force_delete(req: Request) -> Result<Response> {
         }
     }
 
-<<<<<<< HEAD
-    // Update stats for the hard-delete fallback only.
-    if !preserved {
-        if let Some(meta) = metadata {
-            let _ = update_stats_on_remove(&meta);
-        }
-=======
     // Delete all KV artifacts (refs, auth events, subtitle data)
     delete_blob_kv_artifacts(&hash);
 
     // Update stats
     if let Some(meta) = metadata {
         let _ = update_stats_on_remove(&meta);
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
     }
     let _ = remove_from_recent_index(&hash);
 
@@ -2335,21 +2392,16 @@ fn handle_admin_force_delete(req: Request) -> Result<Response> {
         let _ = put_tombstone(&hash, reason);
     }
 
-<<<<<<< HEAD
-=======
     // Purge VCL cache
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
     purge_vcl_cache(&hash);
 
     eprintln!(
-        "[ADMIN DELETE] hash={} reason={} legal_hold={} preserved={}",
-        hash, reason, legal_hold, preserved
+        "[ADMIN DELETE] hash={} reason={} legal_hold={}",
+        hash, reason, legal_hold
     );
 
     let result = serde_json::json!({
         "deleted": true,
-        "soft_deleted": preserved,
-        "preserved": preserved,
         "sha256": hash,
         "legal_hold": legal_hold,
     });
@@ -2766,6 +2818,10 @@ fn handle_mirror(mut req: Request) -> Result<Response> {
         } else {
             None
         },
+        transcript_error_code: None,
+        transcript_error_message: None,
+        transcript_last_attempt_at: None,
+        transcript_retry_after: None,
     };
 
     put_blob_metadata(&metadata)?;
@@ -2792,6 +2848,16 @@ fn handle_mirror(mut req: Request) -> Result<Response> {
 /// POST /admin/api/backfill-vtt - Trigger VTT transcription for all video/audio blobs missing transcripts
 /// Iterates through user index, finds transcribable blobs without VTT, and triggers transcription.
 /// Query params: ?offset=N&limit=M (paginate through users, default limit=50)
+#[derive(Debug, Clone, serde::Serialize)]
+struct TranscriptBackfillCandidate {
+    sha256: String,
+    owner: String,
+    uploaded: String,
+    transcript_status: Option<String>,
+    retry_after_epoch_secs: Option<u64>,
+    cooldown_remaining_secs: Option<u64>,
+}
+
 fn handle_admin_backfill_vtt(req: Request) -> Result<Response> {
     // Accept webhook secret (same as transcoder uses) OR admin session
     let webhook_ok = fastly::secret_store::SecretStore::open("blossom_secrets")
@@ -2829,6 +2895,14 @@ fn handle_admin_backfill_vtt(req: Request) -> Result<Response> {
         .get("limit")
         .and_then(|v| v.parse().ok())
         .unwrap_or(50);
+    let scope = query_pairs
+        .get("scope")
+        .map(|value| value.as_str())
+        .unwrap_or("users");
+    let dry_run = query_pairs
+        .get("dry_run")
+        .map(|value| value == "true")
+        .unwrap_or(false);
 
     // Max triggers per request to avoid Fastly Compute timeout (~30s wall time)
     let max_triggers: u32 = query_pairs
@@ -2848,94 +2922,167 @@ fn handle_admin_backfill_vtt(req: Request) -> Result<Response> {
         .map(|v| v == "true")
         .unwrap_or(false);
 
-    let user_index = crate::metadata::get_user_index()?;
-    let total_users = user_index.pubkeys.len();
-    let end = std::cmp::min(offset + limit, total_users);
-    let pubkeys_to_process = if offset < total_users {
-        &user_index.pubkeys[offset..end]
-    } else {
-        &[] as &[String]
-    };
-
+    let now_epoch_secs = unix_timestamp_secs();
     let mut triggered = 0u32;
     let mut already_complete = 0u32;
     let mut already_processing = 0u32;
+    let mut cooling_down = 0u32;
     let mut reset_count = 0u32;
     let mut not_transcribable = 0u32;
     let mut errors = 0u32;
     let mut hit_limit = false;
+    let mut candidates = Vec::new();
+    let mut processed_hashes = 0usize;
 
-    for pubkey in pubkeys_to_process {
-        if hit_limit {
-            break;
+    let mut process_hash = |hash: &str| -> bool {
+        let Ok(Some(mut metadata)) = crate::metadata::get_blob_metadata_uncached(hash) else {
+            return false;
+        };
+
+        processed_hashes += 1;
+
+        if !is_transcribable_mime_type(&metadata.mime_type) {
+            not_transcribable += 1;
+            return false;
         }
-        let hashes = crate::metadata::get_user_blobs(pubkey).unwrap_or_default();
 
-        for hash in hashes {
-            // Use uncached lookup to avoid stale Simple Cache reads during bulk operations
-            if let Ok(Some(mut metadata)) = crate::metadata::get_blob_metadata_uncached(&hash) {
-                if !is_transcribable_mime_type(&metadata.mime_type) {
-                    not_transcribable += 1;
-                    continue;
+        match metadata.transcript_status {
+            Some(TranscriptStatus::Complete) if !force_retranscribe => {
+                already_complete += 1;
+                return false;
+            }
+            Some(TranscriptStatus::Complete) => {
+                reset_count += 1;
+            }
+            Some(TranscriptStatus::Processing) if !reset_processing => {
+                already_processing += 1;
+                return false;
+            }
+            Some(TranscriptStatus::Processing) => {
+                reset_count += 1;
+            }
+            _ => {}
+        }
+
+        if metadata
+            .transcript_retry_after
+            .map(|retry_after| retry_after > now_epoch_secs)
+            .unwrap_or(false)
+            && !force_retranscribe
+        {
+            cooling_down += 1;
+            return false;
+        }
+
+        if dry_run {
+            candidates.push(TranscriptBackfillCandidate {
+                sha256: metadata.sha256.clone(),
+                owner: metadata.owner.clone(),
+                uploaded: metadata.uploaded.clone(),
+                transcript_status: metadata
+                    .transcript_status
+                    .map(|status| format!("{:?}", status).to_lowercase()),
+                retry_after_epoch_secs: metadata.transcript_retry_after,
+                cooldown_remaining_secs: metadata
+                    .transcript_retry_after
+                    .map(|retry_after| retry_after.saturating_sub(now_epoch_secs))
+                    .filter(|remaining| *remaining > 0),
+            });
+            return false;
+        }
+
+        if triggered >= max_triggers {
+            return true;
+        }
+
+        // Update status to Processing and trigger transcription (async/fire-and-forget)
+        metadata.transcript_status = Some(TranscriptStatus::Processing);
+        let _ = put_blob_metadata(&metadata);
+
+        match trigger_on_demand_transcription(hash, &metadata.owner, None, None) {
+            Ok(_) => triggered += 1,
+            Err(_) => errors += 1,
+        }
+        false
+    };
+
+    let (has_more, next_offset, processed_users) = if scope == "recent" {
+        let recent_index = crate::metadata::get_recent_index()?;
+        let total_hashes = recent_index.hashes.len();
+        let end = std::cmp::min(offset + limit, total_hashes);
+        let hashes_to_process = if offset < total_hashes {
+            &recent_index.hashes[offset..end]
+        } else {
+            &[] as &[String]
+        };
+
+        for hash in hashes_to_process {
+            if hit_limit {
+                break;
+            }
+            if process_hash(hash) {
+                hit_limit = true;
+                break;
+            }
+        }
+
+        (end < total_hashes, if end < total_hashes { Some(end) } else { None }, None)
+    } else {
+        let user_index = crate::metadata::get_user_index()?;
+        let total_users = user_index.pubkeys.len();
+        let end = std::cmp::min(offset + limit, total_users);
+        let pubkeys_to_process = if offset < total_users {
+            &user_index.pubkeys[offset..end]
+        } else {
+            &[] as &[String]
+        };
+
+        for pubkey in pubkeys_to_process {
+            if hit_limit {
+                break;
+            }
+
+            let hashes = crate::metadata::get_user_blobs(pubkey).unwrap_or_default();
+            for hash in hashes {
+                if hit_limit {
+                    break;
                 }
-
-                match metadata.transcript_status {
-                    Some(TranscriptStatus::Complete) if !force_retranscribe => {
-                        already_complete += 1;
-                        continue;
-                    }
-                    Some(TranscriptStatus::Complete) => {
-                        // Force re-transcription with updated phantom detection
-                        reset_count += 1;
-                        // Fall through to trigger
-                    }
-                    Some(TranscriptStatus::Processing) if !reset_processing => {
-                        already_processing += 1;
-                        continue;
-                    }
-                    Some(TranscriptStatus::Processing) => {
-                        // Reset stale processing items
-                        reset_count += 1;
-                        // Fall through to trigger
-                    }
-                    _ => {}
-                }
-
-                if triggered >= max_triggers {
+                if process_hash(&hash) {
                     hit_limit = true;
                     break;
                 }
-
-                // Update status to Processing and trigger transcription (async/fire-and-forget)
-                metadata.transcript_status = Some(TranscriptStatus::Processing);
-                let _ = put_blob_metadata(&metadata);
-
-                match trigger_on_demand_transcription(&hash, &metadata.owner, None, None) {
-                    Ok(_) => triggered += 1,
-                    Err(_) => errors += 1,
-                }
             }
         }
-    }
 
-    let has_more = end < total_users;
+        (
+            end < total_users,
+            if end < total_users { Some(end) } else { None },
+            Some(pubkeys_to_process.len()),
+        )
+    };
+
     let response = serde_json::json!({
         "success": true,
         "batch": {
+            "scope": scope,
             "offset": offset,
             "limit": limit,
-            "processed_users": pubkeys_to_process.len(),
-            "next_offset": if has_more { Some(end) } else { None },
+            "processed_users": processed_users,
+            "processed_hashes": processed_hashes,
+            "next_offset": next_offset,
             "has_more": has_more
         },
         "results": {
+            "dry_run": dry_run,
             "triggered": triggered,
             "already_complete": already_complete,
             "already_processing": already_processing,
+            "cooling_down": cooling_down,
             "not_transcribable": not_transcribable,
             "reset_from_processing": reset_count,
             "errors": errors,
-            "hit_trigger_limit": hit_limit
+            "hit_trigger_limit": hit_limit,
+            "candidates": candidates
         }
     });
 
@@ -3245,23 +3392,12 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
     let payload: serde_json::Value = serde_json::from_str(&body)
         .map_err(|e| BlossomError::BadRequest(format!("Invalid JSON: {}", e)))?;
 
-    let sha256 = payload["sha256"]
-        .as_str()
-        .ok_or_else(|| BlossomError::BadRequest("Missing 'sha256' field".into()))?;
-
-    let status_str = payload["status"]
-        .as_str()
-        .ok_or_else(|| BlossomError::BadRequest("Missing 'status' field".into()))?;
-    let job_id = payload["job_id"].as_str().map(|s| s.to_string());
-    let language = payload["language"].as_str().map(|s| s.to_string());
-    let duration_ms = payload["duration_ms"].as_u64();
-    let cue_count = payload["cue_count"].as_u64().map(|v| v as u32);
-    let error_code = payload["error_code"].as_str().map(|s| s.to_string());
-    let error_message = payload["error_message"].as_str().map(|s| s.to_string());
+    let parsed = parse_transcript_status_webhook_payload(&payload, unix_timestamp_secs())?;
+    let sha256 = parsed.sha256.as_str();
 
     eprintln!(
-        "[TRANSCRIPT] Status webhook: sha256={}, status={}, job_id={:?}",
-        sha256, status_str, job_id
+        "[TRANSCRIPT] Status webhook: sha256={}, status={:?}, job_id={:?}",
+        sha256, parsed.status, parsed.job_id
     );
 
     // Validate sha256 format
@@ -3269,30 +3405,25 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
         return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
     }
 
-    // Map status string to TranscriptStatus
-    let new_status = match status_str.to_lowercase().as_str() {
-        "pending" => TranscriptStatus::Pending,
-        "processing" => TranscriptStatus::Processing,
-        "complete" | "completed" | "ready" => TranscriptStatus::Complete,
-        "failed" | "error" => TranscriptStatus::Failed,
-        _ => {
-            return Err(BlossomError::BadRequest(format!(
-                "Unknown status: {}. Expected pending, processing, complete, or failed",
-                status_str
-            )));
-        }
-    };
-
     use crate::metadata::update_transcript_status;
-    match update_transcript_status(sha256, new_status) {
+    match update_transcript_status(
+        sha256,
+        parsed.status,
+        TranscriptMetadataUpdate {
+            error_code: parsed.error_code.clone(),
+            error_message: parsed.error_message.clone(),
+            last_attempt_at: Some(current_timestamp()),
+            retry_after: parsed.retry_after_epoch_secs,
+        },
+    ) {
         Ok(()) => {
             eprintln!(
                 "[TRANSCRIPT] Updated blob {} to transcript status {:?}",
-                sha256, new_status
+                sha256, parsed.status
             );
 
             // If a subtitle job exists, keep it in sync with webhook status and metadata.
-            let mut updated_job: Option<SubtitleJob> = if let Some(ref id) = job_id {
+            let mut updated_job: Option<SubtitleJob> = if let Some(ref id) = parsed.job_id {
                 get_subtitle_job(id)?
             } else {
                 get_subtitle_job_by_hash(sha256)?
@@ -3300,7 +3431,7 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
 
             if let Some(mut job) = updated_job.take() {
                 job.updated_at = current_timestamp();
-                match new_status {
+                match parsed.status {
                     TranscriptStatus::Pending => {
                         job.status = SubtitleJobStatus::Queued;
                     }
@@ -3313,13 +3444,13 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
                             job.text_track_url =
                                 Some(format!("https://media.divine.video/{}.vtt", sha256));
                         }
-                        if let Some(lang) = language.clone() {
+                        if let Some(lang) = parsed.language.clone() {
                             job.language = Some(lang);
                         }
-                        if let Some(ms) = duration_ms {
+                        if let Some(ms) = parsed.duration_ms {
                             job.duration_ms = Some(ms);
                         }
-                        if let Some(cues) = cue_count {
+                        if let Some(cues) = parsed.cue_count {
                             job.cue_count = Some(cues);
                         }
                         job.next_retry_at_unix = None;
@@ -3329,8 +3460,8 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
                     TranscriptStatus::Failed => {
                         apply_subtitle_job_failure(
                             &mut job,
-                            error_code.clone(),
-                            error_message.clone(),
+                            parsed.error_code.clone(),
+                            parsed.error_message.clone(),
                         );
                     }
                 }
@@ -3340,7 +3471,7 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
 
             // Purge VCL cache on transcript completion so cached 202s are evicted
             if matches!(
-                new_status,
+                parsed.status,
                 TranscriptStatus::Complete | TranscriptStatus::Failed
             ) {
                 purge_transcript_content_cache(sha256);
@@ -3350,7 +3481,7 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
             let response = serde_json::json!({
                 "success": true,
                 "sha256": sha256,
-                "transcript_status": format!("{:?}", new_status).to_lowercase(),
+                "transcript_status": format!("{:?}", parsed.status).to_lowercase(),
                 "message": "Transcript status updated"
             });
             let mut resp = json_response(StatusCode::OK, &response);
@@ -3358,13 +3489,20 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
             Ok(resp)
         }
         Err(BlossomError::NotFound(_)) => {
-            eprintln!("[TRANSCRIPT] Blob {} not found", sha256);
+            eprintln!(
+                "[TRANSCRIPT] Reconciliation pending for missing blob {} status={:?} error_code={:?} retry_after={:?}",
+                sha256,
+                parsed.status,
+                parsed.error_code,
+                parsed.retry_after_epoch_secs
+            );
             let response = serde_json::json!({
-                "success": false,
+                "success": true,
                 "sha256": sha256,
-                "error": "Blob not found"
+                "reconciliation": "pending",
+                "message": "Transcript status accepted for later reconciliation"
             });
-            let mut resp = json_response(StatusCode::NOT_FOUND, &response);
+            let mut resp = json_response(StatusCode::ACCEPTED, &response);
             add_cors_headers(&mut resp);
             Ok(resp)
         }
@@ -3618,9 +3756,6 @@ fn handle_landing_page() -> Response {
                 <span class="method method-delete">DELETE</span>
                 <div class="endpoint-info">
                     <span class="endpoint-path">/&lt;sha256&gt;</span>
-<<<<<<< HEAD
-                    <p class="endpoint-desc">Permanently delete your own blob. Requires Nostr authentication and ownership. <em>(BUD-02)</em></p>
-=======
                     <p class="endpoint-desc">Delete a blob with ref-counting. Sole owner: full delete. Shared: transfers ownership. Non-owner ref: unlinks. Requires Nostr authentication. <em>(BUD-02)</em></p>
                 </div>
             </div>
@@ -3629,7 +3764,6 @@ fn handle_landing_page() -> Response {
                 <div class="endpoint-info">
                     <span class="endpoint-path">/vanish</span>
                     <p class="endpoint-desc">GDPR Right to Erasure. Deletes all blobs and data for the authenticated user. Requires Nostr authentication.</p>
->>>>>>> b22632b (fix: handle QUARANTINE moderation action for AI-detected content)
                 </div>
             </div>
             <div class="endpoint">
@@ -3678,10 +3812,6 @@ fn handle_landing_page() -> Response {
                 <div class="feature">
                     <h3>GCS Storage</h3>
                     <p>Reliable blob storage backed by Google Cloud Storage.</p>
-                </div>
-                <div class="feature">
-                    <h3>Soft Delete Recovery</h3>
-                    <p>Admin deletes preserve stored media as internal soft-deletes, with explicit restore support for recovery and legal workflows.</p>
                 </div>
             </div>
         </section>
@@ -3904,4 +4034,104 @@ fn infer_mime_from_path(path: &str) -> Option<&'static str> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        decide_transcript_fetch_action, parse_transcript_status_webhook_payload,
+        TranscriptFetchAction, TranscriptPendingState,
+    };
+    use crate::blossom::TranscriptStatus;
+
+    #[test]
+    fn parses_transcript_webhook_error_code_fields() {
+        let payload = serde_json::json!({
+            "sha256": "50dfc6758bb3cdf823ef33315e72642ebb881a0b1d0f6b0d8bade0f0fad30c3a",
+            "status": "failed",
+            "error_code": "normalize_failed",
+            "error_message": "bad transcript body"
+        });
+
+        let parsed = parse_transcript_status_webhook_payload(&payload, 1_000).unwrap();
+
+        assert_eq!(parsed.error_code.as_deref(), Some("normalize_failed"));
+        assert_eq!(parsed.error_message.as_deref(), Some("bad transcript body"));
+        assert_eq!(parsed.retry_after_epoch_secs, None);
+    }
+
+    #[test]
+    fn parses_transcript_webhook_retry_after_for_provider_rate_limited() {
+        let payload = serde_json::json!({
+            "sha256": "50dfc6758bb3cdf823ef33315e72642ebb881a0b1d0f6b0d8bade0f0fad30c3a",
+            "status": "failed",
+            "error_code": "provider_rate_limited",
+            "retry_after": 15
+        });
+
+        let parsed = parse_transcript_status_webhook_payload(&payload, 1_000).unwrap();
+
+        assert_eq!(parsed.error_code.as_deref(), Some("provider_rate_limited"));
+        assert_eq!(parsed.retry_after_epoch_secs, Some(1_015));
+    }
+
+    #[test]
+    fn transcript_fetch_action_cools_down_when_retry_after_is_in_future() {
+        assert_eq!(
+            decide_transcript_fetch_action(
+                Some(TranscriptStatus::Failed),
+                Some(1_030),
+                1_000,
+            ),
+            TranscriptFetchAction::Accepted {
+                state: TranscriptPendingState::CoolingDown,
+                retry_after_secs: 30,
+            }
+        );
+    }
+
+    #[test]
+    fn transcript_fetch_action_keeps_processing_items_in_progress() {
+        assert_eq!(
+            decide_transcript_fetch_action(
+                Some(TranscriptStatus::Processing),
+                None,
+                1_000,
+            ),
+            TranscriptFetchAction::Accepted {
+                state: TranscriptPendingState::InProgress,
+                retry_after_secs: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn transcript_fetch_action_triggers_pending_items_without_cooldown() {
+        assert_eq!(
+            decide_transcript_fetch_action(
+                Some(TranscriptStatus::Pending),
+                None,
+                1_000,
+            ),
+            TranscriptFetchAction::Trigger {
+                retry_after_secs: 10,
+                should_repair: false,
+            }
+        );
+    }
+
+    #[test]
+    fn transcript_fetch_action_repairs_missing_vtt_for_complete_status() {
+        assert_eq!(
+            decide_transcript_fetch_action(
+                Some(TranscriptStatus::Complete),
+                None,
+                1_000,
+            ),
+            TranscriptFetchAction::Trigger {
+                retry_after_secs: 10,
+                should_repair: true,
+            }
+        );
+    }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -83,7 +83,7 @@ pub fn get_blob_metadata(hash: &str) -> Result<Option<BlobMetadata>> {
 }
 
 /// Get blob metadata directly from KV store (bypasses cache)
-fn get_blob_metadata_uncached(hash: &str) -> Result<Option<BlobMetadata>> {
+pub fn get_blob_metadata_uncached(hash: &str) -> Result<Option<BlobMetadata>> {
     let store = open_store()?;
     let key = format!("{}{}", BLOB_PREFIX, hash.to_lowercase());
 
@@ -265,14 +265,27 @@ pub fn update_transcode_status(hash: &str, status: crate::blossom::TranscodeStat
 }
 
 /// Update transcript status for an audio/video blob
+#[derive(Debug, Clone, Default)]
+pub struct TranscriptMetadataUpdate {
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+    pub last_attempt_at: Option<String>,
+    pub retry_after: Option<u64>,
+}
+
 pub fn update_transcript_status(
     hash: &str,
     status: crate::blossom::TranscriptStatus,
+    update: TranscriptMetadataUpdate,
 ) -> Result<()> {
     let mut metadata =
         get_blob_metadata(hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     metadata.transcript_status = Some(status);
+    metadata.transcript_error_code = update.error_code;
+    metadata.transcript_error_message = update.error_message;
+    metadata.transcript_last_attempt_at = update.last_attempt_at;
+    metadata.transcript_retry_after = update.retry_after;
     put_blob_metadata(&metadata)?;
 
     Ok(())
@@ -303,8 +316,9 @@ pub fn get_subtitle_job(job_id: &str) -> Result<Option<SubtitleJob>> {
 pub fn put_subtitle_job(job: &SubtitleJob) -> Result<()> {
     let store = open_store()?;
     let key = format!("{}{}", SUBTITLE_JOB_PREFIX, job.job_id);
-    let json = serde_json::to_string(job)
-        .map_err(|e| BlossomError::MetadataError(format!("Failed to serialize subtitle job: {}", e)))?;
+    let json = serde_json::to_string(job).map_err(|e| {
+        BlossomError::MetadataError(format!("Failed to serialize subtitle job: {}", e))
+    })?;
 
     store
         .insert(&key, json)
@@ -340,11 +354,9 @@ pub fn get_subtitle_job_id_by_hash(hash: &str) -> Result<Option<String>> {
 pub fn set_subtitle_job_id_for_hash(hash: &str, job_id: &str) -> Result<()> {
     let store = open_store()?;
     let key = format!("{}{}", SUBTITLE_HASH_PREFIX, hash.to_lowercase());
-    store
-        .insert(&key, job_id.to_string())
-        .map_err(|e| {
-            BlossomError::MetadataError(format!("Failed to store subtitle hash mapping: {}", e))
-        })?;
+    store.insert(&key, job_id.to_string()).map_err(|e| {
+        BlossomError::MetadataError(format!("Failed to store subtitle hash mapping: {}", e))
+    })?;
     Ok(())
 }
 
@@ -738,8 +750,11 @@ pub fn put_tombstone(hash: &str, reason: &str) -> Result<()> {
     let key = format!("{}{}", TOMBSTONE_PREFIX, hash.to_lowercase());
 
     let timestamp = crate::storage::current_timestamp();
-    let json = format!(r#"{{"reason":"{}","removed_at":"{}"}}"#,
-        reason.replace('"', "\\\""), timestamp);
+    let json = format!(
+        r#"{{"reason":"{}","removed_at":"{}"}}"#,
+        reason.replace('"', "\\\""),
+        timestamp
+    );
 
     store
         .insert(&key, json)
@@ -790,6 +805,159 @@ pub fn get_blob_refs(hash: &str) -> Result<Vec<String>> {
     }
 }
 
+/// Remove a pubkey from the blob's references list. Returns the remaining refs.
+pub fn remove_from_blob_refs(hash: &str, pubkey: &str) -> Result<Vec<String>> {
+    let pubkey_lower = pubkey.to_lowercase();
+
+    for attempt in 0..5 {
+        let mut refs = get_blob_refs(hash)?;
+
+        if !refs.contains(&pubkey_lower) {
+            return Ok(refs);
+        }
+
+        refs.retain(|p| p != &pubkey_lower);
+
+        let store = open_store()?;
+        let key = format!("{}{}", REFS_PREFIX, hash.to_lowercase());
+        let json = serde_json::to_string(&refs)
+            .map_err(|e| BlossomError::MetadataError(format!("Failed to serialize refs: {}", e)))?;
+
+        match store.insert(&key, json) {
+            Ok(()) => return Ok(refs),
+            Err(e) if attempt < 4 => {
+                eprintln!("[KV] Retry {} for refs removal: {}", attempt + 1, e);
+                continue;
+            }
+            Err(e) => {
+                return Err(BlossomError::MetadataError(format!(
+                    "Failed to store refs: {}",
+                    e
+                )))
+            }
+        }
+    }
+
+    Err(BlossomError::MetadataError(
+        "Max retries exceeded for refs removal".into(),
+    ))
+}
+
+/// Delete the entire blob refs entry
+pub fn delete_blob_refs(hash: &str) -> Result<()> {
+    let store = open_store()?;
+    let key = format!("{}{}", REFS_PREFIX, hash.to_lowercase());
+
+    match store.delete(&key) {
+        Ok(()) => Ok(()),
+        Err(KVStoreError::ItemNotFound) => Ok(()),
+        Err(e) => Err(BlossomError::MetadataError(format!(
+            "Failed to delete blob refs: {}",
+            e
+        ))),
+    }
+}
+
+/// Delete auth events for a hash (both upload and delete provenance)
+pub fn delete_auth_events(hash: &str) -> Result<()> {
+    let store = open_store()?;
+    let hash_lower = hash.to_lowercase();
+
+    for action in &["upload", "delete"] {
+        let key = format!("{}{}:{}", AUTH_PREFIX, hash_lower, action);
+        match store.delete(&key) {
+            Ok(()) => {}
+            Err(KVStoreError::ItemNotFound) => {}
+            Err(e) => {
+                eprintln!(
+                    "[KV] Failed to delete auth event {}:{}: {}",
+                    hash_lower, action, e
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Delete subtitle data for a hash (job mapping + job record)
+pub fn delete_subtitle_data(hash: &str) -> Result<()> {
+    let hash_lower = hash.to_lowercase();
+
+    // Look up the job ID from the hash mapping
+    if let Some(job_id) = get_subtitle_job_id_by_hash(&hash_lower)? {
+        let store = open_store()?;
+
+        // Delete the job record
+        let job_key = format!("{}{}", SUBTITLE_JOB_PREFIX, job_id);
+        match store.delete(&job_key) {
+            Ok(()) => {}
+            Err(KVStoreError::ItemNotFound) => {}
+            Err(e) => {
+                eprintln!("[KV] Failed to delete subtitle job {}: {}", job_id, e);
+            }
+        }
+
+        // Delete the hash -> job_id mapping
+        let hash_key = format!("{}{}", SUBTITLE_HASH_PREFIX, hash_lower);
+        match store.delete(&hash_key) {
+            Ok(()) => {}
+            Err(KVStoreError::ItemNotFound) => {}
+            Err(e) => {
+                eprintln!(
+                    "[KV] Failed to delete subtitle hash mapping {}: {}",
+                    hash_lower, e
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Delete a user's entire blob list
+pub fn delete_user_list(pubkey: &str) -> Result<()> {
+    let store = open_store()?;
+    let key = format!("{}{}", LIST_PREFIX, pubkey.to_lowercase());
+
+    match store.delete(&key) {
+        Ok(()) => Ok(()),
+        Err(KVStoreError::ItemNotFound) => Ok(()),
+        Err(e) => Err(BlossomError::MetadataError(format!(
+            "Failed to delete user list: {}",
+            e
+        ))),
+    }
+}
+
+/// Remove a pubkey from the user index (with retry for concurrent writes)
+pub fn remove_from_user_index(pubkey: &str) -> Result<()> {
+    let pubkey_lower = pubkey.to_lowercase();
+
+    for attempt in 0..5 {
+        let mut index = get_user_index()?;
+
+        if !index.contains(&pubkey_lower) {
+            return Ok(());
+        }
+
+        index.remove(&pubkey_lower);
+
+        match put_user_index(&index) {
+            Ok(()) => return Ok(()),
+            Err(e) if attempt < 4 => {
+                eprintln!("[KV] Retry {} for user index removal: {}", attempt + 1, e);
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err(BlossomError::MetadataError(
+        "Max retries exceeded for user index removal".into(),
+    ))
+}
+
 /// Add a pubkey to the blob's references list
 pub fn add_to_blob_refs(hash: &str, pubkey: &str) -> Result<()> {
     let pubkey_lower = pubkey.to_lowercase();
@@ -814,10 +982,12 @@ pub fn add_to_blob_refs(hash: &str, pubkey: &str) -> Result<()> {
                 eprintln!("[KV] Retry {} for refs update: {}", attempt + 1, e);
                 continue;
             }
-            Err(e) => return Err(BlossomError::MetadataError(format!(
-                "Failed to store refs: {}",
-                e
-            ))),
+            Err(e) => {
+                return Err(BlossomError::MetadataError(format!(
+                    "Failed to store refs: {}",
+                    e
+                )))
+            }
         }
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1191,20 +1191,129 @@ pub fn write_audit_log(
     // Fire-and-forget POST to Cloud Run /audit endpoint
     // Cloud Run prints structured JSON → auto-ingested by Cloud Logging
     const CLOUD_RUN_HOST: &str = "blossom-upload-rust-149672065768.us-central1.run.app";
-    let mut req = Request::new(
-        Method::POST,
-        format!("https://{}/audit", CLOUD_RUN_HOST),
-    );
+    let mut req = Request::new(Method::POST, format!("https://{}/audit", CLOUD_RUN_HOST));
     req.set_header("Host", CLOUD_RUN_HOST);
     req.set_header("Content-Type", "application/json");
     req.set_body(Body::from(entry));
 
     match req.send_async(CLOUD_RUN_BACKEND) {
         Ok(_) => {
-            eprintln!("[AUDIT] {} sha256={} actor={}", action, sha256, actor_pubkey);
+            eprintln!(
+                "[AUDIT] {} sha256={} actor={}",
+                action, sha256, actor_pubkey
+            );
         }
         Err(e) => {
             eprintln!("[AUDIT] Failed to send audit log: {}", e);
+        }
+    }
+}
+
+/// Fire-and-forget: ask Cloud Run to delete a blob's GCS objects (main + prefix).
+/// This is a backstop for thorough cleanup including any HLS/VTT files
+/// that might not have been caught by the deterministic path deletion.
+pub fn trigger_cloud_run_delete_blob(hash: &str) {
+    let webhook_secret = match get_secret("webhook_secret") {
+        Ok(s) => s,
+        Err(_) => {
+            eprintln!("[DELETE] webhook_secret not configured, skipping Cloud Run delete");
+            return;
+        }
+    };
+
+    let body = format!(r#"{{"hash":"{}"}}"#, hash);
+
+    const CLOUD_RUN_HOST: &str = "blossom-upload-rust-149672065768.us-central1.run.app";
+    let mut req = Request::new(
+        Method::POST,
+        format!("https://{}/delete-blob", CLOUD_RUN_HOST),
+    );
+    req.set_header("Host", CLOUD_RUN_HOST);
+    req.set_header("Content-Type", "application/json");
+    req.set_header("Authorization", format!("Bearer {}", webhook_secret));
+    req.set_body(Body::from(body));
+
+    match req.send_async(CLOUD_RUN_BACKEND) {
+        Ok(_) => {
+            eprintln!("[DELETE] Triggered Cloud Run delete-blob for {}", hash);
+        }
+        Err(e) => {
+            eprintln!(
+                "[DELETE] Failed to trigger Cloud Run delete-blob for {}: {}",
+                hash, e
+            );
+        }
+    }
+}
+
+/// Fire-and-forget: ask Cloud Run to delete all GCS objects for a user (vanish).
+/// Cloud Run does prefix-based listing + deletion as a thorough safety net.
+pub fn trigger_cloud_run_bulk_delete(pubkey: &str, hashes: &[String]) {
+    let webhook_secret = match get_secret("webhook_secret") {
+        Ok(s) => s,
+        Err(_) => {
+            eprintln!("[VANISH] webhook_secret not configured, skipping Cloud Run bulk delete");
+            return;
+        }
+    };
+
+    let body = serde_json::json!({
+        "pubkey": pubkey,
+        "known_hashes": hashes,
+    })
+    .to_string();
+
+    const CLOUD_RUN_HOST: &str = "blossom-upload-rust-149672065768.us-central1.run.app";
+    let mut req = Request::new(
+        Method::POST,
+        format!("https://{}/delete-blobs-by-owner", CLOUD_RUN_HOST),
+    );
+    req.set_header("Host", CLOUD_RUN_HOST);
+    req.set_header("Content-Type", "application/json");
+    req.set_header("Authorization", format!("Bearer {}", webhook_secret));
+    req.set_body(Body::from(body));
+
+    match req.send_async(CLOUD_RUN_BACKEND) {
+        Ok(_) => {
+            eprintln!(
+                "[VANISH] Triggered Cloud Run bulk delete for pubkey={}",
+                pubkey
+            );
+        }
+        Err(e) => {
+            eprintln!("[VANISH] Failed to trigger Cloud Run bulk delete: {}", e);
+        }
+    }
+}
+
+/// Fire-and-forget: ask Cloud Run to mark a pubkey for audit log anonymization.
+pub fn trigger_audit_anonymize(pubkey: &str) {
+    let webhook_secret = match get_secret("webhook_secret") {
+        Ok(s) => s,
+        Err(_) => {
+            eprintln!("[VANISH] webhook_secret not configured, skipping audit anonymize");
+            return;
+        }
+    };
+
+    let body = format!(r#"{{"pubkey":"{}"}}"#, pubkey);
+
+    const CLOUD_RUN_HOST: &str = "blossom-upload-rust-149672065768.us-central1.run.app";
+    let mut req = Request::new(
+        Method::POST,
+        format!("https://{}/audit/anonymize", CLOUD_RUN_HOST),
+    );
+    req.set_header("Host", CLOUD_RUN_HOST);
+    req.set_header("Content-Type", "application/json");
+    req.set_header("Authorization", format!("Bearer {}", webhook_secret));
+    req.set_body(Body::from(body));
+
+    match req.send_async(CLOUD_RUN_BACKEND) {
+        Ok(_) => {
+            eprintln!("[VANISH] Triggered audit anonymize for pubkey={}", pubkey);
+        }
+        Err(e) => {
+            eprintln!("[VANISH] Failed to trigger audit anonymize: {}", e);
         }
     }
 }
@@ -1250,14 +1359,23 @@ pub fn trigger_background_migration(hash: &str, source_backend: &str) -> Result<
         Ok(resp) => {
             let status = resp.get_status();
             if status.is_success() {
-                eprintln!("[MIGRATE] Successfully migrated {} from {}", hash, source_backend);
+                eprintln!(
+                    "[MIGRATE] Successfully migrated {} from {}",
+                    hash, source_backend
+                );
             } else {
-                eprintln!("[MIGRATE] Cloud Run returned {} for {} migration", status, hash);
+                eprintln!(
+                    "[MIGRATE] Cloud Run returned {} for {} migration",
+                    status, hash
+                );
             }
             Ok(())
         }
         Err(e) => {
-            eprintln!("[MIGRATE] Failed to migrate {} from {}: {}", hash, source_backend, e);
+            eprintln!(
+                "[MIGRATE] Failed to migrate {} from {}: {}",
+                hash, source_backend, e
+            );
             // Don't fail the request - migration is best-effort
             Ok(())
         }


### PR DESCRIPTION
## Summary
- add bounded provider retries, concurrency caps, and duplicate suppression in the Cloud Run transcoder
- persist transcript retry metadata in Blossom, honor cooldowns on VTT fetches, and add a recent-scope transcript backfill script
- document transcript recovery and add regression coverage for webhook parsing and cooldown behavior

## Test Plan
- cargo +1.93.0 test
- cargo +1.93.0 test --manifest-path cloud-run-transcoder/Cargo.toml
- bash -n scripts/backfill_missing_transcripts.sh