### PR TITLE
fix: prevent integer underflow in quality variant path parser

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1454,8 +1454,9 @@ fn is_quality_variant_path(path: &str) -> bool {
     let path = path.trim_start_matches('/');
     for (suffix, _) in QUALITY_VARIANTS {
         let suffix = suffix.trim_start_matches('/');
-        if path.ends_with(suffix) {
-            let hash_part = &path[..path.len() - suffix.len() - 1]; // -1 for the /
+        // Need at least hash(64) + '/' + suffix
+        if path.ends_with(suffix) && path.len() > suffix.len() + 1 {
+            let hash_part = &path[..path.len() - suffix.len() - 1];
             if hash_part.len() == 64 && hash_part.chars().all(|c| c.is_ascii_hexdigit()) {
                 return true;
             }
@@ -1469,7 +1470,7 @@ fn parse_quality_variant_path(path: &str) -> Option<(String, &'static str)> {
     let path = path.trim_start_matches('/');
     for (suffix, ts_file) in QUALITY_VARIANTS {
         let suffix = suffix.trim_start_matches('/');
-        if path.ends_with(suffix) {
+        if path.ends_with(suffix) && path.len() > suffix.len() + 1 {
             let hash_part = &path[..path.len() - suffix.len() - 1];
             if hash_part.len() == 64 && hash_part.chars().all(|c| c.is_ascii_hexdigit()) {
                 return Some((hash_part.to_lowercase(), ts_file));
@@ -4178,10 +4179,32 @@ fn infer_mime_from_path(path: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        decide_transcript_fetch_action, parse_transcript_status_webhook_payload,
-        TranscriptFetchAction, TranscriptPendingState,
+        decide_transcript_fetch_action, is_quality_variant_path, parse_quality_variant_path,
+        parse_transcript_status_webhook_payload, TranscriptFetchAction, TranscriptPendingState,
     };
     use crate::blossom::TranscriptStatus;
+
+    #[test]
+    fn quality_variant_path_valid() {
+        let hash = "a".repeat(64);
+        assert!(is_quality_variant_path(&format!("/{}/720p", hash)));
+        assert!(is_quality_variant_path(&format!("/{}/480p", hash)));
+        let (parsed_hash, ts) = parse_quality_variant_path(&format!("/{}/720p", hash)).unwrap();
+        assert_eq!(parsed_hash, hash);
+        assert_eq!(ts, "stream_720p.ts");
+    }
+
+    #[test]
+    fn quality_variant_path_no_underflow_on_short_input() {
+        // These must not panic (previously caused u32::MAX underflow)
+        assert!(!is_quality_variant_path("/720p"));
+        assert!(!is_quality_variant_path("/480p"));
+        assert!(!is_quality_variant_path("720p"));
+        assert!(!is_quality_variant_path("480p"));
+        assert!(!is_quality_variant_path(""));
+        assert!(parse_quality_variant_path("/480p").is_none());
+        assert!(parse_quality_variant_path("720p").is_none());
+    }
 
     #[test]
     fn parses_transcript_webhook_error_code_fields() {


### PR DESCRIPTION
## Description

Fix a Wasm trap caused by integer underflow in `is_quality_variant_path()` and `parse_quality_variant_path()`. A malformed request like `GET /720p` or `GET /480p` (without a 64-char hash prefix) causes a `usize` subtraction to wrap to `u32::MAX`, crashing the Compute instance.

This is a latent security issue: any unauthenticated HTTP request to `/720p` would crash a Fastly Compute instance. Fastly retries on another instance, but repeated requests could degrade service availability.

### Root cause

After stripping the leading `/`, paths like `720p` match `ends_with("720p")`, then `path.len() - suffix.len() - 1` underflows (`4 - 4 - 1` on `usize`). The fix adds a bounds check before the subtraction.

### Production impact

Checked Fastly Insights dashboard (1 week, all regions): the `/720p` and `/480p` paths do not appear in the Top 10 5XX Error URLs, so this hasn't been triggered by bots yet. Current 5xx errors (218/day, 0.09% rate) are from upload timeouts and webhook failures, not this bug.

### Discovery

Found during local E2E testing with the divine-mobile team — Viceroy crashed with `byte index 4294967295 is out of bounds` when the seed script requested variant URLs.

## Type of Change

- [x] Bug fix