### PR TITLE
fix: adapt local mode to subtitle reliability changes

### DIFF
--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -626,6 +626,10 @@ mod tests {
             transcode_status: None,
             dim: None,
             transcript_status: None,
+            transcript_error_code: None,
+            transcript_error_message: None,
+            transcript_last_attempt_at: None,
+            transcript_retry_after: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1726,8 +1726,8 @@ fn trigger_on_demand_transcription(
             vtt.len() as u64,
             owner,
         )?;
-        use crate::metadata::update_transcript_status;
-        update_transcript_status(hash, crate::blossom::TranscriptStatus::Complete)?;
+        use crate::metadata::{update_transcript_status, TranscriptMetadataUpdate};
+        update_transcript_status(hash, crate::blossom::TranscriptStatus::Complete, TranscriptMetadataUpdate::default())?;
         if let Some(id) = job_id {
             if let Ok(Some(mut job)) = crate::metadata::get_subtitle_job(id) {
                 job.status = crate::blossom::SubtitleJobStatus::Ready;


### PR DESCRIPTION
## Summary
- Add missing `BlobMetadata` fields from #26 to test helper
- Add `TranscriptMetadataUpdate::default()` arg to local mode VTT stub

Fixes CI failure on main after #25 + #26 merge.