### PR TITLE
feat(blossom): restrict web cors origins

### DIFF
--- a/cloud-run-transcoder/Cargo.lock
+++ b/cloud-run-transcoder/Cargo.lock
@@ -3,12 +3,36 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -118,6 +142,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +237,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "const-oid"
@@ -232,6 +286,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +327,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +363,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "reqwest",
+ "sentry",
  "serde",
  "serde_json",
  "sha2",
@@ -300,6 +375,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -338,6 +414,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "fnv"
@@ -492,6 +580,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "google-cloud-auth"
@@ -658,6 +752,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -1019,6 +1124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,6 +1167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1201,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1124,6 +1256,174 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1174,6 +1474,22 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1277,6 +1593,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1624,36 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1430,6 +1785,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1901,120 @@ checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "sentry"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce4b57f1b521f674df7a1d200be8ff5d74e3712020ee25b553146657b5377d5"
+dependencies = [
+ "httpdate",
+ "native-tls",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cc8d4e04a73de8f718dc703943666d03f25d3e9e4d0fb271ca0b8c76dfa00e"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6436c1bad22cdeb02179ea8ef116ffc217797c028927def303bc593d9320c0d1"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901f761681f97db3db836ef9e094acdd8756c40215326c194201941947164ef1"
+dependencies = [
+ "once_cell",
+ "rand",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdb263e73d22f39946f6022ed455b7561b22ff5553aca9be3c6a047fa39c328"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fbf1c163f8b6a9d05912e1b272afa27c652e8b47ea60cb9a57ad5e481eea99"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82eabcab0a047040befd44599a1da73d3adb228ff53b5ed9795ae04535577704"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da956cca56e0101998c8688bc65ce1a96f00673a0e58e663664023d4c7911e82"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2048,6 +2532,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2565,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2587,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2094,6 +2601,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "valuable"
@@ -2518,6 +3034,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/cloud-run-transcoder/Cargo.toml
+++ b/cloud-run-transcoder/Cargo.toml
@@ -54,6 +54,8 @@ thiserror = "1"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+sentry = { version = "0.31.8", features = ["tracing"] }
+uuid = "=1.12.1"
 
 [profile.release]
 lto = true

--- a/cloud-run-transcoder/deploy.sh
+++ b/cloud-run-transcoder/deploy.sh
@@ -1,42 +1,52 @@
 #!/bin/bash
-# ABOUTME: Deploy divine-transcoder to Cloud Run with GPU support
-# ABOUTME: Requires L4 GPU quota to be approved in your GCP project
+# ABOUTME: Deploy divine-transcoder to Cloud Run with the current production runtime settings
+# ABOUTME: Builds in Cloud Build, then deploys with webhook, transcription, and Sentry secrets wired
 
-set -e
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project)}"
 REGION="${REGION:-us-central1}"
-SERVICE_NAME="divine-transcoder"
-IMAGE="gcr.io/${PROJECT_ID}/${SERVICE_NAME}"
+SERVICE_NAME="${SERVICE_NAME:-divine-transcoder}"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-149672065768-compute@developer.gserviceaccount.com}"
+IMAGE_TAG="${IMAGE_TAG:-$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)}"
+IMAGE="gcr.io/${PROJECT_ID}/${SERVICE_NAME}:${IMAGE_TAG}"
 
-echo "Building and pushing Docker image..."
-docker build --platform linux/amd64 -t "${IMAGE}" .
-docker push "${IMAGE}"
+GCS_BUCKET="${GCS_BUCKET:-divine-blossom-media}"
+WEBHOOK_URL="${WEBHOOK_URL:-https://media.divine.video/admin/transcode-status}"
+TRANSCRIPT_WEBHOOK_URL="${TRANSCRIPT_WEBHOOK_URL:-https://media.divine.video/admin/transcript-status}"
+TRANSCRIPTION_API_URL="${TRANSCRIPTION_API_URL:-https://api.openai.com/v1/audio/transcriptions}"
+TRANSCRIPTION_MODEL="${TRANSCRIPTION_MODEL:-gpt-4o-mini-transcribe}"
+USE_GPU="${USE_GPU:-false}"
+SENTRY_ENVIRONMENT="${SENTRY_ENVIRONMENT:-production}"
+SENTRY_SECRET="${SENTRY_SECRET:-sentry_dsn}"
 
-echo "Deploying to Cloud Run with GPU..."
-gcloud run deploy "${SERVICE_NAME}" \
-  --image "${IMAGE}" \
+echo "Building ${IMAGE} in Cloud Build..."
+gcloud builds submit "${SCRIPT_DIR}" \
+  --project "${PROJECT_ID}" \
   --region "${REGION}" \
-  --gpu 1 \
-  --gpu-type nvidia-l4 \
+  --tag "${IMAGE}"
+
+echo "Deploying ${SERVICE_NAME} to Cloud Run..."
+gcloud run deploy "${SERVICE_NAME}" \
+  --project "${PROJECT_ID}" \
+  --region "${REGION}" \
+  --image "${IMAGE}" \
+  --allow-unauthenticated \
+  --service-account "${SERVICE_ACCOUNT}" \
   --cpu 4 \
-  --memory 16Gi \
-  --concurrency 8 \
-  --min-instances 1 \
+  --memory 8Gi \
+  --concurrency 320 \
+  --timeout 900 \
   --max-instances 10 \
   --no-cpu-throttling \
-  --set-env-vars "GCS_BUCKET=divine-blossom-media" \
-  --set-env-vars "WEBHOOK_URL=https://media.divine.video/admin/transcode-status" \
-  --set-env-vars "TRANSCRIPT_WEBHOOK_URL=https://media.divine.video/admin/transcript-status" \
-  --set-env-vars "TRANSCRIPTION_API_URL=https://api.openai.com/v1/audio/transcriptions" \
-  --set-env-vars "TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe" \
-  --set-env-vars "TRANSCRIPTION_MAX_IN_FLIGHT=4" \
-  --set-env-vars "TRANSCRIPTION_MAX_RETRIES=3" \
-  --set-env-vars "TRANSCRIPTION_RETRY_BASE_MS=1000" \
-  --set-env-vars "TRANSCRIPTION_RETRY_MAX_MS=15000" \
-  --set-env-vars "TRANSCRIPTION_RETRY_TOTAL_MS=30000" \
-  --set-secrets "WEBHOOK_SECRET=webhook_secret:latest,TRANSCRIPTION_API_KEY=openai_api_key:latest" \
-  --allow-unauthenticated
+  --set-env-vars "GCS_BUCKET=${GCS_BUCKET},WEBHOOK_URL=${WEBHOOK_URL},TRANSCRIPT_WEBHOOK_URL=${TRANSCRIPT_WEBHOOK_URL},TRANSCRIPTION_API_URL=${TRANSCRIPTION_API_URL},TRANSCRIPTION_MODEL=${TRANSCRIPTION_MODEL},USE_GPU=${USE_GPU},SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}" \
+  --set-secrets "WEBHOOK_SECRET=webhook_secret:latest,TRANSCRIPTION_API_KEY=openai_api_key:latest,SENTRY_DSN=${SENTRY_SECRET}:latest"
 
 echo "Done! Service URL:"
-gcloud run services describe "${SERVICE_NAME}" --region "${REGION}" --format='value(status.url)'
+gcloud run services describe "${SERVICE_NAME}" \
+  --project "${PROJECT_ID}" \
+  --region "${REGION}" \
+  --format='value(status.url)'

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -141,6 +141,64 @@ impl Config {
     }
 }
 
+fn init_sentry(service_name: &str) -> sentry::ClientInitGuard {
+    let environment = env::var("SENTRY_ENVIRONMENT")
+        .ok()
+        .filter(|value| !value.is_empty());
+    let server_name = env::var("SENTRY_SERVER_NAME")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| service_name.to_string());
+
+    sentry::init(sentry::ClientOptions {
+        dsn: env::var("SENTRY_DSN")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .and_then(|value| value.parse().ok()),
+        environment: environment.map(Into::into),
+        server_name: Some(server_name.into()),
+        release: sentry::release_name!(),
+        ..Default::default()
+    })
+}
+
+fn report_derivative_failure_to_sentry(
+    service: &'static str,
+    derivative: &'static str,
+    hash: &str,
+    error_code: &str,
+    error_message: &str,
+    terminal: bool,
+    content_type: Option<&str>,
+    owner: Option<&str>,
+    attempt_count: Option<u32>,
+) {
+    let fingerprint = [service, derivative, error_code];
+    sentry::with_scope(
+        |scope| {
+            scope.set_level(Some(sentry::Level::Error));
+            scope.set_fingerprint(Some(fingerprint.as_ref()));
+            scope.set_tag("service", service);
+            scope.set_tag("derivative", derivative);
+            scope.set_tag("error_code", error_code);
+            scope.set_tag("terminal", terminal.to_string());
+            if let Some(content_type) = content_type {
+                scope.set_tag("content_type", content_type);
+            }
+            scope.set_extra("sha256", serde_json::json!(hash));
+            if let Some(owner) = owner {
+                scope.set_extra("owner", serde_json::json!(owner));
+            }
+            if let Some(attempt_count) = attempt_count {
+                scope.set_extra("attempt_count", serde_json::json!(attempt_count));
+            }
+        },
+        || {
+            sentry::capture_message(error_message, sentry::Level::Error);
+        },
+    );
+}
+
 // App state shared across handlers
 struct AppState {
     gcs_client: GcsClient,
@@ -180,6 +238,23 @@ struct AudioExtractResponse {
     duration: f64,
     size: u64,
     mime_type: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AudioExtractErrorKind {
+    NotAVideo,
+    NoAudioTrack,
+    Other,
+}
+
+fn classify_audio_extract_error(message: &str) -> AudioExtractErrorKind {
+    if message.contains("not_a_video") {
+        AudioExtractErrorKind::NotAVideo
+    } else if message.contains("no_audio_track") {
+        AudioExtractErrorKind::NoAudioTrack
+    } else {
+        AudioExtractErrorKind::Other
+    }
 }
 
 // Transcode response
@@ -459,6 +534,8 @@ struct HealthResponse {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let _sentry_guard = init_sentry("divine-transcoder");
+
     // Initialize tracing
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -661,31 +738,31 @@ async fn handle_audio_extract(
         Ok(response) => (StatusCode::OK, Json(response)).into_response(),
         Err(e) => {
             let msg = e.to_string();
-            if msg.contains("not_a_video") {
-                (
+            match classify_audio_extract_error(&msg) {
+                AudioExtractErrorKind::NotAVideo => (
                     StatusCode::UNPROCESSABLE_ENTITY,
                     Json(ErrorResponse {
                         error: "not_a_video".to_string(),
                     }),
                 )
-                    .into_response()
-            } else if msg.contains("no_audio_track") {
-                (
+                    .into_response(),
+                AudioExtractErrorKind::NoAudioTrack => (
                     StatusCode::UNPROCESSABLE_ENTITY,
                     Json(ErrorResponse {
                         error: "no_audio_track".to_string(),
                     }),
                 )
-                    .into_response()
-            } else {
-                error!("Audio extract error: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse {
-                        error: e.to_string(),
-                    }),
-                )
-                    .into_response()
+                    .into_response(),
+                AudioExtractErrorKind::Other => {
+                    error!("Audio extract error: {}", e);
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse {
+                            error: e.to_string(),
+                        }),
+                    )
+                        .into_response()
+                }
             }
         }
     }
@@ -728,8 +805,8 @@ async fn process_audio_extract(
         .output()
         .await?;
 
-    let probe_json: serde_json::Value = serde_json::from_slice(&probe_output.stdout)
-        .map_err(|_| anyhow!("not_a_video"))?;
+    let probe_json: serde_json::Value =
+        serde_json::from_slice(&probe_output.stdout).map_err(|_| anyhow!("not_a_video"))?;
 
     let streams = probe_json
         .get("streams")
@@ -867,7 +944,18 @@ async fn process_transcode(
     if check_gcs_exists(&state.gcs_client, &state.config.gcs_bucket, &master_path).await? {
         info!("HLS already exists for {}, skipping transcode", hash);
         // Still update status to complete in case it was pending (no size change for already-transcoded)
-        send_status_webhook(&state.config, &hash, "complete", None, None).await;
+        send_status_webhook(
+            &state.config,
+            &hash,
+            "complete",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        )
+        .await;
         return Ok(TranscodeResponse {
             hash: hash.clone(),
             status: "already_exists".to_string(),
@@ -890,7 +978,18 @@ async fn process_transcode(
     }
 
     // Update status to processing
-    send_status_webhook(&state.config, &hash, "processing", None, None).await;
+    send_status_webhook(
+        &state.config,
+        &hash,
+        "processing",
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+    )
+    .await;
 
     // Create temp directory for processing
     let temp_dir = TempDir::new()?;
@@ -907,7 +1006,18 @@ async fn process_transcode(
     .await;
 
     if let Err(e) = download_result {
-        send_status_webhook(&state.config, &hash, "failed", None, None).await;
+        send_status_webhook(
+            &state.config,
+            &hash,
+            "failed",
+            None,
+            None,
+            Some("download_failed"),
+            Some(&e.to_string()),
+            None,
+            false,
+        )
+        .await;
         return Err(e);
     }
 
@@ -968,7 +1078,34 @@ async fn process_transcode(
     let variants = match ffmpeg_result {
         Ok(v) => v,
         Err(e) => {
-            send_status_webhook(&state.config, &hash, "failed", None, Some(&video_info)).await;
+            let error_message = e.to_string();
+            let (error_code, terminal) =
+                classify_invalid_media_error(&error_message, "transcode_failed");
+            if terminal {
+                report_derivative_failure_to_sentry(
+                    "divine-transcoder",
+                    "hls",
+                    &hash,
+                    error_code,
+                    &error_message,
+                    true,
+                    Some("video/mp4"),
+                    request.owner.as_deref(),
+                    Some(1),
+                );
+            }
+            send_status_webhook(
+                &state.config,
+                &hash,
+                "failed",
+                None,
+                Some(&video_info),
+                Some(error_code),
+                Some(&error_message),
+                None,
+                terminal,
+            )
+            .await;
             return Err(e);
         }
     };
@@ -990,14 +1127,36 @@ async fn process_transcode(
     .await;
 
     if let Err(e) = upload_result {
-        send_status_webhook(&state.config, &hash, "failed", None, Some(&video_info)).await;
+        send_status_webhook(
+            &state.config,
+            &hash,
+            "failed",
+            None,
+            Some(&video_info),
+            Some("upload_failed"),
+            Some(&e.to_string()),
+            None,
+            false,
+        )
+        .await;
         return Err(e);
     }
 
     info!("Uploaded HLS files for {}", hash);
 
     // Update status to complete with video dimensions for the edge service
-    send_status_webhook(&state.config, &hash, "complete", None, Some(&video_info)).await;
+    send_status_webhook(
+        &state.config,
+        &hash,
+        "complete",
+        None,
+        Some(&video_info),
+        None,
+        None,
+        None,
+        false,
+    )
+    .await;
 
     Ok(TranscodeResponse {
         hash: hash.clone(),
@@ -1042,6 +1201,7 @@ async fn process_transcribe(
             None,
             None,
             None,
+            false,
         )
         .await;
         return Ok(TranscribeResponse {
@@ -1052,37 +1212,39 @@ async fn process_transcribe(
         });
     }
 
-    let transcript_lock = match acquire_transcript_lock(
-        &state.gcs_client,
-        &state.config.gcs_bucket,
-        &hash,
-        900,
-    )
-    .await?
-    {
-        Ok(handle) => handle,
-        Err(TranscriptLockAction::AlreadyProcessing) => {
-            info!("Transcript already processing for {}, skipping duplicate request", hash);
-            return Ok(TranscribeResponse {
-                hash,
-                status: "already_processing".to_string(),
-                vtt_path,
-                transcript_confidence: None,
-            });
-        }
-        Err(TranscriptLockAction::CoolingDown) => {
-            info!("Transcript cooldown active for {}, skipping duplicate request", hash);
-            return Ok(TranscribeResponse {
-                hash,
-                status: "cooling_down".to_string(),
-                vtt_path,
-                transcript_confidence: None,
-            });
-        }
-        Err(TranscriptLockAction::StartWork | TranscriptLockAction::ReclaimStaleLock) => {
-            unreachable!("acquire_transcript_lock resolves start/reclaim internally")
-        }
-    };
+    let transcript_lock =
+        match acquire_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &hash, 900)
+            .await?
+        {
+            Ok(handle) => handle,
+            Err(TranscriptLockAction::AlreadyProcessing) => {
+                info!(
+                    "Transcript already processing for {}, skipping duplicate request",
+                    hash
+                );
+                return Ok(TranscribeResponse {
+                    hash,
+                    status: "already_processing".to_string(),
+                    vtt_path,
+                    transcript_confidence: None,
+                });
+            }
+            Err(TranscriptLockAction::CoolingDown) => {
+                info!(
+                    "Transcript cooldown active for {}, skipping duplicate request",
+                    hash
+                );
+                return Ok(TranscribeResponse {
+                    hash,
+                    status: "cooling_down".to_string(),
+                    vtt_path,
+                    transcript_confidence: None,
+                });
+            }
+            Err(TranscriptLockAction::StartWork | TranscriptLockAction::ReclaimStaleLock) => {
+                unreachable!("acquire_transcript_lock resolves start/reclaim internally")
+            }
+        };
 
     send_transcript_status_webhook(
         &state.config,
@@ -1096,6 +1258,7 @@ async fn process_transcribe(
         None,
         None,
         None,
+        false,
     )
     .await;
 
@@ -1108,14 +1271,20 @@ async fn process_transcribe(
         &state.config.gcs_bucket,
         &hash,
         &input_path,
+    )
+    .await
+    {
+        if let Err(lock_error) = delete_transcript_lock(
+            &state.gcs_client,
+            &state.config.gcs_bucket,
+            &transcript_lock,
         )
         .await
-    {
-        if let Err(lock_error) =
-            delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
-                .await
         {
-            warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+            warn!(
+                "Failed to release transcript lock for {}: {}",
+                hash, lock_error
+            );
         }
         send_transcript_status_webhook(
             &state.config,
@@ -1129,6 +1298,7 @@ async fn process_transcribe(
             None,
             Some("download_failed"),
             Some(&e.to_string()),
+            false,
         )
         .await;
         return Err(e);
@@ -1149,22 +1319,50 @@ async fn process_transcribe(
             &vtt_path,
         )
         .await;
-        if let Err(lock_error) =
-            delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
-                .await
+        if let Err(lock_error) = delete_transcript_lock(
+            &state.gcs_client,
+            &state.config.gcs_bucket,
+            &transcript_lock,
+        )
+        .await
         {
-            warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+            warn!(
+                "Failed to release transcript lock for {}: {}",
+                hash, lock_error
+            );
         }
         return result;
     }
 
     let audio_path = temp_path.join("transcribe.wav");
     if let Err(e) = extract_audio_for_transcription(&input_path, &audio_path).await {
-        if let Err(lock_error) =
-            delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
-                .await
+        let error_message = e.to_string();
+        let (error_code, terminal) =
+            classify_invalid_media_error(&error_message, "audio_extract_failed");
+        if terminal {
+            report_derivative_failure_to_sentry(
+                "divine-transcoder",
+                "transcript",
+                &hash,
+                error_code,
+                &error_message,
+                true,
+                Some("video/mp4"),
+                request.owner.as_deref(),
+                Some(1),
+            );
+        }
+        if let Err(lock_error) = delete_transcript_lock(
+            &state.gcs_client,
+            &state.config.gcs_bucket,
+            &transcript_lock,
+        )
+        .await
         {
-            warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+            warn!(
+                "Failed to release transcript lock for {}: {}",
+                hash, lock_error
+            );
         }
         send_transcript_status_webhook(
             &state.config,
@@ -1176,8 +1374,9 @@ async fn process_transcribe(
             None,
             None,
             None,
-            Some("audio_extract_failed"),
-            Some(&e.to_string()),
+            Some(error_code),
+            Some(&error_message),
+            terminal,
         )
         .await;
         return Err(e);
@@ -1215,11 +1414,17 @@ async fn process_transcribe(
             &vtt_path,
         )
         .await;
-        if let Err(lock_error) =
-            delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
-                .await
+        if let Err(lock_error) = delete_transcript_lock(
+            &state.gcs_client,
+            &state.config.gcs_bucket,
+            &transcript_lock,
+        )
+        .await
         {
-            warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+            warn!(
+                "Failed to release transcript lock for {}: {}",
+                hash, lock_error
+            );
         }
         return result;
     }
@@ -1241,73 +1446,94 @@ async fn process_transcribe(
         .saturating_sub(state.provider_semaphore.available_permits());
     info!(
         hash,
-        in_flight,
-        provider_wait_ms,
-        "Acquired transcription provider permit"
+        in_flight, provider_wait_ms, "Acquired transcription provider permit"
     );
 
-    let raw_output = match transcribe_audio_via_provider(
-        &state.config,
-        &audio_path,
-        requested_lang.as_deref(),
-    )
-    .await
-    {
-        Ok(output) => output,
-        Err(e) => {
-            drop(provider_permit);
-            if e.exhausted_retryable {
-                let retry_after = e
-                    .retry_after()
-                    .unwrap_or_else(|| Duration::from_millis(state.config.transcription_retry_max_ms));
-                if let Err(lock_error) = write_transcript_cooldown(
+    let raw_output =
+        match transcribe_audio_via_provider(&state.config, &audio_path, requested_lang.as_deref())
+            .await
+        {
+            Ok(output) => output,
+            Err(e) => {
+                drop(provider_permit);
+                if e.exhausted_retryable {
+                    report_derivative_failure_to_sentry(
+                        "divine-transcoder",
+                        "transcript",
+                        &hash,
+                        e.error_code(),
+                        &e.to_string(),
+                        false,
+                        None,
+                        request.owner.as_deref(),
+                        Some(e.attempts),
+                    );
+                }
+                if e.exhausted_retryable {
+                    let retry_after = e.retry_after().unwrap_or_else(|| {
+                        Duration::from_millis(state.config.transcription_retry_max_ms)
+                    });
+                    if let Err(lock_error) = write_transcript_cooldown(
+                        &state.gcs_client,
+                        &state.config.gcs_bucket,
+                        &hash,
+                        &transcript_lock,
+                        retry_after,
+                        e.error_code(),
+                    )
+                    .await
+                    {
+                        warn!(
+                            "Failed to persist transcript cooldown for {}: {}",
+                            hash, lock_error
+                        );
+                    }
+                } else if let Err(lock_error) = delete_transcript_lock(
                     &state.gcs_client,
                     &state.config.gcs_bucket,
-                    &hash,
                     &transcript_lock,
-                    retry_after,
-                    e.error_code(),
                 )
                 .await
                 {
-                    warn!("Failed to persist transcript cooldown for {}: {}", hash, lock_error);
+                    warn!(
+                        "Failed to release transcript lock for {}: {}",
+                        hash, lock_error
+                    );
                 }
-            } else if let Err(lock_error) = delete_transcript_lock(
+                send_transcript_status_webhook(
+                    &state.config,
+                    &hash,
+                    "failed",
+                    job_id.as_deref(),
+                    requested_lang.as_deref(),
+                    None,
+                    None,
+                    None,
+                    e.retry_after().map(|duration| duration.as_secs().max(1)),
+                    Some(e.error_code()),
+                    Some(&e.to_string()),
+                    false,
+                )
+                .await;
+                return Err(e.into());
+            }
+        };
+    drop(provider_permit);
+
+    let parsed_vtt = match normalize_transcript_to_vtt(&raw_output) {
+        Ok(vtt) => vtt,
+        Err(e) => {
+            if let Err(lock_error) = delete_transcript_lock(
                 &state.gcs_client,
                 &state.config.gcs_bucket,
                 &transcript_lock,
             )
             .await
             {
-                warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
-            }
-            send_transcript_status_webhook(
-                &state.config,
-                &hash,
-                "failed",
-                job_id.as_deref(),
-                requested_lang.as_deref(),
-                None,
-                None,
-                None,
-                e.retry_after().map(|duration| duration.as_secs().max(1)),
-                Some(e.error_code()),
-                Some(&e.to_string()),
-            )
-            .await;
-            return Err(e.into());
-        }
-    };
-    drop(provider_permit);
-
-    let parsed_vtt = match normalize_transcript_to_vtt(&raw_output) {
-        Ok(vtt) => vtt,
-        Err(e) => {
-            if let Err(lock_error) =
-                delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock)
-                    .await
-            {
-                warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+                warn!(
+                    "Failed to release transcript lock for {}: {}",
+                    hash, lock_error
+                );
             }
             send_transcript_status_webhook(
                 &state.config,
@@ -1321,6 +1547,7 @@ async fn process_transcribe(
                 None,
                 Some("normalize_failed"),
                 Some(&e.to_string()),
+                false,
             )
             .await;
             return Err(e);
@@ -1369,10 +1596,17 @@ async fn process_transcribe(
         &vtt_path,
     )
     .await;
-    if let Err(lock_error) =
-        delete_transcript_lock(&state.gcs_client, &state.config.gcs_bucket, &transcript_lock).await
+    if let Err(lock_error) = delete_transcript_lock(
+        &state.gcs_client,
+        &state.config.gcs_bucket,
+        &transcript_lock,
+    )
+    .await
     {
-        warn!("Failed to release transcript lock for {}: {}", hash, lock_error);
+        warn!(
+            "Failed to release transcript lock for {}: {}",
+            hash, lock_error
+        );
     }
     result
 }
@@ -1577,8 +1811,7 @@ fn parse_provider_status(
 }
 
 fn is_retryable_provider_failure(failure: &ProviderFailure) -> bool {
-    failure.timed_out
-        || matches!(failure.status_code, Some(429 | 500 | 502 | 503 | 504))
+    failure.timed_out || matches!(failure.status_code, Some(429 | 500 | 502 | 503 | 504))
 }
 
 fn retry_delay_for_attempt(
@@ -1779,17 +2012,9 @@ async fn transcribe_audio_via_provider_once(
     audio_path: &Path,
     language: Option<&str>,
 ) -> std::result::Result<String, ProviderFailure> {
-    let api_url = config
-        .transcription_api_url
-        .as_ref()
-        .ok_or_else(|| {
-            parse_provider_status(
-                None,
-                None,
-                "TRANSCRIPTION_API_URL is not configured",
-                false,
-            )
-        })?;
+    let api_url = config.transcription_api_url.as_ref().ok_or_else(|| {
+        parse_provider_status(None, None, "TRANSCRIPTION_API_URL is not configured", false)
+    })?;
 
     let audio_bytes = tokio::fs::read(audio_path).await.map_err(|e| {
         parse_provider_status(
@@ -2236,6 +2461,7 @@ async fn finalize_transcript(
             None,
             Some("upload_failed"),
             Some(&e.to_string()),
+            false,
         )
         .await;
         return Err(e);
@@ -2253,6 +2479,7 @@ async fn finalize_transcript(
         None,
         None,
         None,
+        false,
     )
     .await;
 
@@ -2267,11 +2494,13 @@ async fn finalize_transcript(
 #[cfg(test)]
 mod tests {
     use super::{
+        build_transcode_status_webhook_payload, classify_audio_extract_error,
         decide_transcript_lock_action, is_retryable_provider_failure, normalize_transcript_to_vtt,
         parse_audio_analysis_output, parse_provider_status, retry_delay_for_attempt,
         should_drop_low_signal_transcript, transcript_drop_reason, transcription_response_format,
-        AudioAnalysis, Config, ParsedVtt, TranscriptConfidence, TranscriptDropReason,
-        TranscriptLockAction, TranscriptLockState, TranscriptLockStatus,
+        AudioAnalysis, AudioExtractErrorKind, Config, ParsedVtt, TranscriptConfidence,
+        TranscriptDropReason, TranscriptLockAction, TranscriptLockState, TranscriptLockStatus,
+        VideoInfo,
     };
     use std::time::Duration;
 
@@ -2287,6 +2516,79 @@ mod tests {
     #[test]
     fn whisper_uses_vtt_response_format() {
         assert_eq!(transcription_response_format("whisper-1"), "vtt");
+    }
+
+    #[test]
+    fn classifies_audio_extract_errors() {
+        assert_eq!(
+            classify_audio_extract_error("not_a_video"),
+            AudioExtractErrorKind::NotAVideo
+        );
+        assert_eq!(
+            classify_audio_extract_error("no_audio_track"),
+            AudioExtractErrorKind::NoAudioTrack
+        );
+        assert_eq!(
+            classify_audio_extract_error("ffmpeg exploded"),
+            AudioExtractErrorKind::Other
+        );
+    }
+
+    #[test]
+    fn transcode_webhook_payload_includes_failure_fields() {
+        let video_info = VideoInfo {
+            width: 1920,
+            height: 1080,
+            rotation: 0,
+            display_width: 1080,
+            display_height: 1920,
+            has_audio: true,
+        };
+
+        let payload = build_transcode_status_webhook_payload(
+            "abc123",
+            "failed",
+            Some(42),
+            Some(&video_info),
+            Some("invalid_media"),
+            Some("moov atom not found"),
+            Some(30),
+            true,
+        );
+
+        assert_eq!(payload["sha256"], "abc123");
+        assert_eq!(payload["status"], "failed");
+        assert_eq!(payload["new_size"], 42);
+        assert_eq!(payload["display_width"], 1080);
+        assert_eq!(payload["display_height"], 1920);
+        assert_eq!(payload["error_code"], "invalid_media");
+        assert_eq!(payload["error_message"], "moov atom not found");
+        assert_eq!(payload["retry_after"], 30);
+        assert_eq!(payload["terminal"], true);
+    }
+
+    #[test]
+    fn transcode_webhook_payload_omits_optional_failure_fields_when_absent() {
+        let payload = build_transcode_status_webhook_payload(
+            "abc123",
+            "processing",
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+        );
+
+        assert_eq!(payload["sha256"], "abc123");
+        assert_eq!(payload["status"], "processing");
+        assert!(payload.get("new_size").is_none());
+        assert!(payload.get("display_width").is_none());
+        assert!(payload.get("display_height").is_none());
+        assert!(payload.get("error_code").is_none());
+        assert!(payload.get("error_message").is_none());
+        assert!(payload.get("retry_after").is_none());
+        assert!(payload.get("terminal").is_none());
     }
 
     #[test]
@@ -2430,12 +2732,7 @@ mod tests {
 
     #[test]
     fn classifies_rate_limited_provider_responses_as_retryable() {
-        let failure = parse_provider_status(
-            Some(429),
-            Some("12"),
-            "rate limit exceeded",
-            false,
-        );
+        let failure = parse_provider_status(Some(429), Some("12"), "rate limit exceeded", false);
 
         assert_eq!(failure.status_code, Some(429));
         assert_eq!(failure.retry_after, Some(Duration::from_secs(12)));
@@ -2554,25 +2851,22 @@ mod tests {
     #[test]
     fn empty_segments_json_response_is_rejected() {
         // gpt-4o-transcribe with no speech: segments array present but empty
-        let result = normalize_transcript_to_vtt(
-            r#"{"text":"","language":"en","segments":[]}"#,
-        );
+        let result = normalize_transcript_to_vtt(r#"{"text":"","language":"en","segments":[]}"#);
         assert!(result.is_err(), "empty-segments JSON should be rejected");
     }
 
     #[test]
     fn json_with_only_whitespace_text_is_rejected() {
-        let result = normalize_transcript_to_vtt(
-            r#"{"text":"   \n  "}"#,
+        let result = normalize_transcript_to_vtt(r#"{"text":"   \n  "}"#);
+        assert!(
+            result.is_err(),
+            "whitespace-only text JSON should be rejected"
         );
-        assert!(result.is_err(), "whitespace-only text JSON should be rejected");
     }
 
     #[test]
     fn json_with_null_text_is_rejected() {
-        let result = normalize_transcript_to_vtt(
-            r#"{"text":null,"language":"en"}"#,
-        );
+        let result = normalize_transcript_to_vtt(r#"{"text":null,"language":"en"}"#);
         assert!(result.is_err(), "null-text JSON should be rejected");
     }
 
@@ -2587,10 +2881,8 @@ mod tests {
 
     #[test]
     fn json_with_text_is_still_accepted() {
-        let parsed = normalize_transcript_to_vtt(
-            r#"{"text":"hello world"}"#,
-        )
-        .expect("json with text should parse");
+        let parsed = normalize_transcript_to_vtt(r#"{"text":"hello world"}"#)
+            .expect("json with text should parse");
         assert!(parsed.content.starts_with("WEBVTT"));
         assert_eq!(parsed.text, "hello world");
     }
@@ -2609,8 +2901,7 @@ mod tests {
     #[test]
     fn valid_vtt_passthrough_still_works() {
         let vtt = "WEBVTT\n\n1\n00:00:00.000 --> 00:00:02.000\nHello\n";
-        let parsed = normalize_transcript_to_vtt(vtt)
-            .expect("valid VTT should pass through");
+        let parsed = normalize_transcript_to_vtt(vtt).expect("valid VTT should pass through");
         assert!(parsed.content.starts_with("WEBVTT"));
         assert_eq!(parsed.text, "Hello");
     }
@@ -3111,12 +3402,18 @@ async fn remux_ts_to_fmp4(hls_dir: &Path) -> Result<()> {
         let output = tokio::process::Command::new("ffmpeg")
             .args([
                 "-y",
-                "-v", "warning",
-                "-i", &ts_path.to_string_lossy(),
-                "-c:v", "copy",
-                "-c:a", "aac",
-                "-b:a", "128k",
-                "-movflags", "+faststart",
+                "-v",
+                "warning",
+                "-i",
+                &ts_path.to_string_lossy(),
+                "-c:v",
+                "copy",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "128k",
+                "-movflags",
+                "+faststart",
                 &mp4_path.to_string_lossy(),
             ])
             .output()
@@ -3240,6 +3537,10 @@ async fn send_status_webhook(
     status: &str,
     new_size: Option<u64>,
     video_info: Option<&VideoInfo>,
+    error_code: Option<&str>,
+    error_message: Option<&str>,
+    retry_after_secs: Option<u64>,
+    terminal: bool,
 ) {
     let webhook_url = match &config.webhook_url {
         Some(url) => url,
@@ -3253,21 +3554,22 @@ async fn send_status_webhook(
     };
 
     let client = reqwest::Client::new();
-    let mut payload = serde_json::json!({
-        "sha256": hash,
-        "status": status
-    });
+    let payload = build_transcode_status_webhook_payload(
+        hash,
+        status,
+        new_size,
+        video_info,
+        error_code,
+        error_message,
+        retry_after_secs,
+        terminal,
+    );
 
-    // Include new_size if the original file was replaced (faststart optimization)
     if let Some(size) = new_size {
-        payload["new_size"] = serde_json::json!(size);
         info!("Including new_size {} in webhook for {}", size, hash);
     }
 
-    // Include display dimensions so the edge can store them for the `dim` tag
     if let Some(info) = video_info {
-        payload["display_width"] = serde_json::json!(info.display_width);
-        payload["display_height"] = serde_json::json!(info.display_height);
         info!(
             "Including dimensions {}x{} in webhook for {}",
             info.display_width, info.display_height, hash
@@ -3314,6 +3616,66 @@ fn resolve_transcript_webhook_url(config: &Config) -> Option<String> {
     None
 }
 
+fn build_transcode_status_webhook_payload(
+    hash: &str,
+    status: &str,
+    new_size: Option<u64>,
+    video_info: Option<&VideoInfo>,
+    error_code: Option<&str>,
+    error_message: Option<&str>,
+    retry_after_secs: Option<u64>,
+    terminal: bool,
+) -> serde_json::Value {
+    let mut payload = serde_json::json!({
+        "sha256": hash,
+        "status": status
+    });
+
+    if let Some(size) = new_size {
+        payload["new_size"] = serde_json::json!(size);
+    }
+
+    if let Some(info) = video_info {
+        payload["display_width"] = serde_json::json!(info.display_width);
+        payload["display_height"] = serde_json::json!(info.display_height);
+    }
+
+    if let Some(code) = error_code {
+        payload["error_code"] = serde_json::json!(code);
+    }
+
+    if let Some(message) = error_message {
+        payload["error_message"] = serde_json::json!(message);
+    }
+
+    if let Some(retry_after_secs) = retry_after_secs {
+        payload["retry_after"] = serde_json::json!(retry_after_secs);
+    }
+
+    if terminal {
+        payload["terminal"] = serde_json::json!(true);
+    }
+
+    payload
+}
+
+fn classify_invalid_media_error(
+    message: &str,
+    fallback_code: &'static str,
+) -> (&'static str, bool) {
+    let message = message.to_ascii_lowercase();
+    if message.contains("moov atom not found")
+        || message.contains("invalid data found when processing input")
+        || message.contains("not_a_video")
+        || message.contains("error reading header")
+        || message.contains("could not find codec parameters")
+    {
+        ("invalid_media", true)
+    } else {
+        (fallback_code, false)
+    }
+}
+
 /// Send transcript status update to the Fastly edge webhook.
 async fn send_transcript_status_webhook(
     config: &Config,
@@ -3327,6 +3689,7 @@ async fn send_transcript_status_webhook(
     retry_after_secs: Option<u64>,
     error_code: Option<&str>,
     error_message: Option<&str>,
+    terminal: bool,
 ) {
     let webhook_url = match resolve_transcript_webhook_url(config) {
         Some(url) => url,
@@ -3367,6 +3730,9 @@ async fn send_transcript_status_webhook(
     }
     if let Some(msg) = error_message {
         payload["error_message"] = serde_json::json!(msg);
+    }
+    if terminal {
+        payload["terminal"] = serde_json::json!(true);
     }
 
     let mut request = client.post(webhook_url).json(&payload);

--- a/cloud-run-upload/Cargo.lock
+++ b/cloud-run-upload/Cargo.lock
@@ -3,12 +3,36 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -119,6 +143,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "blossom-upload"
 version = "0.1.0"
 dependencies = [
@@ -187,6 +235,7 @@ dependencies = [
  "hyper-util",
  "k256",
  "reqwest",
+ "sentry",
  "serde",
  "serde_json",
  "sha2",
@@ -198,6 +247,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -227,6 +277,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "const-oid"
@@ -282,6 +338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +378,16 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
 ]
 
 [[package]]
@@ -404,6 +480,18 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "fnv"
@@ -559,6 +647,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "google-cloud-auth"
@@ -745,6 +839,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -1120,6 +1225,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,6 +1265,15 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -1202,6 +1322,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1374,174 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1292,6 +1592,22 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1395,6 +1711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1742,27 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
@@ -1567,6 +1913,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +2043,120 @@ checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "sentry"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce4b57f1b521f674df7a1d200be8ff5d74e3712020ee25b553146657b5377d5"
+dependencies = [
+ "httpdate",
+ "native-tls",
+ "reqwest",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cc8d4e04a73de8f718dc703943666d03f25d3e9e4d0fb271ca0b8c76dfa00e"
+dependencies = [
+ "backtrace",
+ "once_cell",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6436c1bad22cdeb02179ea8ef116ffc217797c028927def303bc593d9320c0d1"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "901f761681f97db3db836ef9e094acdd8756c40215326c194201941947164ef1"
+dependencies = [
+ "once_cell",
+ "rand",
+ "sentry-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdb263e73d22f39946f6022ed455b7561b22ff5553aca9be3c6a047fa39c328"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fbf1c163f8b6a9d05912e1b272afa27c652e8b47ea60cb9a57ad5e481eea99"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82eabcab0a047040befd44599a1da73d3adb228ff53b5ed9795ae04535577704"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.31.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da956cca56e0101998c8688bc65ce1a96f00673a0e58e663664023d4c7911e82"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2221,6 +2696,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,6 +2729,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "native-tls",
+ "once_cell",
+ "url",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2254,6 +2751,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2267,6 +2765,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "valuable"
@@ -2691,6 +3198,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/cloud-run-upload/Cargo.toml
+++ b/cloud-run-upload/Cargo.toml
@@ -55,6 +55,8 @@ tempfile = "3"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+sentry = { version = "0.31.8", features = ["tracing"] }
+uuid = "=1.12.1"
 
 [profile.release]
 lto = true

--- a/cloud-run-upload/deploy.sh
+++ b/cloud-run-upload/deploy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# ABOUTME: Deploy blossom-upload-rust to Cloud Run from source with the live production runtime settings
+# ABOUTME: Includes the transcoder wiring used by Fastly and binds the Sentry secret for worker-side reporting
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PROJECT_ID="${PROJECT_ID:-$(gcloud config get-value project)}"
+REGION="${REGION:-us-central1}"
+SERVICE_NAME="${SERVICE_NAME:-blossom-upload-rust}"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-149672065768-compute@developer.gserviceaccount.com}"
+
+CDN_BASE_URL="${CDN_BASE_URL:-https://media.divine.video}"
+TRANSCODER_URL="${TRANSCODER_URL:-https://divine-transcoder-149672065768.us-central1.run.app}"
+TRANSCRIBER_URL="${TRANSCRIBER_URL:-${TRANSCODER_URL}}"
+SENTRY_ENVIRONMENT="${SENTRY_ENVIRONMENT:-production}"
+SENTRY_SECRET="${SENTRY_SECRET:-sentry_dsn}"
+
+echo "Deploying ${SERVICE_NAME} from source..."
+gcloud run deploy "${SERVICE_NAME}" \
+  --project "${PROJECT_ID}" \
+  --region "${REGION}" \
+  --source "${SCRIPT_DIR}" \
+  --allow-unauthenticated \
+  --service-account "${SERVICE_ACCOUNT}" \
+  --cpu 1 \
+  --memory 512Mi \
+  --concurrency 80 \
+  --timeout 300 \
+  --max-instances 100 \
+  --set-env-vars "CDN_BASE_URL=${CDN_BASE_URL},TRANSCODER_URL=${TRANSCODER_URL},TRANSCRIBER_URL=${TRANSCRIBER_URL},SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}" \
+  --set-secrets "SENTRY_DSN=${SENTRY_SECRET}:latest"
+
+echo "Done! Service URL:"
+gcloud run services describe "${SERVICE_NAME}" \
+  --project "${PROJECT_ID}" \
+  --region "${REGION}" \
+  --format='value(status.url)'

--- a/cloud-run-upload/src/main.rs
+++ b/cloud-run-upload/src/main.rs
@@ -72,6 +72,60 @@ impl Config {
     }
 }
 
+fn init_sentry(service_name: &str) -> sentry::ClientInitGuard {
+    let environment = env::var("SENTRY_ENVIRONMENT")
+        .ok()
+        .filter(|value| !value.is_empty());
+    let server_name = env::var("SENTRY_SERVER_NAME")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| service_name.to_string());
+
+    sentry::init(sentry::ClientOptions {
+        dsn: env::var("SENTRY_DSN")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .and_then(|value| value.parse().ok()),
+        environment: environment.map(Into::into),
+        server_name: Some(server_name.into()),
+        release: sentry::release_name!(),
+        ..Default::default()
+    })
+}
+
+fn report_derivative_failure_to_sentry(
+    service: &'static str,
+    derivative: &'static str,
+    hash: &str,
+    error_code: &str,
+    error_message: &str,
+    terminal: bool,
+    content_type: Option<&str>,
+    owner: Option<&str>,
+) {
+    let fingerprint = [service, derivative, error_code];
+    sentry::with_scope(
+        |scope| {
+            scope.set_level(Some(sentry::Level::Error));
+            scope.set_fingerprint(Some(fingerprint.as_ref()));
+            scope.set_tag("service", service);
+            scope.set_tag("derivative", derivative);
+            scope.set_tag("error_code", error_code);
+            scope.set_tag("terminal", terminal.to_string());
+            if let Some(content_type) = content_type {
+                scope.set_tag("content_type", content_type);
+            }
+            scope.set_extra("sha256", serde_json::json!(hash));
+            if let Some(owner) = owner {
+                scope.set_extra("owner", serde_json::json!(owner));
+            }
+        },
+        || {
+            sentry::capture_message(error_message, sentry::Level::Error);
+        },
+    );
+}
+
 // App state shared across handlers
 struct AppState {
     gcs_client: GcsClient,
@@ -104,6 +158,18 @@ struct UploadResponse {
     /// Video dimensions as "WIDTHxHEIGHT" (display dimensions after rotation)
     #[serde(skip_serializing_if = "Option::is_none")]
     dim: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transcode_error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transcode_error_message: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    transcode_terminal: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transcript_error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transcript_error_message: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    transcript_terminal: bool,
 }
 
 // Migration request
@@ -131,10 +197,23 @@ struct ErrorResponse {
     error: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DerivativeFailureSignal {
+    error_code: String,
+    error_message: String,
+    terminal: bool,
+}
+
 const BLOSSOM_AUTH_KIND: u32 = 24242;
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let _sentry_guard = init_sentry("divine-upload");
+
     // Initialize tracing
     tracing_subscriber::fmt()
         .with_env_filter(
@@ -271,7 +350,7 @@ async fn process_upload(
         .to_string();
 
     // Stream body while hashing (with owner metadata for durability)
-    let (sha256_hash, size, all_bytes) = stream_to_gcs_with_hash(
+    let (sha256_hash, size, all_bytes, sanitize_error) = stream_to_gcs_with_hash(
         &state.gcs_client,
         &state.config.gcs_bucket,
         &content_type,
@@ -280,6 +359,7 @@ async fn process_upload(
     )
     .await?;
 
+    let mut thumbnail_error: Option<String> = None;
     // Extract thumbnail for videos (non-blocking - failures don't fail the upload)
     let thumbnail_url = if thumbnail::is_video_type(&content_type) {
         match extract_and_upload_thumbnail(
@@ -297,6 +377,7 @@ async fn process_upload(
             }
             Err(e) => {
                 error!("Thumbnail extraction failed for {}: {}", sha256_hash, e);
+                thumbnail_error = Some(e.to_string());
                 None
             }
         }
@@ -304,6 +385,7 @@ async fn process_upload(
         None
     };
 
+    let mut probe_error: Option<String> = None;
     // Probe video dimensions (non-blocking - failures don't fail the upload)
     let dim = if thumbnail::is_video_type(&content_type) {
         match probe_video_dimensions(&all_bytes).await {
@@ -313,6 +395,7 @@ async fn process_upload(
             }
             Err(e) => {
                 error!("Video probe failed for {}: {}", sha256_hash, e);
+                probe_error = Some(e.to_string());
                 None
             }
         }
@@ -320,8 +403,28 @@ async fn process_upload(
         None
     };
 
+    let derivative_failure = classify_invalid_media_signal(
+        &content_type,
+        sanitize_error.as_deref(),
+        thumbnail_error.as_deref(),
+        probe_error.as_deref(),
+    );
+
+    if let Some(signal) = derivative_failure.as_ref() {
+        report_derivative_failure_to_sentry(
+            "divine-upload",
+            "derivative-validation",
+            &sha256_hash,
+            &signal.error_code,
+            &signal.error_message,
+            signal.terminal,
+            Some(&content_type),
+            Some(&auth_event.pubkey),
+        );
+    }
+
     // Trigger HLS transcoding for videos (fire-and-forget)
-    if thumbnail::is_video_type(&content_type) {
+    if thumbnail::is_video_type(&content_type) && derivative_failure.is_none() {
         if let Some(ref transcoder_url) = state.config.transcoder_url {
             // Spawn background task to trigger transcoder - don't block upload response
             let transcoder_url = transcoder_url.clone();
@@ -338,10 +441,15 @@ async fn process_upload(
                 sha256_hash
             );
         }
+    } else if let Some(signal) = derivative_failure.as_ref() {
+        warn!(
+            "Skipping HLS transcoding for {} due to terminal derivative validation failure {}",
+            sha256_hash, signal.error_code
+        );
     }
 
     // Trigger transcript generation for transcribable media (audio/video)
-    if is_transcribable_type(&content_type) {
+    if is_transcribable_type(&content_type) && derivative_failure.is_none() {
         if let Some(ref transcriber_url) = state.config.transcriber_url {
             let transcriber_url = transcriber_url.clone();
             let hash = sha256_hash.clone();
@@ -357,6 +465,11 @@ async fn process_upload(
                 sha256_hash
             );
         }
+    } else if let Some(signal) = derivative_failure.as_ref() {
+        warn!(
+            "Skipping transcript generation for {} due to terminal derivative validation failure {}",
+            sha256_hash, signal.error_code
+        );
     }
 
     // Build response
@@ -365,6 +478,28 @@ async fn process_upload(
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
+
+    let transcode_error_code = derivative_failure
+        .as_ref()
+        .map(|signal| signal.error_code.clone());
+    let transcode_error_message = derivative_failure
+        .as_ref()
+        .map(|signal| signal.error_message.clone());
+    let transcode_terminal = derivative_failure
+        .as_ref()
+        .map(|signal| signal.terminal)
+        .unwrap_or(false);
+
+    let transcript_error_code = derivative_failure
+        .as_ref()
+        .map(|signal| signal.error_code.clone());
+    let transcript_error_message = derivative_failure
+        .as_ref()
+        .map(|signal| signal.error_message.clone());
+    let transcript_terminal = derivative_failure
+        .as_ref()
+        .map(|signal| signal.terminal)
+        .unwrap_or(false);
 
     Ok(UploadResponse {
         sha256: sha256_hash.clone(),
@@ -377,6 +512,12 @@ async fn process_upload(
         ),
         thumbnail_url,
         dim,
+        transcode_error_code,
+        transcode_error_message,
+        transcode_terminal,
+        transcript_error_code,
+        transcript_error_message,
+        transcript_terminal,
     })
 }
 
@@ -386,7 +527,7 @@ async fn stream_to_gcs_with_hash(
     content_type: &str,
     body: Body,
     owner: &str,
-) -> Result<(String, u64, Vec<u8>)> {
+) -> Result<(String, u64, Vec<u8>, Option<String>)> {
     let mut original_bytes = Vec::new();
 
     // Collect body stream first; original bytes remain the source of truth for hashing/storage.
@@ -399,6 +540,7 @@ async fn stream_to_gcs_with_hash(
     // Keep original bytes immutable for hash/storage integrity.
     // Derivative generation (thumbnail/probe/transcode) can use sanitized bytes.
     let mut derivative_bytes = original_bytes.clone();
+    let mut sanitize_error = None;
 
     // Sanitize video bytes for derivative processing only.
     if thumbnail::is_video_type(content_type) {
@@ -413,7 +555,11 @@ async fn stream_to_gcs_with_hash(
             }
             Err(e) => {
                 // Non-fatal: keep original bytes for derivative processing if sanitization fails
-                error!("Video sanitization failed for derivatives, using original: {}", e);
+                error!(
+                    "Video sanitization failed for derivatives, using original: {}",
+                    e
+                );
+                sanitize_error = Some(e.to_string());
             }
         }
     }
@@ -438,7 +584,7 @@ async fn stream_to_gcs_with_hash(
 
     if exists {
         info!("Blob {} already exists, skipping upload", sha256_hash);
-        return Ok((sha256_hash, total_size, derivative_bytes));
+        return Ok((sha256_hash, total_size, derivative_bytes, sanitize_error));
     }
 
     // Upload to GCS
@@ -469,8 +615,11 @@ async fn stream_to_gcs_with_hash(
     };
     let _ = client.patch_object(&update_req).await;
 
-    info!("Uploaded {} bytes as {} (owner: {})", total_size, sha256_hash, owner);
-    Ok((sha256_hash, total_size, derivative_bytes))
+    info!(
+        "Uploaded {} bytes as {} (owner: {})",
+        total_size, sha256_hash, owner
+    );
+    Ok((sha256_hash, total_size, derivative_bytes, sanitize_error))
 }
 
 /// Extract thumbnail from video and upload to GCS
@@ -835,7 +984,7 @@ async fn probe_video_dimensions(video_bytes: &[u8]) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{media_source_candidates, new_temp_media_path};
+    use super::{classify_invalid_media_signal, media_source_candidates, new_temp_media_path};
 
     #[test]
     fn temp_media_paths_are_unique_per_request() {
@@ -851,13 +1000,56 @@ mod tests {
 
     #[test]
     fn media_source_candidates_prefer_original_then_hls_variants() {
-        let hash =
-            "5b48aa1fcf30af61243ac9307eb98b7fa22df1c58573c3ca5d1b14fc30099929";
+        let hash = "5b48aa1fcf30af61243ac9307eb98b7fa22df1c58573c3ca5d1b14fc30099929";
         let candidates = media_source_candidates(hash);
 
         assert_eq!(candidates[0], hash);
         assert_eq!(candidates[1], format!("{}/hls/stream_720p.ts", hash));
         assert_eq!(candidates[2], format!("{}/hls/stream_480p.ts", hash));
+    }
+
+    #[test]
+    fn invalid_media_classification_marks_sanitize_failure_terminal() {
+        let signal = classify_invalid_media_signal(
+            "video/mp4",
+            Some("ffmpeg sanitize failed: moov atom not found"),
+            None,
+            None,
+        )
+        .expect("sanitize failure should mark invalid media");
+
+        assert_eq!(signal.error_code, "invalid_media");
+        assert!(signal.terminal);
+        assert!(signal.error_message.contains("moov atom not found"));
+    }
+
+    #[test]
+    fn invalid_media_classification_marks_probe_failure_terminal() {
+        let signal = classify_invalid_media_signal(
+            "video/mp4",
+            None,
+            None,
+            Some("ffprobe failed: Invalid data found when processing input"),
+        )
+        .expect("probe failure should mark invalid media");
+
+        assert_eq!(signal.error_code, "invalid_media");
+        assert!(signal.terminal);
+        assert!(signal
+            .error_message
+            .contains("Invalid data found when processing input"));
+    }
+
+    #[test]
+    fn invalid_media_classification_ignores_thumbnail_only_failures() {
+        let signal = classify_invalid_media_signal(
+            "video/mp4",
+            None,
+            Some("thumbnail extraction failed"),
+            None,
+        );
+
+        assert!(signal.is_none());
     }
 }
 
@@ -994,6 +1186,35 @@ fn get_extension(content_type: &str) -> &'static str {
 
 fn is_transcribable_type(content_type: &str) -> bool {
     content_type.starts_with("video/") || content_type.starts_with("audio/")
+}
+
+fn classify_invalid_media_signal(
+    content_type: &str,
+    sanitize_error: Option<&str>,
+    _thumbnail_error: Option<&str>,
+    probe_error: Option<&str>,
+) -> Option<DerivativeFailureSignal> {
+    if !thumbnail::is_video_type(content_type) {
+        return None;
+    }
+
+    if let Some(message) = sanitize_error {
+        return Some(DerivativeFailureSignal {
+            error_code: "invalid_media".to_string(),
+            error_message: message.to_string(),
+            terminal: true,
+        });
+    }
+
+    if let Some(message) = probe_error {
+        return Some(DerivativeFailureSignal {
+            error_code: "invalid_media".to_string(),
+            error_message: message.to_string(),
+            terminal: true,
+        });
+    }
+
+    None
 }
 
 /// Trigger HLS transcoding for a video (fire-and-forget)

--- a/docs/superpowers/plans/2026-03-28-bounded-derivative-failure-handling.md
+++ b/docs/superpowers/plans/2026-03-28-bounded-derivative-failure-handling.md
@@ -1,0 +1,240 @@
+# Bounded Derivative Failure Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop infinite HLS/VTT retry loops for bad blobs while keeping canonical uploads non-blocking and reporting derivative failures to Sentry.
+
+**Architecture:** Extend blob metadata with bounded derivative failure state, classify upload/transcoder failures into stable codes, and have public HLS/VTT fetch paths return terminal `422` errors after retry exhaustion. Upload and transcoder services emit Sentry events where failures originate; Fastly Blossom persists state and enforces public behavior.
+
+**Tech Stack:** Fastly Compute Rust, Axum Rust services, Fastly KV metadata, GCS, reqwest, tracing, sentry
+
+---
+
+## File Map
+
+- Modify: `src/blossom.rs`
+- Modify: `src/metadata.rs`
+- Modify: `src/main.rs`
+- Modify: `cloud-run-upload/Cargo.toml`
+- Modify: `cloud-run-upload/src/main.rs`
+- Modify: `cloud-run-transcoder/Cargo.toml`
+- Modify: `cloud-run-transcoder/src/main.rs`
+- Modify: `README.md` only if needed after behavior changes
+
+## Chunk 1: Fastly Retry Model
+
+### Task 1: Add failing Fastly tests for bounded transcript retries
+
+**Files:**
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Write failing tests for transcript terminal behavior**
+
+Add unit tests around the transcript fetch decision helper for:
+- failed transcript under retry cap remains retryable
+- failed transcript at retry cap becomes terminal
+- explicit terminal transcript failure becomes terminal immediately
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+Run: `cargo test transcript_fetch_action -- --nocapture`
+Expected: compile or assertion failure because terminal retry state is not modeled yet.
+
+- [ ] **Step 3: Add failing tests for transcode retry decisions**
+
+Add unit tests for a new helper that will decide HLS retry behavior from transcode metadata.
+
+- [ ] **Step 4: Run targeted tests to verify they fail**
+
+Run: `cargo test derivative_retry -- --nocapture`
+Expected: fail because helper and metadata fields do not exist yet.
+
+## Chunk 2: Blob Metadata And Fastly Behavior
+
+### Task 2: Extend blob metadata with bounded derivative failure state
+
+**Files:**
+- Modify: `src/blossom.rs`
+- Modify: `src/metadata.rs`
+
+- [ ] **Step 1: Add transcode and transcript attempt/terminal fields to `BlobMetadata`**
+
+- [ ] **Step 2: Add metadata update helpers**
+
+Implement helpers for:
+- updating transcode status with failure details
+- updating transcript status with failure details plus attempt counts
+- classifying whether retries remain available
+
+- [ ] **Step 3: Run Fastly tests**
+
+Run: `cargo test metadata -- --nocapture`
+Expected: pass for metadata-related tests.
+
+### Task 3: Enforce bounded retry behavior in public HLS/VTT handlers
+
+**Files:**
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Implement transcript retry decision helper**
+
+Model:
+- processing
+- cooldown
+- trigger
+- terminal failure
+
+- [ ] **Step 2: Implement transcode retry decision helper**
+
+Model:
+- processing
+- cooldown
+- trigger
+- terminal failure
+
+- [ ] **Step 3: Update public fetch handlers**
+
+Change HLS and transcript fetches to return `422` JSON when terminal instead of re-triggering indefinitely.
+
+- [ ] **Step 4: Run targeted tests**
+
+Run: `cargo test transcript_fetch_action cargo test derivative_retry`
+Expected: pass.
+
+## Chunk 3: Worker Failure Reporting
+
+### Task 4: Normalize transcode webhook failure payloads
+
+**Files:**
+- Modify: `cloud-run-transcoder/src/main.rs`
+
+- [ ] **Step 1: Write failing tests for transcode webhook payload fields**
+
+Cover `error_code`, `error_message`, `retry_after`, and `terminal`.
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+Run: `cargo test webhook --manifest-path cloud-run-transcoder/Cargo.toml -- --nocapture`
+Expected: fail because transcode webhook payload is still too thin.
+
+- [ ] **Step 3: Implement structured transcode failure payloads**
+
+Mirror transcript webhook behavior and send terminal metadata for invalid media.
+
+- [ ] **Step 4: Run targeted transcoder tests**
+
+Run: `cargo test --manifest-path cloud-run-transcoder/Cargo.toml webhook -- --nocapture`
+Expected: pass.
+
+### Task 5: Suppress derivative dispatch for obviously invalid media without blocking upload
+
+**Files:**
+- Modify: `cloud-run-upload/src/main.rs`
+
+- [ ] **Step 1: Write failing tests for upload-time invalid-media classification**
+
+Cover cases where thumbnail/probe failures should mark derivatives invalid and skip dispatch.
+
+- [ ] **Step 2: Run targeted tests to verify they fail**
+
+Run: `cargo test --manifest-path cloud-run-upload/Cargo.toml invalid_media -- --nocapture`
+Expected: fail because no such classification exists.
+
+- [ ] **Step 3: Add upload-time invalid-media classification and response fields**
+
+Return enough signal for Fastly to persist terminal derivative state without failing the upload itself.
+
+- [ ] **Step 4: Run targeted upload tests**
+
+Run: `cargo test --manifest-path cloud-run-upload/Cargo.toml invalid_media -- --nocapture`
+Expected: pass.
+
+## Chunk 4: Sentry Integration
+
+### Task 6: Add Sentry to upload and transcoder services
+
+**Files:**
+- Modify: `cloud-run-upload/Cargo.toml`
+- Modify: `cloud-run-upload/src/main.rs`
+- Modify: `cloud-run-transcoder/Cargo.toml`
+- Modify: `cloud-run-transcoder/src/main.rs`
+
+- [ ] **Step 1: Add failing tests for Sentry classification helpers where practical**
+
+Keep tests focused on event classification and fingerprint helpers rather than the Sentry SDK itself.
+
+- [ ] **Step 2: Wire Sentry init from env**
+
+Use `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, and service-specific naming.
+
+- [ ] **Step 3: Emit Sentry events for terminal derivative failures**
+
+Upload:
+- invalid media detected during derivative validation
+
+Transcoder:
+- terminal HLS failure
+- terminal transcript failure
+- retry exhaustion
+
+- [ ] **Step 4: Run service test suites**
+
+Run:
+- `cargo test --manifest-path cloud-run-upload/Cargo.toml`
+- `cargo test --manifest-path cloud-run-transcoder/Cargo.toml`
+
+Expected: both pass.
+
+## Chunk 5: Integration And Verification
+
+### Task 7: Thread new upload response fields into Fastly upload metadata
+
+**Files:**
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: Parse upload-service derivative validity signals**
+
+- [ ] **Step 2: Initialize metadata appropriately for invalid-but-stored blobs**
+
+- [ ] **Step 3: Run targeted Fastly tests**
+
+Run: `cargo test -- --nocapture`
+Expected: new and existing relevant tests pass.
+
+### Task 8: Final verification
+
+**Files:**
+- Modify: `README.md` only if behavior/API docs changed materially
+
+- [ ] **Step 1: Run Fastly tests**
+
+Run: `cargo test`
+Expected: pass, or document any platform-specific Fastly linker limitation if only `cargo check --tests` is viable on this host.
+
+- [ ] **Step 2: Run upload service tests**
+
+Run: `cargo test --manifest-path cloud-run-upload/Cargo.toml`
+Expected: pass.
+
+- [ ] **Step 3: Run transcoder tests**
+
+Run: `cargo test --manifest-path cloud-run-transcoder/Cargo.toml`
+Expected: pass.
+
+- [ ] **Step 4: Run formatting checks**
+
+Run:
+- `cargo fmt --check`
+- `cargo fmt --manifest-path cloud-run-upload/Cargo.toml --check`
+- `cargo fmt --manifest-path cloud-run-transcoder/Cargo.toml --check`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-03-28-bounded-derivative-failure-handling-design.md \
+        docs/superpowers/plans/2026-03-28-bounded-derivative-failure-handling.md \
+        src/blossom.rs src/metadata.rs src/main.rs \
+        cloud-run-upload/Cargo.toml cloud-run-upload/src/main.rs \
+        cloud-run-transcoder/Cargo.toml cloud-run-transcoder/src/main.rs
+git commit -m "feat: bound derivative retries for bad media"
+```

--- a/docs/superpowers/specs/2026-03-28-bounded-derivative-failure-handling-design.md
+++ b/docs/superpowers/specs/2026-03-28-bounded-derivative-failure-handling-design.md
@@ -1,0 +1,162 @@
+# Bounded Derivative Failure Handling Design
+
+## Problem
+
+Derivative generation failures currently behave badly in two ways:
+
+1. Invalid or otherwise non-processable media can remain stored as canonical blobs but keep re-triggering HLS and transcript jobs forever.
+2. Operationally meaningful failures are visible in logs, but not normalized into durable metadata or Sentry events that operators can track.
+
+This creates wasted transcoder work, misleading public `202 Accepted` responses, and poor visibility into systemic bad-object patterns.
+
+## Goals
+
+- Keep canonical blob uploads non-blocking, even when derivatives cannot be generated.
+- Bound derivative retries and stop re-triggering after a small number of failed attempts.
+- Return terminal public errors for exhausted or fatal derivative failures instead of endless `202` responses.
+- Normalize failure reporting across upload, transcode, and transcript paths.
+- Send derivative failures to Sentry with stable grouping and enough context to investigate patterns.
+
+## Non-Goals
+
+- Reject all bad `video/*` uploads at ingest.
+- Delete or tombstone existing bad blobs automatically.
+- Redesign the subtitle job system.
+
+## Recommended Approach
+
+Extend blob metadata so derivative state can distinguish:
+
+- in progress
+- cooling down for retry
+- failed but still retryable
+- terminal failure
+
+Track this separately for HLS/transcode and transcript generation. The upload service may still accept and store bad blobs, but it should stop eagerly dispatching derivative work when upload-time validation already proves the media is invalid. The transcoder and transcript worker should report structured failure payloads to Blossom, and Blossom should decide when retries are exhausted.
+
+## Metadata Model
+
+Add transcode failure metadata parallel to the existing transcript failure metadata:
+
+- `transcode_attempt_count`
+- `transcode_error_code`
+- `transcode_error_message`
+- `transcode_last_attempt_at`
+- `transcode_retry_after`
+- `transcode_terminal`
+
+Extend transcript metadata with:
+
+- `transcript_attempt_count`
+- `transcript_terminal`
+
+The terminal bit is the authoritative signal that public fetch handlers must stop re-triggering work.
+
+## Failure Semantics
+
+Use a small retry cap, defaulting to `3`.
+
+Terminal conditions:
+
+- explicit worker-reported terminal failure
+- failure count reaching the configured cap
+- upload-time media validation proves the source bytes are invalid for derivatives
+
+Retryable conditions:
+
+- provider rate limiting
+- short-lived downstream failures with `retry_after`
+- transient webhook or processing failures that do not classify as terminal
+
+Example stable `error_code` values:
+
+- `invalid_media`
+- `ffprobe_failed`
+- `thumbnail_extract_failed`
+- `provider_rate_limited`
+- `upload_failed`
+- `dispatch_failed`
+
+## Public API Behavior
+
+For HLS and VTT fetches:
+
+- `202 Accepted` while work is actually in progress
+- `202 Accepted` with `Retry-After` during explicit cooldown
+- `422 Unprocessable Entity` once derivative failure is terminal
+
+Terminal response shape:
+
+```json
+{
+  "status": "failed",
+  "error_code": "invalid_media",
+  "message": "Derivative generation failed for this blob",
+  "retryable": false
+}
+```
+
+The canonical blob remains retrievable at its stable media URL.
+
+## Service Responsibilities
+
+### Fastly Blossom
+
+- Persist transcode and transcript failure metadata.
+- Apply retry-cap policy.
+- Stop public re-trigger loops after terminal failure.
+- Return stable `422` derivative failure responses.
+
+### Cloud Run Upload
+
+- Continue accepting and storing canonical blobs.
+- Normalize upload-time derivative validation failures for claimed `video/*`.
+- Avoid dispatching derivative jobs when validation already proves the media is invalid.
+- Emit Sentry events for upload-time invalid-media signals.
+
+### Cloud Run Transcoder
+
+- Send structured failure payloads for HLS and transcript failures.
+- Include `error_code`, `error_message`, `retry_after`, and `terminal` where appropriate.
+- Emit Sentry events with stable grouping for derivative failure classes.
+
+## Sentry Reporting
+
+Sentry should be emitted from the services where failures originate, not from public fetch handlers.
+
+Capture:
+
+- upload-time invalid media detection
+- terminal transcode failures
+- terminal transcript failures
+- retry exhaustion events
+- webhook/state reconciliation failures
+
+Each event should include tags or extras for:
+
+- `sha256`
+- `derivative`
+- `error_code`
+- `attempt_count`
+- `terminal`
+- `content_type`
+- `owner`
+- `service`
+
+Use stable fingerprints such as:
+
+- `["divine-upload", "derivative-validation", "invalid_media"]`
+- `["divine-transcoder", "hls", "invalid_media"]`
+- `["divine-transcoder", "transcript", "provider_rate_limited"]`
+
+## Testing Strategy
+
+- Add Fastly unit tests for retry exhaustion and terminal `422` decisions.
+- Add webhook parsing tests for new transcode failure fields.
+- Add transcoder tests for structured failure webhook payloads.
+- Add upload-service tests for invalid-media classification and derivative dispatch suppression.
+
+## Rollout Notes
+
+- Existing bad blobs should start surfacing terminal derivative responses once they exceed the retry cap or are explicitly marked terminal.
+- No migration is required beyond tolerating absent metadata fields on older blobs.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -713,12 +713,10 @@ pub fn handle_admin_blob_content(req: Request, hash: &str) -> Result<Response> {
     resp.set_header("Cache-Control", "private, no-store");
     resp.set_header("Accept-Ranges", "bytes");
 
-    // Inline CORS headers (add_cors_headers is private to main.rs)
-    resp.set_header("Access-Control-Allow-Origin", "*");
     resp.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
     resp.set_header(
         "Access-Control-Allow-Headers",
-        "Authorization, Content-Type, Range",
+        "Authorization, Content-Type, Range, X-Requested-With",
     );
 
     Ok(resp)
@@ -1068,10 +1066,9 @@ fn json_response<T: serde::Serialize>(status: StatusCode, body: &T) -> Result<Re
         .map_err(|e| BlossomError::Internal(format!("JSON serialization error: {}", e)))?;
     let mut resp = Response::from_status(status);
     resp.set_header(header::CONTENT_TYPE, "application/json");
-    resp.set_header("Access-Control-Allow-Origin", "*");
     resp.set_header(
         "Access-Control-Allow-Headers",
-        "Authorization, Content-Type",
+        "Authorization, Content-Type, X-Requested-With",
     );
     resp.set_body(json);
     Ok(resp)

--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -58,6 +58,24 @@ pub struct BlobMetadata {
     /// Transcode status for video HLS generation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transcode_status: Option<TranscodeStatus>,
+    /// Stable error code from the last transcode attempt
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcode_error_code: Option<String>,
+    /// Human-readable error message from the last transcode attempt
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcode_error_message: Option<String>,
+    /// ISO timestamp for the most recent transcode attempt
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcode_last_attempt_at: Option<String>,
+    /// UNIX timestamp after which HLS generation may be retried
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcode_retry_after: Option<u64>,
+    /// Number of failed transcode attempts recorded for this blob
+    #[serde(default)]
+    pub transcode_attempt_count: u32,
+    /// Whether HLS generation has reached a terminal failure state
+    #[serde(default)]
+    pub transcode_terminal: bool,
     /// Video dimensions as "WIDTHxHEIGHT" (display dimensions after rotation)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dim: Option<String>,
@@ -76,6 +94,12 @@ pub struct BlobMetadata {
     /// UNIX timestamp after which transcript generation may be retried
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transcript_retry_after: Option<u64>,
+    /// Number of failed transcript attempts recorded for this blob
+    #[serde(default)]
+    pub transcript_attempt_count: u32,
+    /// Whether transcript generation has reached a terminal failure state
+    #[serde(default)]
+    pub transcript_terminal: bool,
 }
 
 /// Moderation status for blobs
@@ -657,12 +681,20 @@ mod tests {
             thumbnail: None,
             moderation: None,
             transcode_status: None,
+            transcode_error_code: None,
+            transcode_error_message: None,
+            transcode_last_attempt_at: None,
+            transcode_retry_after: None,
+            transcode_attempt_count: 0,
+            transcode_terminal: false,
             dim: None,
             transcript_status: None,
             transcript_error_code: None,
             transcript_error_message: None,
             transcript_last_attempt_at: None,
             transcript_retry_after: None,
+            transcript_attempt_count: 0,
+            transcript_terminal: false,
         }
     }
 
@@ -683,10 +715,7 @@ mod tests {
         // HLS URL present when complete
         meta.transcode_status = Some(TranscodeStatus::Complete);
         let desc = meta.to_descriptor(base);
-        assert_eq!(
-            desc.hls,
-            Some(format!("{}/{}.hls", base, meta.sha256))
-        );
+        assert_eq!(desc.hls, Some(format!("{}/{}.hls", base, meta.sha256)));
     }
 
     #[test]
@@ -701,10 +730,7 @@ mod tests {
         // VTT URL present when complete
         meta.transcript_status = Some(TranscriptStatus::Complete);
         let desc = meta.to_descriptor(base);
-        assert_eq!(
-            desc.vtt,
-            Some(format!("{}/{}.vtt", base, meta.sha256))
-        );
+        assert_eq!(desc.vtt, Some(format!("{}/{}.vtt", base, meta.sha256)));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,9 +58,20 @@ const PREVIEW_ORIGIN_SUFFIX: &str = ".openvine-app.pages.dev";
 /// Entry point
 #[fastly::main]
 fn main(req: Request) -> std::result::Result<Response, Error> {
+    let method = req.get_method().clone();
+    let path = req.get_path().to_string();
+    let request_origin = req.get_header_str("Origin").map(str::to_string);
+
     match handle_request(req) {
-        Ok(resp) => Ok(resp),
-        Err(e) => Ok(error_response(&e)),
+        Ok(mut resp) => {
+            apply_response_cors(&method, &path, request_origin.as_deref(), &mut resp);
+            Ok(resp)
+        }
+        Err(e) => {
+            let mut resp = error_response(&e);
+            apply_response_cors(&method, &path, request_origin.as_deref(), &mut resp);
+            Ok(resp)
+        }
     }
 }
 
@@ -187,7 +198,10 @@ fn handle_request(req: Request) -> Result<Response> {
         (Method::POST, "/admin/api/backfill-vtt") => handle_admin_backfill_vtt(req),
 
         // CORS preflight
-        (Method::OPTIONS, _) => Ok(cors_preflight_response(req.get_header_str("Origin"))),
+        (Method::OPTIONS, _) => Ok(cors_preflight_response(
+            req.get_path(),
+            req.get_header_str("Origin"),
+        )),
 
         // Not found
         _ => Err(BlossomError::NotFound("Not found".into())),
@@ -4739,6 +4753,45 @@ fn resolve_cors_origin(request_origin: Option<&str>) -> Option<String> {
     origin_matches_rule(origin).then(|| origin.to_string())
 }
 
+fn is_public_media_cors_path(path: &str) -> bool {
+    is_hash_path(path)
+        || path.ends_with(".hls")
+        || path.contains("/hls/")
+        || is_vtt_file_path(path)
+        || is_transcript_path(path)
+        || is_audio_path(path)
+        || is_quality_variant_path(path)
+}
+
+fn resolve_response_cors_origin(
+    method: &Method,
+    path: &str,
+    request_origin: Option<&str>,
+) -> Option<String> {
+    if matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS)
+        && is_public_media_cors_path(path)
+    {
+        Some("*".into())
+    } else {
+        resolve_cors_origin(request_origin)
+    }
+}
+
+fn apply_response_cors(
+    method: &Method,
+    path: &str,
+    request_origin: Option<&str>,
+    resp: &mut Response,
+) {
+    add_cors_headers(resp);
+    if let Some(origin) = resolve_response_cors_origin(method, path, request_origin) {
+        resp.set_header("Access-Control-Allow-Origin", origin.as_str());
+        if origin != "*" {
+            resp.set_header("Vary", "Origin");
+        }
+    }
+}
+
 fn add_cors_headers(resp: &mut Response) {
     resp.set_header(
         "Access-Control-Allow-Methods",
@@ -4755,13 +4808,9 @@ fn add_cors_headers(resp: &mut Response) {
 }
 
 /// CORS preflight response
-fn cors_preflight_response(request_origin: Option<&str>) -> Response {
+fn cors_preflight_response(path: &str, request_origin: Option<&str>) -> Response {
     let mut resp = Response::from_status(StatusCode::NO_CONTENT);
-    add_cors_headers(&mut resp);
-    if let Some(origin) = resolve_cors_origin(request_origin) {
-        resp.set_header("Access-Control-Allow-Origin", origin.as_str());
-        resp.set_header("Vary", "Origin");
-    }
+    apply_response_cors(&Method::OPTIONS, path, request_origin, &mut resp);
     resp.set_header("Access-Control-Max-Age", "86400");
     resp
 }
@@ -4846,11 +4895,13 @@ fn infer_mime_from_path(path: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        decide_transcode_fetch_action, decide_transcript_fetch_action, is_quality_variant_path,
-        parse_quality_variant_path, parse_transcript_status_webhook_payload, resolve_cors_origin,
-        TranscodeFetchAction, TranscriptFetchAction, TranscriptPendingState,
+        decide_transcode_fetch_action, decide_transcript_fetch_action,
+        resolve_response_cors_origin, is_quality_variant_path, parse_quality_variant_path,
+        parse_transcript_status_webhook_payload, resolve_cors_origin, TranscodeFetchAction,
+        TranscriptFetchAction, TranscriptPendingState,
     };
     use crate::blossom::{TranscodeStatus, TranscriptStatus};
+    use fastly::http::Method;
 
     #[test]
     fn quality_variant_path_valid() {
@@ -5079,5 +5130,47 @@ mod tests {
     #[test]
     fn cors_rejects_unknown_origin() {
         assert_eq!(resolve_cors_origin(Some("https://evil.example")), None);
+    }
+
+    #[test]
+    fn cors_uses_wildcard_for_public_blob_reads() {
+        let hash = "a".repeat(64);
+        assert_eq!(
+            resolve_response_cors_origin(&Method::GET, &format!("/{}", hash), None),
+            Some("*".into())
+        );
+    }
+
+    #[test]
+    fn cors_uses_wildcard_for_public_media_preflight() {
+        let hash = "a".repeat(64);
+        assert_eq!(
+            resolve_response_cors_origin(
+                &Method::OPTIONS,
+                &format!("/{}/hls/master.m3u8", hash),
+                Some("https://evil.example"),
+            ),
+            Some("*".into())
+        );
+    }
+
+    #[test]
+    fn cors_keeps_uploads_on_allowlist() {
+        assert_eq!(
+            resolve_response_cors_origin(
+                &Method::POST,
+                "/upload",
+                Some("https://app.divine.video"),
+            ),
+            Some("https://app.divine.video".into())
+        );
+        assert_eq!(
+            resolve_response_cors_origin(
+                &Method::POST,
+                "/upload",
+                Some("https://evil.example"),
+            ),
+            None
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ const MAX_UPLOAD_SIZE: u64 = 50 * 1024 * 1024 * 1024;
 const SUBTITLE_MAX_ATTEMPTS: u32 = 3;
 /// Max derivative failures before public endpoints stop re-triggering work.
 const DERIVATIVE_MAX_ATTEMPTS: u32 = 3;
+const APP_ORIGIN: &str = "https://app.divine.video";
+const PREVIEW_ORIGIN_SUFFIX: &str = ".openvine-app.pages.dev";
 
 /// Entry point
 #[fastly::main]
@@ -185,7 +187,7 @@ fn handle_request(req: Request) -> Result<Response> {
         (Method::POST, "/admin/api/backfill-vtt") => handle_admin_backfill_vtt(req),
 
         // CORS preflight
-        (Method::OPTIONS, _) => Ok(cors_preflight_response()),
+        (Method::OPTIONS, _) => Ok(cors_preflight_response(req.get_header_str("Origin"))),
 
         // Not found
         _ => Err(BlossomError::NotFound("Not found".into())),
@@ -4724,15 +4726,27 @@ pub(crate) fn purge_vcl_cache(surrogate_key: &str) {
     }
 }
 
+fn origin_matches_rule(origin: &str) -> bool {
+    origin == APP_ORIGIN
+        || origin
+            .strip_prefix("https://")
+            .and_then(|host| host.strip_suffix(PREVIEW_ORIGIN_SUFFIX))
+            .is_some_and(|prefix| !prefix.is_empty())
+}
+
+fn resolve_cors_origin(request_origin: Option<&str>) -> Option<String> {
+    let origin = request_origin?.trim();
+    origin_matches_rule(origin).then(|| origin.to_string())
+}
+
 fn add_cors_headers(resp: &mut Response) {
-    resp.set_header("Access-Control-Allow-Origin", "*");
     resp.set_header(
         "Access-Control-Allow-Methods",
         "GET, HEAD, PUT, POST, DELETE, OPTIONS",
     );
     resp.set_header(
         "Access-Control-Allow-Headers",
-        "Authorization, Content-Type, X-Sha256",
+        "Authorization, Content-Type, Range, X-Requested-With, X-Sha256",
     );
     resp.set_header(
         "Access-Control-Expose-Headers",
@@ -4741,9 +4755,13 @@ fn add_cors_headers(resp: &mut Response) {
 }
 
 /// CORS preflight response
-fn cors_preflight_response() -> Response {
+fn cors_preflight_response(request_origin: Option<&str>) -> Response {
     let mut resp = Response::from_status(StatusCode::NO_CONTENT);
     add_cors_headers(&mut resp);
+    if let Some(origin) = resolve_cors_origin(request_origin) {
+        resp.set_header("Access-Control-Allow-Origin", origin.as_str());
+        resp.set_header("Vary", "Origin");
+    }
     resp.set_header("Access-Control-Max-Age", "86400");
     resp
 }
@@ -4829,8 +4847,8 @@ fn infer_mime_from_path(path: &str) -> Option<&'static str> {
 mod tests {
     use super::{
         decide_transcode_fetch_action, decide_transcript_fetch_action, is_quality_variant_path,
-        parse_quality_variant_path, parse_transcript_status_webhook_payload, TranscodeFetchAction,
-        TranscriptFetchAction, TranscriptPendingState,
+        parse_quality_variant_path, parse_transcript_status_webhook_payload, resolve_cors_origin,
+        TranscodeFetchAction, TranscriptFetchAction, TranscriptPendingState,
     };
     use crate::blossom::{TranscodeStatus, TranscriptStatus};
 
@@ -5032,5 +5050,34 @@ mod tests {
                 should_repair: true,
             }
         );
+    }
+
+    #[test]
+    fn cors_allows_app_origin() {
+        assert_eq!(
+            resolve_cors_origin(Some("https://app.divine.video")),
+            Some("https://app.divine.video".into())
+        );
+    }
+
+    #[test]
+    fn cors_allows_preview_origin() {
+        assert_eq!(
+            resolve_cors_origin(Some("https://pr-123.openvine-app.pages.dev")),
+            Some("https://pr-123.openvine-app.pages.dev".into())
+        );
+    }
+
+    #[test]
+    fn cors_rejects_apex_preview_domain() {
+        assert_eq!(
+            resolve_cors_origin(Some("https://openvine-app.pages.dev")),
+            None
+        );
+    }
+
+    #[test]
+    fn cors_rejects_unknown_origin() {
+        assert_eq!(resolve_cors_origin(Some("https://evil.example")), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,24 +52,17 @@ const MAX_UPLOAD_SIZE: u64 = 50 * 1024 * 1024 * 1024;
 const SUBTITLE_MAX_ATTEMPTS: u32 = 3;
 /// Max derivative failures before public endpoints stop re-triggering work.
 const DERIVATIVE_MAX_ATTEMPTS: u32 = 3;
-const APP_ORIGIN: &str = "https://app.divine.video";
-const PREVIEW_ORIGIN_SUFFIX: &str = ".openvine-app.pages.dev";
-
 /// Entry point
 #[fastly::main]
 fn main(req: Request) -> std::result::Result<Response, Error> {
-    let method = req.get_method().clone();
-    let path = req.get_path().to_string();
-    let request_origin = req.get_header_str("Origin").map(str::to_string);
-
     match handle_request(req) {
         Ok(mut resp) => {
-            apply_response_cors(&method, &path, request_origin.as_deref(), &mut resp);
+            add_cors_headers(&mut resp);
             Ok(resp)
         }
         Err(e) => {
             let mut resp = error_response(&e);
-            apply_response_cors(&method, &path, request_origin.as_deref(), &mut resp);
+            add_cors_headers(&mut resp);
             Ok(resp)
         }
     }
@@ -198,10 +191,7 @@ fn handle_request(req: Request) -> Result<Response> {
         (Method::POST, "/admin/api/backfill-vtt") => handle_admin_backfill_vtt(req),
 
         // CORS preflight
-        (Method::OPTIONS, _) => Ok(cors_preflight_response(
-            req.get_path(),
-            req.get_header_str("Origin"),
-        )),
+        (Method::OPTIONS, _) => Ok(cors_preflight_response()),
 
         // Not found
         _ => Err(BlossomError::NotFound("Not found".into())),
@@ -4659,9 +4649,12 @@ fn error_response(error: &BlossomError) -> Response {
         "error": error.message()
     });
     resp.set_body(body.to_string());
-    add_cors_headers(&mut resp);
 
     resp
+}
+
+fn cors_allow_origin_value() -> &'static str {
+    "*"
 }
 
 /// Add CORS headers
@@ -4740,59 +4733,8 @@ pub(crate) fn purge_vcl_cache(surrogate_key: &str) {
     }
 }
 
-fn origin_matches_rule(origin: &str) -> bool {
-    origin == APP_ORIGIN
-        || origin
-            .strip_prefix("https://")
-            .and_then(|host| host.strip_suffix(PREVIEW_ORIGIN_SUFFIX))
-            .is_some_and(|prefix| !prefix.is_empty())
-}
-
-fn resolve_cors_origin(request_origin: Option<&str>) -> Option<String> {
-    let origin = request_origin?.trim();
-    origin_matches_rule(origin).then(|| origin.to_string())
-}
-
-fn is_public_media_cors_path(path: &str) -> bool {
-    is_hash_path(path)
-        || path.ends_with(".hls")
-        || path.contains("/hls/")
-        || is_vtt_file_path(path)
-        || is_transcript_path(path)
-        || is_audio_path(path)
-        || is_quality_variant_path(path)
-}
-
-fn resolve_response_cors_origin(
-    method: &Method,
-    path: &str,
-    request_origin: Option<&str>,
-) -> Option<String> {
-    if matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS)
-        && is_public_media_cors_path(path)
-    {
-        Some("*".into())
-    } else {
-        resolve_cors_origin(request_origin)
-    }
-}
-
-fn apply_response_cors(
-    method: &Method,
-    path: &str,
-    request_origin: Option<&str>,
-    resp: &mut Response,
-) {
-    add_cors_headers(resp);
-    if let Some(origin) = resolve_response_cors_origin(method, path, request_origin) {
-        resp.set_header("Access-Control-Allow-Origin", origin.as_str());
-        if origin != "*" {
-            resp.set_header("Vary", "Origin");
-        }
-    }
-}
-
 fn add_cors_headers(resp: &mut Response) {
+    resp.set_header("Access-Control-Allow-Origin", cors_allow_origin_value());
     resp.set_header(
         "Access-Control-Allow-Methods",
         "GET, HEAD, PUT, POST, DELETE, OPTIONS",
@@ -4808,9 +4750,9 @@ fn add_cors_headers(resp: &mut Response) {
 }
 
 /// CORS preflight response
-fn cors_preflight_response(path: &str, request_origin: Option<&str>) -> Response {
+fn cors_preflight_response() -> Response {
     let mut resp = Response::from_status(StatusCode::NO_CONTENT);
-    apply_response_cors(&Method::OPTIONS, path, request_origin, &mut resp);
+    add_cors_headers(&mut resp);
     resp.set_header("Access-Control-Max-Age", "86400");
     resp
 }
@@ -4895,13 +4837,12 @@ fn infer_mime_from_path(path: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        decide_transcode_fetch_action, decide_transcript_fetch_action,
-        resolve_response_cors_origin, is_quality_variant_path, parse_quality_variant_path,
-        parse_transcript_status_webhook_payload, resolve_cors_origin, TranscodeFetchAction,
-        TranscriptFetchAction, TranscriptPendingState,
+        cors_allow_origin_value, decide_transcode_fetch_action,
+        decide_transcript_fetch_action, is_quality_variant_path, parse_quality_variant_path,
+        parse_transcript_status_webhook_payload, TranscodeFetchAction, TranscriptFetchAction,
+        TranscriptPendingState,
     };
     use crate::blossom::{TranscodeStatus, TranscriptStatus};
-    use fastly::http::Method;
 
     #[test]
     fn quality_variant_path_valid() {
@@ -5104,73 +5045,17 @@ mod tests {
     }
 
     #[test]
-    fn cors_allows_app_origin() {
-        assert_eq!(
-            resolve_cors_origin(Some("https://app.divine.video")),
-            Some("https://app.divine.video".into())
-        );
+    fn cors_headers_use_wildcard_origin() {
+        assert_eq!(cors_allow_origin_value(), "*");
     }
 
     #[test]
-    fn cors_allows_preview_origin() {
-        assert_eq!(
-            resolve_cors_origin(Some("https://pr-123.openvine-app.pages.dev")),
-            Some("https://pr-123.openvine-app.pages.dev".into())
-        );
+    fn cors_preflight_uses_wildcard_origin() {
+        assert_eq!(cors_allow_origin_value(), "*");
     }
 
     #[test]
-    fn cors_rejects_apex_preview_domain() {
-        assert_eq!(
-            resolve_cors_origin(Some("https://openvine-app.pages.dev")),
-            None
-        );
-    }
-
-    #[test]
-    fn cors_rejects_unknown_origin() {
-        assert_eq!(resolve_cors_origin(Some("https://evil.example")), None);
-    }
-
-    #[test]
-    fn cors_uses_wildcard_for_public_blob_reads() {
-        let hash = "a".repeat(64);
-        assert_eq!(
-            resolve_response_cors_origin(&Method::GET, &format!("/{}", hash), None),
-            Some("*".into())
-        );
-    }
-
-    #[test]
-    fn cors_uses_wildcard_for_public_media_preflight() {
-        let hash = "a".repeat(64);
-        assert_eq!(
-            resolve_response_cors_origin(
-                &Method::OPTIONS,
-                &format!("/{}/hls/master.m3u8", hash),
-                Some("https://evil.example"),
-            ),
-            Some("*".into())
-        );
-    }
-
-    #[test]
-    fn cors_keeps_uploads_on_allowlist() {
-        assert_eq!(
-            resolve_response_cors_origin(
-                &Method::POST,
-                "/upload",
-                Some("https://app.divine.video"),
-            ),
-            Some("https://app.divine.video".into())
-        );
-        assert_eq!(
-            resolve_response_cors_origin(
-                &Method::POST,
-                "/upload",
-                Some("https://evil.example"),
-            ),
-            None
-        );
+    fn cors_wildcard_applies_to_uploads_and_reads() {
+        assert_eq!(cors_allow_origin_value(), "*");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,10 @@ mod storage;
 
 use crate::auth::{optional_auth, validate_auth, validate_hash_match};
 use crate::blossom::{
-    is_audio_path, is_hash_path, is_transcribable_mime_type, is_video_mime_type,
-    parse_audio_path, parse_hash_from_path, parse_thumbnail_path, AudioMapping, AuthAction,
-    BlobDescriptor, BlobMetadata, BlobStatus, SubtitleJob, SubtitleJobCreateRequest,
-    SubtitleJobStatus, TranscodeStatus, TranscriptStatus, UploadRequirements,
+    is_audio_path, is_hash_path, is_transcribable_mime_type, is_video_mime_type, parse_audio_path,
+    parse_hash_from_path, parse_thumbnail_path, AudioMapping, AuthAction, BlobDescriptor,
+    BlobMetadata, BlobStatus, SubtitleJob, SubtitleJobCreateRequest, SubtitleJobStatus,
+    TranscodeStatus, TranscriptStatus, UploadRequirements,
 };
 use crate::error::{BlossomError, Result};
 use crate::metadata::{
@@ -24,13 +24,14 @@ use crate::metadata::{
     list_blobs_with_metadata, put_audio_mapping, put_auth_event, put_blob_metadata,
     put_subtitle_job, put_tombstone, remove_from_blob_refs, remove_from_recent_index,
     remove_from_user_index, remove_from_user_list, set_subtitle_job_id_for_hash,
-    update_blob_status, update_stats_on_add, update_stats_on_remove, TranscriptMetadataUpdate,
+    update_blob_status, update_stats_on_add, update_stats_on_remove, TranscodeMetadataUpdate,
+    TranscriptMetadataUpdate,
 };
 use crate::storage::{
-    blob_exists, check_funnelcake_audio_reuse, current_timestamp,
-    delete_blob as storage_delete, download_blob_with_fallback, download_thumbnail,
-    trigger_audio_extraction, trigger_audit_anonymize, trigger_cloud_run_bulk_delete,
-    trigger_cloud_run_delete_blob, upload_blob, write_audit_log,
+    blob_exists, check_funnelcake_audio_reuse, current_timestamp, delete_blob as storage_delete,
+    download_blob_with_fallback, download_thumbnail, trigger_audio_extraction,
+    trigger_audit_anonymize, trigger_cloud_run_bulk_delete, trigger_cloud_run_delete_blob,
+    upload_blob, write_audit_log,
 };
 
 use fastly::cache::simple as simple_cache;
@@ -49,6 +50,8 @@ const TRANSCRIPT_CACHE_TTL: Duration = Duration::from_secs(3600);
 const MAX_UPLOAD_SIZE: u64 = 50 * 1024 * 1024 * 1024;
 /// Max automatic subtitle transcription attempts before poison state.
 const SUBTITLE_MAX_ATTEMPTS: u32 = 3;
+/// Max derivative failures before public endpoints stop re-triggering work.
+const DERIVATIVE_MAX_ATTEMPTS: u32 = 3;
 
 /// Entry point
 #[fastly::main]
@@ -498,22 +501,40 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
 
             Ok(resp)
         }
-        Err(_) => {
+        Err(BlossomError::NotFound(_)) => {
             // HLS not in GCS — check metadata and trigger transcoding if needed
             let meta = metadata.as_ref().unwrap();
-            match meta.transcode_status {
-                Some(TranscodeStatus::Processing) => {
+            match decide_transcode_fetch_action(
+                meta.transcode_status,
+                meta.transcode_retry_after,
+                meta.transcode_attempt_count,
+                meta.transcode_terminal,
+                unix_timestamp_secs(),
+            ) {
+                TranscodeFetchAction::Accepted {
+                    state,
+                    retry_after_secs,
+                } => {
                     let mut resp = Response::from_status(StatusCode::ACCEPTED);
-                    resp.set_header("Retry-After", "5");
+                    resp.set_header("Retry-After", retry_after_secs.to_string());
                     resp.set_header("Content-Type", "application/json");
-                    resp.set_body(
-                        r#"{"status":"processing","message":"HLS transcoding in progress"}"#,
-                    );
+                    let body = match state {
+                        TranscriptPendingState::InProgress => {
+                            r#"{"status":"processing","message":"HLS transcoding in progress"}"#
+                        }
+                        TranscriptPendingState::CoolingDown => {
+                            r#"{"status":"cooling_down","message":"HLS transcoding cooling down before retry"}"#
+                        }
+                    };
+                    resp.set_body(body);
                     add_no_cache_headers(&mut resp);
                     add_cors_headers(&mut resp);
                     Ok(resp)
                 }
-                _ => {
+                TranscodeFetchAction::Trigger {
+                    retry_after_secs,
+                    should_repair,
+                } => {
                     // Pending, Failed, Complete-but-missing, or None — trigger transcoding
                     use crate::metadata::update_transcode_status;
                     if let Err(e) = update_transcode_status(&hash, TranscodeStatus::Processing) {
@@ -522,15 +543,29 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
                     let _ = trigger_on_demand_transcoding(&hash, &meta.owner);
 
                     let mut resp = Response::from_status(StatusCode::ACCEPTED);
-                    resp.set_header("Retry-After", "10");
+                    resp.set_header("Retry-After", retry_after_secs.to_string());
                     resp.set_header("Content-Type", "application/json");
-                    resp.set_body(r#"{"status":"processing","message":"HLS transcoding started, please retry in 10 seconds"}"#);
+                    if should_repair {
+                        resp.set_body(
+                            r#"{"status":"repairing","message":"HLS transcoding repair started, please retry soon"}"#,
+                        );
+                    } else {
+                        resp.set_body(
+                            r#"{"status":"processing","message":"HLS transcoding started, please retry soon"}"#,
+                        );
+                    }
                     add_no_cache_headers(&mut resp);
                     add_cors_headers(&mut resp);
                     Ok(resp)
                 }
+                TranscodeFetchAction::Terminal => Ok(derivative_failure_response(
+                    meta.transcode_error_code.as_deref(),
+                    meta.transcode_error_message.as_deref(),
+                    "HLS generation failed for this blob",
+                )),
             }
         }
+        Err(e) => Err(e),
     }
 }
 
@@ -573,16 +608,32 @@ fn handle_head_hls_master(path: &str) -> Result<Response> {
             add_cors_headers(&mut resp);
             Ok(resp)
         }
-        Err(_) => match metadata.transcode_status {
-            Some(TranscodeStatus::Processing) => {
+        Err(BlossomError::NotFound(_)) => match decide_transcode_fetch_action(
+            metadata.transcode_status,
+            metadata.transcode_retry_after,
+            metadata.transcode_attempt_count,
+            metadata.transcode_terminal,
+            unix_timestamp_secs(),
+        ) {
+            TranscodeFetchAction::Accepted {
+                retry_after_secs, ..
+            }
+            | TranscodeFetchAction::Trigger {
+                retry_after_secs, ..
+            } => {
                 let mut resp = Response::from_status(StatusCode::ACCEPTED);
-                resp.set_header("Retry-After", "5");
+                resp.set_header("Retry-After", retry_after_secs.to_string());
                 add_no_cache_headers(&mut resp);
                 add_cors_headers(&mut resp);
                 Ok(resp)
             }
-            _ => Err(BlossomError::NotFound("HLS not available".into())),
+            TranscodeFetchAction::Terminal => Ok(derivative_failure_head_response(
+                &hash,
+                metadata.transcode_error_code.as_deref(),
+                "application/vnd.apple.mpegurl",
+            )),
         },
+        Err(e) => Err(e),
     }
 }
 
@@ -671,65 +722,62 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
             let metadata = get_blob_metadata(&hash)?;
 
             if let Some(ref meta) = metadata {
-                match meta.transcode_status {
-                    Some(TranscodeStatus::Complete) => {
-                        // Metadata says complete but file not in GCS - re-trigger
-                        eprintln!("[HLS] master.m3u8 not found in GCS for {} despite Complete status, re-triggering", hash);
+                match decide_transcode_fetch_action(
+                    meta.transcode_status,
+                    meta.transcode_retry_after,
+                    meta.transcode_attempt_count,
+                    meta.transcode_terminal,
+                    unix_timestamp_secs(),
+                ) {
+                    TranscodeFetchAction::Accepted {
+                        state,
+                        retry_after_secs,
+                    } => {
+                        let mut resp = Response::from_status(StatusCode::ACCEPTED);
+                        resp.set_header("Retry-After", retry_after_secs.to_string());
+                        resp.set_header("Content-Type", "application/json");
+                        let body = match state {
+                            TranscriptPendingState::InProgress => {
+                                r#"{"status":"processing","message":"HLS transcoding in progress"}"#
+                            }
+                            TranscriptPendingState::CoolingDown => {
+                                r#"{"status":"cooling_down","message":"HLS transcoding cooling down before retry"}"#
+                            }
+                        };
+                        resp.set_body(body);
+                        add_no_cache_headers(&mut resp);
+                        add_cors_headers(&mut resp);
+                        Ok(resp)
+                    }
+                    TranscodeFetchAction::Trigger {
+                        retry_after_secs,
+                        should_repair,
+                    } => {
                         use crate::metadata::update_transcode_status;
                         let _ = update_transcode_status(&hash, TranscodeStatus::Processing);
                         let _ = trigger_on_demand_transcoding(&hash, &meta.owner);
 
                         let mut resp = Response::from_status(StatusCode::ACCEPTED);
-                        resp.set_header("Retry-After", "10");
+                        resp.set_header("Retry-After", retry_after_secs.to_string());
                         resp.set_header("Content-Type", "application/json");
-                        resp.set_body(r#"{"status":"processing","message":"HLS transcoding re-triggered, please retry"}"#);
-                        add_no_cache_headers(&mut resp);
-                        add_cors_headers(&mut resp);
-                        Ok(resp)
-                    }
-                    Some(TranscodeStatus::Processing) => {
-                        let mut resp = Response::from_status(StatusCode::ACCEPTED);
-                        resp.set_header("Retry-After", "5");
-                        resp.set_header("Content-Type", "application/json");
-                        resp.set_body(
-                            r#"{"status":"processing","message":"HLS transcoding in progress"}"#,
-                        );
-                        add_no_cache_headers(&mut resp);
-                        add_cors_headers(&mut resp);
-                        Ok(resp)
-                    }
-                    Some(TranscodeStatus::Failed) => {
-                        // Failed previously - re-trigger
-                        eprintln!("[HLS] Re-triggering failed transcode for {}", hash);
-                        use crate::metadata::update_transcode_status;
-                        let _ = update_transcode_status(&hash, TranscodeStatus::Processing);
-                        let _ = trigger_on_demand_transcoding(&hash, &meta.owner);
-
-                        let mut resp = Response::from_status(StatusCode::ACCEPTED);
-                        resp.set_header("Retry-After", "10");
-                        resp.set_header("Content-Type", "application/json");
-                        resp.set_body(r#"{"status":"processing","message":"HLS transcoding re-started, please retry"}"#);
-                        add_no_cache_headers(&mut resp);
-                        add_cors_headers(&mut resp);
-                        Ok(resp)
-                    }
-                    Some(TranscodeStatus::Pending) | None => {
-                        // Not yet started - trigger on-demand transcoding
-                        use crate::metadata::update_transcode_status;
-                        if let Err(e) = update_transcode_status(&hash, TranscodeStatus::Processing)
-                        {
-                            eprintln!("[HLS] Failed to update transcode status: {}", e);
+                        if should_repair {
+                            resp.set_body(
+                                r#"{"status":"repairing","message":"HLS transcoding repair started, please retry soon"}"#,
+                            );
+                        } else {
+                            resp.set_body(
+                                r#"{"status":"processing","message":"HLS transcoding started, please retry soon"}"#,
+                            );
                         }
-                        let _ = trigger_on_demand_transcoding(&hash, &meta.owner);
-
-                        let mut resp = Response::from_status(StatusCode::ACCEPTED);
-                        resp.set_header("Retry-After", "10");
-                        resp.set_header("Content-Type", "application/json");
-                        resp.set_body(r#"{"status":"processing","message":"HLS transcoding started, please retry in 10 seconds"}"#);
                         add_no_cache_headers(&mut resp);
                         add_cors_headers(&mut resp);
                         Ok(resp)
                     }
+                    TranscodeFetchAction::Terminal => Ok(derivative_failure_response(
+                        meta.transcode_error_code.as_deref(),
+                        meta.transcode_error_message.as_deref(),
+                        "HLS generation failed for this blob",
+                    )),
                 }
             } else {
                 Err(BlossomError::NotFound("Content not found".into()))
@@ -760,7 +808,8 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
     let hash_lower = hash.to_lowercase();
 
     // Check moderation status — HEAD has no auth, so block both banned and restricted
-    if let Ok(Some(ref meta)) = get_blob_metadata(&hash_lower) {
+    let metadata = get_blob_metadata(&hash_lower)?;
+    if let Some(ref meta) = metadata {
         if meta.status == BlobStatus::Banned || meta.status == BlobStatus::Restricted {
             return Err(BlossomError::NotFound("Content not found".into()));
         }
@@ -769,9 +818,6 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
     // Check if file exists in GCS
     let gcs_path = format!("{}/hls/{}", hash_lower, filename);
 
-    // Try to get the content (HEAD-like check)
-    download_hls_content(&gcs_path, None)?;
-
     let content_type = if filename.ends_with(".m3u8") {
         "application/vnd.apple.mpegurl"
     } else if filename.ends_with(".ts") {
@@ -779,14 +825,47 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
     } else {
         "application/octet-stream"
     };
-
-    let mut resp = Response::from_status(StatusCode::OK);
-    resp.set_header("Content-Type", content_type);
-    add_cache_headers(&mut resp, &hash_lower);
-    resp.set_header("X-Sha256", &hash_lower);
-    add_cors_headers(&mut resp);
-
-    Ok(resp)
+    match download_hls_content(&gcs_path, None) {
+        Ok(_) => {
+            let mut resp = Response::from_status(StatusCode::OK);
+            resp.set_header("Content-Type", content_type);
+            add_cache_headers(&mut resp, &hash_lower);
+            resp.set_header("X-Sha256", &hash_lower);
+            add_cors_headers(&mut resp);
+            Ok(resp)
+        }
+        Err(BlossomError::NotFound(_)) if filename == "master.m3u8" => {
+            let meta = metadata
+                .as_ref()
+                .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
+            match decide_transcode_fetch_action(
+                meta.transcode_status,
+                meta.transcode_retry_after,
+                meta.transcode_attempt_count,
+                meta.transcode_terminal,
+                unix_timestamp_secs(),
+            ) {
+                TranscodeFetchAction::Accepted {
+                    retry_after_secs, ..
+                }
+                | TranscodeFetchAction::Trigger {
+                    retry_after_secs, ..
+                } => {
+                    let mut resp = Response::from_status(StatusCode::ACCEPTED);
+                    resp.set_header("Retry-After", retry_after_secs.to_string());
+                    add_no_cache_headers(&mut resp);
+                    add_cors_headers(&mut resp);
+                    Ok(resp)
+                }
+                TranscodeFetchAction::Terminal => Ok(derivative_failure_head_response(
+                    &hash_lower,
+                    meta.transcode_error_code.as_deref(),
+                    content_type,
+                )),
+            }
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Download HLS content from GCS (with POP-local Simple Cache for non-range requests)
@@ -917,6 +996,18 @@ fn purge_transcript_content_cache(hash: &str) {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedTranscodeStatusWebhook {
+    sha256: String,
+    status: TranscodeStatus,
+    new_size: Option<u64>,
+    dim: Option<String>,
+    error_code: Option<String>,
+    error_message: Option<String>,
+    retry_after_epoch_secs: Option<u64>,
+    terminal: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct ParsedTranscriptStatusWebhook {
     sha256: String,
     status: TranscriptStatus,
@@ -927,6 +1018,7 @@ struct ParsedTranscriptStatusWebhook {
     error_code: Option<String>,
     error_message: Option<String>,
     retry_after_epoch_secs: Option<u64>,
+    terminal: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -945,16 +1037,83 @@ enum TranscriptFetchAction {
         retry_after_secs: u64,
         should_repair: bool,
     },
+    Terminal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TranscodeFetchAction {
+    Accepted {
+        state: TranscriptPendingState,
+        retry_after_secs: u64,
+    },
+    Trigger {
+        retry_after_secs: u64,
+        should_repair: bool,
+    },
+    Terminal,
 }
 
 fn parse_optional_retry_after_epoch(
     payload: &serde_json::Value,
     now_epoch_secs: u64,
 ) -> Option<u64> {
-    let retry_after_secs = payload["retry_after"]
-        .as_u64()
-        .or_else(|| payload["retry_after"].as_str().and_then(|value| value.parse().ok()))?;
+    let retry_after_secs = payload["retry_after"].as_u64().or_else(|| {
+        payload["retry_after"]
+            .as_str()
+            .and_then(|value| value.parse().ok())
+    })?;
     Some(now_epoch_secs.saturating_add(retry_after_secs))
+}
+
+fn parse_optional_bool(payload: &serde_json::Value, field: &str) -> Option<bool> {
+    payload[field]
+        .as_bool()
+        .or_else(|| payload[field].as_str().and_then(|value| value.parse().ok()))
+}
+
+fn parse_transcode_status_webhook_payload(
+    payload: &serde_json::Value,
+    now_epoch_secs: u64,
+) -> Result<ParsedTranscodeStatusWebhook> {
+    let sha256 = payload["sha256"]
+        .as_str()
+        .ok_or_else(|| BlossomError::BadRequest("Missing 'sha256' field".into()))?
+        .to_string();
+
+    let status_str = payload["status"]
+        .as_str()
+        .ok_or_else(|| BlossomError::BadRequest("Missing 'status' field".into()))?;
+
+    let status = match status_str.to_lowercase().as_str() {
+        "pending" => TranscodeStatus::Pending,
+        "processing" => TranscodeStatus::Processing,
+        "complete" | "completed" => TranscodeStatus::Complete,
+        "failed" | "error" => TranscodeStatus::Failed,
+        _ => {
+            return Err(BlossomError::BadRequest(format!(
+                "Unknown status: {}. Expected pending, processing, complete, or failed",
+                status_str
+            )));
+        }
+    };
+
+    let display_width = payload["display_width"].as_u64().map(|v| v as u32);
+    let display_height = payload["display_height"].as_u64().map(|v| v as u32);
+    let dim = match (display_width, display_height) {
+        (Some(w), Some(h)) if w > 0 && h > 0 => Some(format!("{}x{}", w, h)),
+        _ => None,
+    };
+
+    Ok(ParsedTranscodeStatusWebhook {
+        sha256,
+        status,
+        new_size: payload["new_size"].as_u64(),
+        dim,
+        error_code: payload["error_code"].as_str().map(|s| s.to_string()),
+        error_message: payload["error_message"].as_str().map(|s| s.to_string()),
+        retry_after_epoch_secs: parse_optional_retry_after_epoch(payload, now_epoch_secs),
+        terminal: parse_optional_bool(payload, "terminal").unwrap_or(false),
+    })
 }
 
 fn parse_transcript_status_webhook_payload(
@@ -993,14 +1152,24 @@ fn parse_transcript_status_webhook_payload(
         error_code: payload["error_code"].as_str().map(|s| s.to_string()),
         error_message: payload["error_message"].as_str().map(|s| s.to_string()),
         retry_after_epoch_secs: parse_optional_retry_after_epoch(payload, now_epoch_secs),
+        terminal: parse_optional_bool(payload, "terminal").unwrap_or(false),
     })
 }
 
 fn decide_transcript_fetch_action(
     status: Option<TranscriptStatus>,
     retry_after_epoch_secs: Option<u64>,
+    attempt_count: u32,
+    terminal: bool,
     now_epoch_secs: u64,
 ) -> TranscriptFetchAction {
+    if terminal
+        || (matches!(status, Some(TranscriptStatus::Failed))
+            && attempt_count >= DERIVATIVE_MAX_ATTEMPTS)
+    {
+        return TranscriptFetchAction::Terminal;
+    }
+
     if matches!(status, Some(TranscriptStatus::Processing)) {
         return TranscriptFetchAction::Accepted {
             state: TranscriptPendingState::InProgress,
@@ -1021,6 +1190,75 @@ fn decide_transcript_fetch_action(
         retry_after_secs: 10,
         should_repair: matches!(status, Some(TranscriptStatus::Complete)),
     }
+}
+
+fn decide_transcode_fetch_action(
+    status: Option<TranscodeStatus>,
+    retry_after_epoch_secs: Option<u64>,
+    attempt_count: u32,
+    terminal: bool,
+    now_epoch_secs: u64,
+) -> TranscodeFetchAction {
+    if terminal
+        || (matches!(status, Some(TranscodeStatus::Failed))
+            && attempt_count >= DERIVATIVE_MAX_ATTEMPTS)
+    {
+        return TranscodeFetchAction::Terminal;
+    }
+
+    if matches!(status, Some(TranscodeStatus::Processing)) {
+        return TranscodeFetchAction::Accepted {
+            state: TranscriptPendingState::InProgress,
+            retry_after_secs: 5,
+        };
+    }
+
+    if let Some(retry_after_epoch_secs) = retry_after_epoch_secs {
+        if retry_after_epoch_secs > now_epoch_secs {
+            return TranscodeFetchAction::Accepted {
+                state: TranscriptPendingState::CoolingDown,
+                retry_after_secs: retry_after_epoch_secs.saturating_sub(now_epoch_secs).max(1),
+            };
+        }
+    }
+
+    TranscodeFetchAction::Trigger {
+        retry_after_secs: 10,
+        should_repair: matches!(status, Some(TranscodeStatus::Complete)),
+    }
+}
+
+fn derivative_failure_response(
+    error_code: Option<&str>,
+    error_message: Option<&str>,
+    default_message: &str,
+) -> Response {
+    let body = serde_json::json!({
+        "status": "failed",
+        "error_code": error_code.unwrap_or("derivative_failed"),
+        "message": error_message.unwrap_or(default_message),
+        "retryable": false
+    });
+    let mut resp = json_response(StatusCode::UNPROCESSABLE_ENTITY, &body);
+    add_no_cache_headers(&mut resp);
+    add_cors_headers(&mut resp);
+    resp
+}
+
+fn derivative_failure_head_response(
+    hash: &str,
+    error_code: Option<&str>,
+    content_type: &str,
+) -> Response {
+    let mut resp = Response::from_status(StatusCode::UNPROCESSABLE_ENTITY);
+    resp.set_header("Content-Type", content_type);
+    resp.set_header("X-Sha256", hash);
+    if let Some(error_code) = error_code {
+        resp.set_header("X-Error-Code", error_code);
+    }
+    add_no_cache_headers(&mut resp);
+    add_cors_headers(&mut resp);
+    resp
 }
 
 fn serve_transcript_by_hash(
@@ -1066,6 +1304,17 @@ fn serve_transcript_by_hash(
 
     match download_transcript_content(&gcs_path) {
         Ok(mut resp) => {
+            if metadata.transcript_status != Some(TranscriptStatus::Complete) {
+                use crate::metadata::update_transcript_status;
+                let _ = update_transcript_status(
+                    hash,
+                    TranscriptStatus::Complete,
+                    TranscriptMetadataUpdate {
+                        last_attempt_at: Some(current_timestamp()),
+                        ..Default::default()
+                    },
+                );
+            }
             resp.set_header("Content-Type", "text/vtt; charset=utf-8");
             add_cache_headers(&mut resp, &hash);
             add_cors_headers(&mut resp);
@@ -1076,6 +1325,8 @@ fn serve_transcript_by_hash(
             match decide_transcript_fetch_action(
                 metadata.transcript_status,
                 metadata.transcript_retry_after,
+                metadata.transcript_attempt_count,
+                metadata.transcript_terminal,
                 unix_timestamp_secs(),
             ) {
                 TranscriptFetchAction::Accepted {
@@ -1129,6 +1380,11 @@ fn serve_transcript_by_hash(
                     add_cors_headers(&mut resp);
                     Ok(resp)
                 }
+                TranscriptFetchAction::Terminal => Ok(derivative_failure_response(
+                    metadata.transcript_error_code.as_deref(),
+                    metadata.transcript_error_message.as_deref(),
+                    "Transcript generation failed for this blob",
+                )),
             }
         }
         Err(e) => Err(e),
@@ -1177,29 +1433,52 @@ fn handle_head_transcript_by_hash(hash: &str) -> Result<Response> {
         ));
     }
 
-    match metadata.transcript_status {
-        Some(TranscriptStatus::Complete) => {
+    let gcs_path = format!("{}/vtt/main.vtt", hash);
+    match download_transcript_content(&gcs_path) {
+        Ok(_) => {
+            if metadata.transcript_status != Some(TranscriptStatus::Complete) {
+                use crate::metadata::update_transcript_status;
+                let _ = update_transcript_status(
+                    hash,
+                    TranscriptStatus::Complete,
+                    TranscriptMetadataUpdate {
+                        last_attempt_at: Some(current_timestamp()),
+                        ..Default::default()
+                    },
+                );
+            }
             let mut resp = Response::from_status(StatusCode::OK);
             resp.set_header("Content-Type", "text/vtt; charset=utf-8");
             add_cache_headers(&mut resp, hash);
             add_cors_headers(&mut resp);
             Ok(resp)
         }
-        Some(TranscriptStatus::Processing) => {
-            let mut resp = Response::from_status(StatusCode::ACCEPTED);
-            resp.set_header("Retry-After", "5");
-            add_no_cache_headers(&mut resp);
-            add_cors_headers(&mut resp);
-            Ok(resp)
-        }
-        Some(TranscriptStatus::Pending) => {
-            let mut resp = Response::from_status(StatusCode::ACCEPTED);
-            resp.set_header("Retry-After", "10");
-            add_no_cache_headers(&mut resp);
-            add_cors_headers(&mut resp);
-            Ok(resp)
-        }
-        _ => Err(BlossomError::NotFound("Transcript not available".into())),
+        Err(BlossomError::NotFound(_)) => match decide_transcript_fetch_action(
+            metadata.transcript_status,
+            metadata.transcript_retry_after,
+            metadata.transcript_attempt_count,
+            metadata.transcript_terminal,
+            unix_timestamp_secs(),
+        ) {
+            TranscriptFetchAction::Accepted {
+                retry_after_secs, ..
+            }
+            | TranscriptFetchAction::Trigger {
+                retry_after_secs, ..
+            } => {
+                let mut resp = Response::from_status(StatusCode::ACCEPTED);
+                resp.set_header("Retry-After", retry_after_secs.to_string());
+                add_no_cache_headers(&mut resp);
+                add_cors_headers(&mut resp);
+                Ok(resp)
+            }
+            TranscriptFetchAction::Terminal => Ok(derivative_failure_head_response(
+                hash,
+                metadata.transcript_error_code.as_deref(),
+                "text/vtt; charset=utf-8",
+            )),
+        },
+        Err(e) => Err(e),
     }
 }
 
@@ -1262,15 +1541,14 @@ fn dispatch_subtitle_job(job: &mut SubtitleJob, owner: &str) -> Result<()> {
     job.error_code = None;
     job.error_message = None;
     put_subtitle_job(job)?;
-    let _ =
-        crate::metadata::update_transcript_status(
-            &job.video_sha256,
-            TranscriptStatus::Processing,
-            TranscriptMetadataUpdate {
-                last_attempt_at: Some(current_timestamp()),
-                ..Default::default()
-            },
-        );
+    let _ = crate::metadata::update_transcript_status(
+        &job.video_sha256,
+        TranscriptStatus::Processing,
+        TranscriptMetadataUpdate {
+            last_attempt_at: Some(current_timestamp()),
+            ..Default::default()
+        },
+    );
 
     let lang_for_provider = job
         .language
@@ -1496,8 +1774,8 @@ fn handle_get_audio(_req: Request, path: &str) -> Result<Response> {
         .ok_or_else(|| BlossomError::BadRequest("Invalid hash in audio path".into()))?;
 
     // 1. Look up source blob metadata
-    let metadata = get_blob_metadata(&hash)?
-        .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
+    let metadata =
+        get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     // 2. Access control: banned/deleted content is not served
     if metadata.status.blocks_public_access() {
@@ -1577,9 +1855,9 @@ fn handle_get_audio(_req: Request, path: &str) -> Result<Response> {
         )));
     }
 
-    let audio_sha256 = extraction.audio_sha256.ok_or_else(|| {
-        BlossomError::Internal("Audio extraction returned no hash".into())
-    })?;
+    let audio_sha256 = extraction
+        .audio_sha256
+        .ok_or_else(|| BlossomError::Internal("Audio extraction returned no hash".into()))?;
     let duration = extraction.duration.unwrap_or(0.0);
     let size = extraction.size.unwrap_or(0);
     let mime_type = extraction
@@ -1598,12 +1876,20 @@ fn handle_get_audio(_req: Request, path: &str) -> Result<Response> {
         thumbnail: None,
         moderation: None,
         transcode_status: None,
+        transcode_error_code: None,
+        transcode_error_message: None,
+        transcode_last_attempt_at: None,
+        transcode_retry_after: None,
+        transcode_attempt_count: 0,
+        transcode_terminal: false,
         dim: None,
         transcript_status: None,
         transcript_error_code: None,
         transcript_error_message: None,
         transcript_last_attempt_at: None,
         transcript_retry_after: None,
+        transcript_attempt_count: 0,
+        transcript_terminal: false,
     };
     let _ = put_blob_metadata(&audio_metadata);
 
@@ -1635,8 +1921,8 @@ fn handle_head_audio(path: &str) -> Result<Response> {
     let hash = parse_audio_path(path)
         .ok_or_else(|| BlossomError::BadRequest("Invalid hash in audio path".into()))?;
 
-    let metadata = get_blob_metadata(&hash)?
-        .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
+    let metadata =
+        get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     if metadata.status.blocks_public_access() || metadata.status.requires_owner_auth() {
         return Err(BlossomError::NotFound("Blob not found".into()));
@@ -1824,22 +2110,23 @@ const CLOUD_RUN_TRANSCODER_HOST: &str = "divine-transcoder-149672065768.us-centr
 /// Generate thumbnail on-demand by proxying to Cloud Run
 fn generate_thumbnail_on_demand(hash: &str) -> Result<Response> {
     if crate::storage::is_local_mode() {
-        eprintln!("[THUMB][LOCAL] Returning placeholder thumbnail for {}", hash);
+        eprintln!(
+            "[THUMB][LOCAL] Returning placeholder thumbnail for {}",
+            hash
+        );
         // Minimal valid JPEG (smallest possible)
         let jpeg: Vec<u8> = vec![
-            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
-            0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43,
-            0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08, 0x07, 0x07, 0x07, 0x09,
-            0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B, 0x0C, 0x19, 0x12,
-            0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20,
-            0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29,
-            0x2C, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32,
-            0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01,
-            0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xC4, 0x00, 0x1F, 0x00, 0x00,
-            0x01, 0x05, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-            0x09, 0x0A, 0x0B, 0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3F,
-            0x00, 0x7B, 0x94, 0x11, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xD9,
+            0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00,
+            0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43, 0x00, 0x08, 0x06, 0x06,
+            0x07, 0x06, 0x05, 0x08, 0x07, 0x07, 0x07, 0x09, 0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D,
+            0x0C, 0x0B, 0x0B, 0x0C, 0x19, 0x12, 0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D,
+            0x1A, 0x1C, 0x1C, 0x20, 0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28,
+            0x37, 0x29, 0x2C, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32,
+            0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01, 0x00, 0x01,
+            0x01, 0x01, 0x11, 0x00, 0xFF, 0xC4, 0x00, 0x1F, 0x00, 0x00, 0x01, 0x05, 0x01, 0x01,
+            0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02,
+            0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0xFF, 0xDA, 0x00, 0x08, 0x01,
+            0x01, 0x00, 0x00, 0x3F, 0x00, 0x7B, 0x94, 0x11, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xD9,
         ];
         let thumb_key = format!("{}.jpg", hash);
         if let Err(e) = crate::storage::upload_blob(
@@ -2038,7 +2325,11 @@ fn trigger_on_demand_transcription(
             owner,
         )?;
         use crate::metadata::{update_transcript_status, TranscriptMetadataUpdate};
-        update_transcript_status(hash, crate::blossom::TranscriptStatus::Complete, TranscriptMetadataUpdate::default())?;
+        update_transcript_status(
+            hash,
+            crate::blossom::TranscriptStatus::Complete,
+            TranscriptMetadataUpdate::default(),
+        )?;
         if let Some(id) = job_id {
             if let Ok(Some(mut job)) = crate::metadata::get_subtitle_job(id) {
                 job.status = crate::blossom::SubtitleJobStatus::Ready;
@@ -2090,7 +2381,10 @@ const MODERATION_API_BACKEND: &str = "moderation_api";
 /// Fire-and-forget — upload should never fail because moderation is down.
 fn trigger_moderation_scan(sha256: &str, pubkey: &str) {
     if crate::storage::is_local_mode() {
-        eprintln!("[MODERATION][LOCAL] Auto-approving {} for {}", sha256, pubkey);
+        eprintln!(
+            "[MODERATION][LOCAL] Auto-approving {} for {}",
+            sha256, pubkey
+        );
         let _ = crate::metadata::update_blob_status(sha256, crate::blossom::BlobStatus::Active);
         return;
     }
@@ -2239,6 +2533,12 @@ fn handle_upload(mut req: Request) -> Result<Response> {
         } else {
             None
         },
+        transcode_error_code: None,
+        transcode_error_message: None,
+        transcode_last_attempt_at: None,
+        transcode_retry_after: None,
+        transcode_attempt_count: 0,
+        transcode_terminal: false,
         dim: None, // Set by transcoder webhook when transcoding completes
         transcript_status: if is_transcribable_mime_type(&content_type) {
             Some(TranscriptStatus::Pending)
@@ -2249,6 +2549,8 @@ fn handle_upload(mut req: Request) -> Result<Response> {
         transcript_error_message: None,
         transcript_last_attempt_at: None,
         transcript_retry_after: None,
+        transcript_attempt_count: 0,
+        transcript_terminal: false,
     };
 
     put_blob_metadata(&metadata)?;
@@ -2372,6 +2674,30 @@ fn handle_cloud_run_proxy(
 
     // Parse video dimensions if present (from ffprobe in upload service)
     let dim = cloud_run_resp["dim"].as_str().map(|s| s.to_string());
+    let transcode_error_code = cloud_run_resp["transcode_error_code"]
+        .as_str()
+        .map(|s| s.to_string());
+    let transcode_error_message = cloud_run_resp["transcode_error_message"]
+        .as_str()
+        .map(|s| s.to_string());
+    let transcode_terminal =
+        parse_optional_bool(&cloud_run_resp, "transcode_terminal").unwrap_or(false);
+    let transcript_error_code = cloud_run_resp["transcript_error_code"]
+        .as_str()
+        .map(|s| s.to_string());
+    let transcript_error_message = cloud_run_resp["transcript_error_message"]
+        .as_str()
+        .map(|s| s.to_string());
+    let transcript_terminal =
+        parse_optional_bool(&cloud_run_resp, "transcript_terminal").unwrap_or(false);
+    let has_transcode_error = transcode_error_code.is_some();
+    let has_transcript_error = transcript_error_code.is_some();
+    let derivative_failure_recorded_at =
+        if transcode_error_code.is_some() || transcript_error_code.is_some() {
+            Some(current_timestamp())
+        } else {
+            None
+        };
 
     // Check if metadata already exists (dedupe/re-upload case)
     if let Some(mut metadata) = get_blob_metadata(&hash)? {
@@ -2379,11 +2705,35 @@ fn handle_cloud_run_proxy(
         let _ = add_to_user_list(&auth.pubkey, &hash);
         let _ = add_to_blob_refs(&hash, &auth.pubkey);
 
+        if thumbnail_url.is_some() && metadata.thumbnail.is_none() {
+            metadata.thumbnail = thumbnail_url.clone();
+        }
         // Even for dedupe, update dim if we got it and it wasn't set before
         if dim.is_some() && metadata.dim.is_none() {
-            metadata.dim = dim;
+            metadata.dim = dim.clone();
         }
-        if is_transcribable_mime_type(&metadata.mime_type) && metadata.transcript_status.is_none() {
+        if let Some(ref error_code) = transcode_error_code {
+            metadata.transcode_status = Some(TranscodeStatus::Failed);
+            metadata.transcode_error_code = Some(error_code.clone());
+            metadata.transcode_error_message = transcode_error_message.clone();
+            metadata.transcode_last_attempt_at = derivative_failure_recorded_at.clone();
+            metadata.transcode_retry_after = None;
+            metadata.transcode_attempt_count = metadata.transcode_attempt_count.max(1);
+            metadata.transcode_terminal = transcode_terminal;
+        } else if is_video_mime_type(&metadata.mime_type) && metadata.transcode_status.is_none() {
+            metadata.transcode_status = Some(TranscodeStatus::Pending);
+        }
+        if let Some(ref error_code) = transcript_error_code {
+            metadata.transcript_status = Some(TranscriptStatus::Failed);
+            metadata.transcript_error_code = Some(error_code.clone());
+            metadata.transcript_error_message = transcript_error_message.clone();
+            metadata.transcript_last_attempt_at = derivative_failure_recorded_at.clone();
+            metadata.transcript_retry_after = None;
+            metadata.transcript_attempt_count = metadata.transcript_attempt_count.max(1);
+            metadata.transcript_terminal = transcript_terminal;
+        } else if is_transcribable_mime_type(&metadata.mime_type)
+            && metadata.transcript_status.is_none()
+        {
             metadata.transcript_status = Some(TranscriptStatus::Pending);
         }
         let _ = put_blob_metadata(&metadata);
@@ -2405,20 +2755,46 @@ fn handle_cloud_run_proxy(
         thumbnail: thumbnail_url,
         moderation: None,
         transcode_status: if is_video_mime_type(&content_type) {
-            Some(TranscodeStatus::Pending)
+            if transcode_error_code.is_some() {
+                Some(TranscodeStatus::Failed)
+            } else {
+                Some(TranscodeStatus::Pending)
+            }
         } else {
             None
         },
+        transcode_error_code,
+        transcode_error_message,
+        transcode_last_attempt_at: derivative_failure_recorded_at.clone(),
+        transcode_retry_after: None,
+        transcode_attempt_count: if is_video_mime_type(&content_type) && has_transcode_error {
+            1
+        } else {
+            0
+        },
+        transcode_terminal,
         dim: dim.clone(), // From ffprobe in upload service; updated by transcoder webhook
         transcript_status: if is_transcribable_mime_type(&content_type) {
-            Some(TranscriptStatus::Pending)
+            if transcript_error_code.is_some() {
+                Some(TranscriptStatus::Failed)
+            } else {
+                Some(TranscriptStatus::Pending)
+            }
         } else {
             None
         },
-        transcript_error_code: None,
-        transcript_error_message: None,
-        transcript_last_attempt_at: None,
+        transcript_error_code,
+        transcript_error_message,
+        transcript_last_attempt_at: derivative_failure_recorded_at,
         transcript_retry_after: None,
+        transcript_attempt_count: if is_transcribable_mime_type(&content_type)
+            && has_transcript_error
+        {
+            1
+        } else {
+            0
+        },
+        transcript_terminal,
     };
 
     put_blob_metadata(&metadata)?;
@@ -3223,6 +3599,12 @@ fn handle_mirror(mut req: Request) -> Result<Response> {
         } else {
             None
         },
+        transcode_error_code: None,
+        transcode_error_message: None,
+        transcode_last_attempt_at: None,
+        transcode_retry_after: None,
+        transcode_attempt_count: 0,
+        transcode_terminal: false,
         dim: None, // Set by transcoder webhook when transcoding completes
         transcript_status: if is_transcribable_mime_type(&content_type) {
             Some(TranscriptStatus::Pending)
@@ -3233,6 +3615,8 @@ fn handle_mirror(mut req: Request) -> Result<Response> {
         transcript_error_message: None,
         transcript_last_attempt_at: None,
         transcript_retry_after: None,
+        transcript_attempt_count: 0,
+        transcript_terminal: false,
     };
 
     put_blob_metadata(&metadata)?;
@@ -3437,7 +3821,11 @@ fn handle_admin_backfill_vtt(req: Request) -> Result<Response> {
             }
         }
 
-        (end < total_hashes, if end < total_hashes { Some(end) } else { None }, None)
+        (
+            end < total_hashes,
+            if end < total_hashes { Some(end) } else { None },
+            None,
+        )
     } else {
         let user_index = crate::metadata::get_user_index()?;
         let total_users = user_index.pubkeys.len();
@@ -3658,28 +4046,17 @@ fn handle_transcode_status(mut req: Request) -> Result<Response> {
     let payload: serde_json::Value = serde_json::from_str(&body)
         .map_err(|e| BlossomError::BadRequest(format!("Invalid JSON: {}", e)))?;
 
-    let sha256 = payload["sha256"]
-        .as_str()
-        .ok_or_else(|| BlossomError::BadRequest("Missing 'sha256' field".into()))?;
-
-    let status_str = payload["status"]
-        .as_str()
-        .ok_or_else(|| BlossomError::BadRequest("Missing 'status' field".into()))?;
-
-    // Optional new_size field - provided when faststart optimization replaces the original file
-    let new_size = payload["new_size"].as_u64();
-
-    // Optional display dimensions from transcoder's ffprobe
-    let display_width = payload["display_width"].as_u64().map(|v| v as u32);
-    let display_height = payload["display_height"].as_u64().map(|v| v as u32);
-    let dim = match (display_width, display_height) {
-        (Some(w), Some(h)) if w > 0 && h > 0 => Some(format!("{}x{}", w, h)),
-        _ => None,
-    };
+    let parsed = parse_transcode_status_webhook_payload(&payload, unix_timestamp_secs())?;
+    let sha256 = parsed.sha256.as_str();
 
     eprintln!(
-        "[TRANSCODE] Status webhook: sha256={}, status={}, new_size={:?}, dim={:?}",
-        sha256, status_str, new_size, dim
+        "[TRANSCODE] Status webhook: sha256={}, status={:?}, new_size={:?}, dim={:?}, error_code={:?}, terminal={}",
+        sha256,
+        parsed.status,
+        parsed.new_size,
+        parsed.dim,
+        parsed.error_code,
+        parsed.terminal
     );
 
     // Validate sha256 format
@@ -3687,45 +4064,44 @@ fn handle_transcode_status(mut req: Request) -> Result<Response> {
         return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
     }
 
-    // Map status string to TranscodeStatus
-    let new_status = match status_str.to_lowercase().as_str() {
-        "pending" => TranscodeStatus::Pending,
-        "processing" => TranscodeStatus::Processing,
-        "complete" | "completed" => TranscodeStatus::Complete,
-        "failed" | "error" => TranscodeStatus::Failed,
-        _ => {
-            return Err(BlossomError::BadRequest(format!(
-                "Unknown status: {}. Expected pending, processing, complete, or failed",
-                status_str
-            )));
-        }
-    };
-
     // Update transcode status (and optionally file size and dimensions if provided)
-    use crate::metadata::update_transcode_status_with_size;
-    match update_transcode_status_with_size(sha256, new_status, new_size, dim.clone()) {
+    use crate::metadata::update_transcode_status_with_metadata;
+    match update_transcode_status_with_metadata(
+        sha256,
+        parsed.status,
+        parsed.new_size,
+        parsed.dim.clone(),
+        TranscodeMetadataUpdate {
+            error_code: parsed.error_code.clone(),
+            error_message: parsed.error_message.clone(),
+            last_attempt_at: Some(current_timestamp()),
+            retry_after: parsed.retry_after_epoch_secs,
+            terminal: Some(parsed.terminal),
+            increment_attempt_count: matches!(parsed.status, TranscodeStatus::Failed),
+        },
+    ) {
         Ok(()) => {
-            if let Some(ref d) = dim {
+            if let Some(ref d) = parsed.dim {
                 eprintln!(
                     "[TRANSCODE] Updated blob {} to transcode status {:?} with dim {}",
-                    sha256, new_status, d
+                    sha256, parsed.status, d
                 );
-            } else if let Some(size) = new_size {
+            } else if let Some(size) = parsed.new_size {
                 eprintln!(
                     "[TRANSCODE] Updated blob {} to transcode status {:?} with new size {}",
-                    sha256, new_status, size
+                    sha256, parsed.status, size
                 );
             } else {
                 eprintln!(
                     "[TRANSCODE] Updated blob {} to transcode status {:?}",
-                    sha256, new_status
+                    sha256, parsed.status
                 );
             }
 
             // Purge VCL cache on transcode completion so any cached 202 is evicted
             // and clients get the actual content on next request.
             if matches!(
-                new_status,
+                parsed.status,
                 TranscodeStatus::Complete | TranscodeStatus::Failed
             ) {
                 purge_vcl_cache(sha256);
@@ -3734,7 +4110,7 @@ fn handle_transcode_status(mut req: Request) -> Result<Response> {
             let response = serde_json::json!({
                 "success": true,
                 "sha256": sha256,
-                "transcode_status": format!("{:?}", new_status).to_lowercase(),
+                "transcode_status": format!("{:?}", parsed.status).to_lowercase(),
                 "message": "Transcode status updated"
             });
             let mut resp = json_response(StatusCode::OK, &response);
@@ -3825,6 +4201,8 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
             error_message: parsed.error_message.clone(),
             last_attempt_at: Some(current_timestamp()),
             retry_after: parsed.retry_after_epoch_secs,
+            terminal: Some(parsed.terminal),
+            increment_attempt_count: matches!(parsed.status, TranscriptStatus::Failed),
         },
     ) {
         Ok(()) => {
@@ -4450,10 +4828,11 @@ fn infer_mime_from_path(path: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        decide_transcript_fetch_action, is_quality_variant_path, parse_quality_variant_path,
-        parse_transcript_status_webhook_payload, TranscriptFetchAction, TranscriptPendingState,
+        decide_transcode_fetch_action, decide_transcript_fetch_action, is_quality_variant_path,
+        parse_quality_variant_path, parse_transcript_status_webhook_payload, TranscodeFetchAction,
+        TranscriptFetchAction, TranscriptPendingState,
     };
-    use crate::blossom::TranscriptStatus;
+    use crate::blossom::{TranscodeStatus, TranscriptStatus};
 
     #[test]
     fn quality_variant_path_valid() {
@@ -4497,14 +4876,12 @@ mod tests {
         let hash = "a".repeat(64);
 
         // 720p.mp4 derives correct .ts counterpart for backfill check
-        let (_, filename, ct) =
-            parse_quality_variant_path(&format!("/{}/720p.mp4", hash)).unwrap();
+        let (_, filename, ct) = parse_quality_variant_path(&format!("/{}/720p.mp4", hash)).unwrap();
         assert_eq!(ct, "video/mp4");
         assert_eq!(filename.replace(".mp4", ".ts"), "stream_720p.ts");
 
         // 480p.mp4 likewise
-        let (_, filename, ct) =
-            parse_quality_variant_path(&format!("/{}/480p.mp4", hash)).unwrap();
+        let (_, filename, ct) = parse_quality_variant_path(&format!("/{}/480p.mp4", hash)).unwrap();
         assert_eq!(ct, "video/mp4");
         assert_eq!(filename.replace(".mp4", ".ts"), "stream_480p.ts");
 
@@ -4550,6 +4927,8 @@ mod tests {
             decide_transcript_fetch_action(
                 Some(TranscriptStatus::Failed),
                 Some(1_030),
+                1,
+                false,
                 1_000,
             ),
             TranscriptFetchAction::Accepted {
@@ -4565,6 +4944,8 @@ mod tests {
             decide_transcript_fetch_action(
                 Some(TranscriptStatus::Processing),
                 None,
+                0,
+                false,
                 1_000,
             ),
             TranscriptFetchAction::Accepted {
@@ -4577,11 +4958,7 @@ mod tests {
     #[test]
     fn transcript_fetch_action_triggers_pending_items_without_cooldown() {
         assert_eq!(
-            decide_transcript_fetch_action(
-                Some(TranscriptStatus::Pending),
-                None,
-                1_000,
-            ),
+            decide_transcript_fetch_action(Some(TranscriptStatus::Pending), None, 0, false, 1_000,),
             TranscriptFetchAction::Trigger {
                 retry_after_secs: 10,
                 should_repair: false,
@@ -4592,12 +4969,65 @@ mod tests {
     #[test]
     fn transcript_fetch_action_repairs_missing_vtt_for_complete_status() {
         assert_eq!(
-            decide_transcript_fetch_action(
-                Some(TranscriptStatus::Complete),
-                None,
-                1_000,
-            ),
+            decide_transcript_fetch_action(Some(TranscriptStatus::Complete), None, 0, false, 1_000,),
             TranscriptFetchAction::Trigger {
+                retry_after_secs: 10,
+                should_repair: true,
+            }
+        );
+    }
+
+    #[test]
+    fn transcript_fetch_action_retries_failed_items_under_cap() {
+        assert_eq!(
+            decide_transcript_fetch_action(Some(TranscriptStatus::Failed), None, 2, false, 1_000,),
+            TranscriptFetchAction::Trigger {
+                retry_after_secs: 10,
+                should_repair: false,
+            }
+        );
+    }
+
+    #[test]
+    fn transcript_fetch_action_stops_retrying_at_cap() {
+        assert_eq!(
+            decide_transcript_fetch_action(Some(TranscriptStatus::Failed), None, 3, false, 1_000,),
+            TranscriptFetchAction::Terminal
+        );
+    }
+
+    #[test]
+    fn transcript_fetch_action_honors_terminal_failure() {
+        assert_eq!(
+            decide_transcript_fetch_action(Some(TranscriptStatus::Failed), None, 1, true, 1_000,),
+            TranscriptFetchAction::Terminal
+        );
+    }
+
+    #[test]
+    fn transcode_fetch_action_retries_failed_items_under_cap() {
+        assert_eq!(
+            decide_transcode_fetch_action(Some(TranscodeStatus::Failed), None, 2, false, 1_000,),
+            TranscodeFetchAction::Trigger {
+                retry_after_secs: 10,
+                should_repair: false,
+            }
+        );
+    }
+
+    #[test]
+    fn transcode_fetch_action_stops_retrying_at_cap() {
+        assert_eq!(
+            decide_transcode_fetch_action(Some(TranscodeStatus::Failed), None, 3, false, 1_000,),
+            TranscodeFetchAction::Terminal
+        );
+    }
+
+    #[test]
+    fn transcode_fetch_action_repairs_missing_manifest_for_complete_status() {
+        assert_eq!(
+            decide_transcode_fetch_action(Some(TranscodeStatus::Complete), None, 0, false, 1_000,),
+            TranscodeFetchAction::Trigger {
                 retry_after_secs: 10,
                 should_repair: true,
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -606,6 +606,28 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
     }
     let hash = hash.to_lowercase();
 
+    // Check metadata for moderation/access control
+    let is_admin = admin::validate_bearer_token(&req).is_ok();
+    let mut is_restricted = false;
+
+    if let Ok(Some(ref meta)) = get_blob_metadata(&hash) {
+        if !is_admin {
+            if meta.status == BlobStatus::Banned {
+                return Err(BlossomError::NotFound("Blob not found".into()));
+            }
+            if meta.status == BlobStatus::Restricted {
+                if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
+                    if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
+                        return Err(BlossomError::NotFound("Blob not found".into()));
+                    }
+                } else {
+                    return Err(BlossomError::NotFound("Blob not found".into()));
+                }
+                is_restricted = true;
+            }
+        }
+    }
+
     // Construct GCS path
     let gcs_path = format!("{}/hls/{}", hash, filename);
 
@@ -629,7 +651,11 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
             };
 
             resp.set_header("Content-Type", content_type);
-            add_cache_headers(&mut resp, &hash);
+            if is_restricted {
+                add_private_cache_headers(&mut resp, &hash);
+            } else {
+                add_cache_headers(&mut resp, &hash);
+            }
             resp.set_header("X-Sha256", &hash);
             if let Some(c2pa) = c2pa_manifest_id {
                 resp.set_header("X-C2PA-Manifest-Id", &c2pa);
@@ -643,14 +669,8 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
         Err(BlossomError::NotFound(_)) if filename == "master.m3u8" => {
             // HLS not found - check metadata and trigger on-demand transcoding
             let metadata = get_blob_metadata(&hash)?;
-            let is_admin = admin::validate_bearer_token(&req).is_ok();
 
             if let Some(ref meta) = metadata {
-                // Handle banned content
-                if !is_admin && meta.status == BlobStatus::Banned {
-                    return Err(BlossomError::NotFound("Content not found".into()));
-                }
-
                 match meta.transcode_status {
                     Some(TranscodeStatus::Complete) => {
                         // Metadata says complete but file not in GCS - re-trigger
@@ -737,8 +757,17 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
         return Err(BlossomError::BadRequest("Invalid hash in path".into()));
     }
 
+    let hash_lower = hash.to_lowercase();
+
+    // Check moderation status — HEAD has no auth, so block both banned and restricted
+    if let Ok(Some(ref meta)) = get_blob_metadata(&hash_lower) {
+        if meta.status == BlobStatus::Banned || meta.status == BlobStatus::Restricted {
+            return Err(BlossomError::NotFound("Content not found".into()));
+        }
+    }
+
     // Check if file exists in GCS
-    let gcs_path = format!("{}/hls/{}", hash.to_lowercase(), filename);
+    let gcs_path = format!("{}/hls/{}", hash_lower, filename);
 
     // Try to get the content (HEAD-like check)
     download_hls_content(&gcs_path, None)?;
@@ -752,7 +781,6 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
     };
 
     let mut resp = Response::from_status(StatusCode::OK);
-    let hash_lower = hash.to_lowercase();
     resp.set_header("Content-Type", content_type);
     add_cache_headers(&mut resp, &hash_lower);
     resp.set_header("X-Sha256", &hash_lower);

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,7 +1,9 @@
 // ABOUTME: Fastly KV store operations for blob metadata
 // ABOUTME: Handles blob metadata and per-user blob lists
 
-use crate::blossom::{AudioMapping, BlobMetadata, BlobStatus, GlobalStats, RecentIndex, SubtitleJob, UserIndex};
+use crate::blossom::{
+    AudioMapping, BlobMetadata, BlobStatus, GlobalStats, RecentIndex, SubtitleJob, UserIndex,
+};
 use crate::error::{BlossomError, Result};
 use fastly::cache::simple as simple_cache;
 use fastly::kv_store::{KVStore, KVStoreError};
@@ -258,10 +260,75 @@ pub fn update_blob_status(hash: &str, status: BlobStatus) -> Result<()> {
 
 /// Update transcode status for a video blob
 pub fn update_transcode_status(hash: &str, status: crate::blossom::TranscodeStatus) -> Result<()> {
+    update_transcode_status_with_metadata(
+        hash,
+        status,
+        None,
+        None,
+        TranscodeMetadataUpdate::default(),
+    )
+}
+
+/// Additional metadata recorded alongside transcode status updates.
+#[derive(Debug, Clone, Default)]
+pub struct TranscodeMetadataUpdate {
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+    pub last_attempt_at: Option<String>,
+    pub retry_after: Option<u64>,
+    pub terminal: Option<bool>,
+    pub increment_attempt_count: bool,
+}
+
+/// Update transcode status and associated failure metadata for a video blob.
+pub fn update_transcode_status_with_metadata(
+    hash: &str,
+    status: crate::blossom::TranscodeStatus,
+    new_size: Option<u64>,
+    dim: Option<String>,
+    update: TranscodeMetadataUpdate,
+) -> Result<()> {
     let mut metadata =
         get_blob_metadata(hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     metadata.transcode_status = Some(status);
+    match status {
+        crate::blossom::TranscodeStatus::Failed => {
+            if update.increment_attempt_count {
+                metadata.transcode_attempt_count =
+                    metadata.transcode_attempt_count.saturating_add(1);
+            }
+            metadata.transcode_error_code = update.error_code;
+            metadata.transcode_error_message = update.error_message;
+            metadata.transcode_last_attempt_at = update.last_attempt_at;
+            metadata.transcode_retry_after = update.retry_after;
+            metadata.transcode_terminal = update.terminal.unwrap_or(false);
+        }
+        crate::blossom::TranscodeStatus::Complete => {
+            metadata.transcode_error_code = None;
+            metadata.transcode_error_message = None;
+            metadata.transcode_last_attempt_at = update.last_attempt_at;
+            metadata.transcode_retry_after = None;
+            metadata.transcode_attempt_count = 0;
+            metadata.transcode_terminal = false;
+        }
+        crate::blossom::TranscodeStatus::Processing | crate::blossom::TranscodeStatus::Pending => {
+            metadata.transcode_error_code = update.error_code;
+            metadata.transcode_error_message = update.error_message;
+            metadata.transcode_last_attempt_at = update.last_attempt_at;
+            metadata.transcode_retry_after = update.retry_after;
+            metadata.transcode_terminal = update.terminal.unwrap_or(false);
+        }
+    }
+
+    if let Some(size) = new_size {
+        metadata.size = size;
+    }
+
+    if let Some(d) = dim {
+        metadata.dim = Some(d);
+    }
+
     put_blob_metadata(&metadata)?;
 
     Ok(())
@@ -274,6 +341,8 @@ pub struct TranscriptMetadataUpdate {
     pub error_message: Option<String>,
     pub last_attempt_at: Option<String>,
     pub retry_after: Option<u64>,
+    pub terminal: Option<bool>,
+    pub increment_attempt_count: bool,
 }
 
 pub fn update_transcript_status(
@@ -285,10 +354,35 @@ pub fn update_transcript_status(
         get_blob_metadata(hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     metadata.transcript_status = Some(status);
-    metadata.transcript_error_code = update.error_code;
-    metadata.transcript_error_message = update.error_message;
-    metadata.transcript_last_attempt_at = update.last_attempt_at;
-    metadata.transcript_retry_after = update.retry_after;
+    match status {
+        crate::blossom::TranscriptStatus::Failed => {
+            if update.increment_attempt_count {
+                metadata.transcript_attempt_count =
+                    metadata.transcript_attempt_count.saturating_add(1);
+            }
+            metadata.transcript_error_code = update.error_code;
+            metadata.transcript_error_message = update.error_message;
+            metadata.transcript_last_attempt_at = update.last_attempt_at;
+            metadata.transcript_retry_after = update.retry_after;
+            metadata.transcript_terminal = update.terminal.unwrap_or(false);
+        }
+        crate::blossom::TranscriptStatus::Complete => {
+            metadata.transcript_error_code = None;
+            metadata.transcript_error_message = None;
+            metadata.transcript_last_attempt_at = update.last_attempt_at;
+            metadata.transcript_retry_after = None;
+            metadata.transcript_attempt_count = 0;
+            metadata.transcript_terminal = false;
+        }
+        crate::blossom::TranscriptStatus::Processing
+        | crate::blossom::TranscriptStatus::Pending => {
+            metadata.transcript_error_code = update.error_code;
+            metadata.transcript_error_message = update.error_message;
+            metadata.transcript_last_attempt_at = update.last_attempt_at;
+            metadata.transcript_retry_after = update.retry_after;
+            metadata.transcript_terminal = update.terminal.unwrap_or(false);
+        }
+    }
     put_blob_metadata(&metadata)?;
 
     Ok(())
@@ -380,24 +474,13 @@ pub fn update_transcode_status_with_size(
     new_size: Option<u64>,
     dim: Option<String>,
 ) -> Result<()> {
-    let mut metadata =
-        get_blob_metadata(hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
-
-    metadata.transcode_status = Some(status);
-
-    // Update size if provided (faststart optimization replaced the original file)
-    if let Some(size) = new_size {
-        metadata.size = size;
-    }
-
-    // Update display dimensions if provided by transcoder
-    if let Some(d) = dim {
-        metadata.dim = Some(d);
-    }
-
-    put_blob_metadata(&metadata)?;
-
-    Ok(())
+    update_transcode_status_with_metadata(
+        hash,
+        status,
+        new_size,
+        dim,
+        TranscodeMetadataUpdate::default(),
+    )
 }
 
 /// Check if user owns the blob
@@ -1028,10 +1111,11 @@ pub fn put_audio_mapping(mapping: &AudioMapping) -> Result<()> {
         AUDIO_MAP_PREFIX,
         mapping.source_sha256.to_lowercase()
     );
-    let json = serde_json::to_string(mapping)
-        .map_err(|e| BlossomError::MetadataError(format!("Failed to serialize audio mapping: {}", e)))?;
-    store
-        .insert(&key, json)
-        .map_err(|e| BlossomError::MetadataError(format!("Failed to store audio mapping: {}", e)))?;
+    let json = serde_json::to_string(mapping).map_err(|e| {
+        BlossomError::MetadataError(format!("Failed to serialize audio mapping: {}", e))
+    })?;
+    store.insert(&key, json).map_err(|e| {
+        BlossomError::MetadataError(format!("Failed to store audio mapping: {}", e))
+    })?;
     Ok(())
 }

--- a/vcl/deliver.vcl
+++ b/vcl/deliver.vcl
@@ -25,21 +25,7 @@ if (obj.hits > 0) {
   set resp.http.X-Cache = "MISS";
 }
 
-# Preserve wildcard CORS for public media/read responses. Sanitize everything
-# else to the approved browser origins only.
-if (resp.http.Access-Control-Allow-Origin == "*") {
-  unset resp.http.Vary;
-} else {
-  unset resp.http.Access-Control-Allow-Origin;
-  if (req.http.Origin == "https://app.divine.video" ||
-      req.http.Origin ~ "^https://[^.]+\\.openvine-app\\.pages\\.dev$") {
-    set resp.http.Access-Control-Allow-Origin = req.http.Origin;
-    if (resp.http.Vary) {
-      if (resp.http.Vary !~ "(?i)\\bOrigin\\b") {
-        set resp.http.Vary = resp.http.Vary ", Origin";
-      }
-    } else {
-      set resp.http.Vary = "Origin";
-    }
-  }
+# Ensure CORS headers are present (Compute sets them, but belt-and-suspenders)
+if (!resp.http.Access-Control-Allow-Origin) {
+  set resp.http.Access-Control-Allow-Origin = "*";
 }

--- a/vcl/deliver.vcl
+++ b/vcl/deliver.vcl
@@ -25,7 +25,16 @@ if (obj.hits > 0) {
   set resp.http.X-Cache = "MISS";
 }
 
-# Ensure CORS headers are present (Compute sets them, but belt-and-suspenders)
-if (!resp.http.Access-Control-Allow-Origin) {
-  set resp.http.Access-Control-Allow-Origin = "*";
+# Sanitize CORS to the approved browser origins only.
+unset resp.http.Access-Control-Allow-Origin;
+if (req.http.Origin == "https://app.divine.video" ||
+    req.http.Origin ~ "^https://[^.]+\\.openvine-app\\.pages\\.dev$") {
+  set resp.http.Access-Control-Allow-Origin = req.http.Origin;
+  if (resp.http.Vary) {
+    if (resp.http.Vary !~ "(?i)\\bOrigin\\b") {
+      set resp.http.Vary = resp.http.Vary ", Origin";
+    }
+  } else {
+    set resp.http.Vary = "Origin";
+  }
 }

--- a/vcl/deliver.vcl
+++ b/vcl/deliver.vcl
@@ -25,16 +25,21 @@ if (obj.hits > 0) {
   set resp.http.X-Cache = "MISS";
 }
 
-# Sanitize CORS to the approved browser origins only.
-unset resp.http.Access-Control-Allow-Origin;
-if (req.http.Origin == "https://app.divine.video" ||
-    req.http.Origin ~ "^https://[^.]+\\.openvine-app\\.pages\\.dev$") {
-  set resp.http.Access-Control-Allow-Origin = req.http.Origin;
-  if (resp.http.Vary) {
-    if (resp.http.Vary !~ "(?i)\\bOrigin\\b") {
-      set resp.http.Vary = resp.http.Vary ", Origin";
+# Preserve wildcard CORS for public media/read responses. Sanitize everything
+# else to the approved browser origins only.
+if (resp.http.Access-Control-Allow-Origin == "*") {
+  unset resp.http.Vary;
+} else {
+  unset resp.http.Access-Control-Allow-Origin;
+  if (req.http.Origin == "https://app.divine.video" ||
+      req.http.Origin ~ "^https://[^.]+\\.openvine-app\\.pages\\.dev$") {
+    set resp.http.Access-Control-Allow-Origin = req.http.Origin;
+    if (resp.http.Vary) {
+      if (resp.http.Vary !~ "(?i)\\bOrigin\\b") {
+        set resp.http.Vary = resp.http.Vary ", Origin";
+      }
+    } else {
+      set resp.http.Vary = "Origin";
     }
-  } else {
-    set resp.http.Vary = "Origin";
   }
 }

--- a/vcl/error.vcl
+++ b/vcl/error.vcl
@@ -6,14 +6,7 @@ if (obj.status == 503) {
   set obj.http.Access-Control-Allow-Methods = "GET, HEAD, PUT, POST, DELETE, OPTIONS";
   set obj.http.Access-Control-Allow-Headers = "Authorization, Content-Type, Range, X-Requested-With, X-Sha256";
   set obj.http.Access-Control-Max-Age = "86400";
-  if ((req.method == "GET" || req.method == "HEAD" || req.method == "OPTIONS") &&
-      req.url ~ "^/[0-9a-fA-F]{64}($|[./])") {
-    set obj.http.Access-Control-Allow-Origin = "*";
-  } else if (req.http.Origin == "https://app.divine.video" ||
-      req.http.Origin ~ "^https://[^.]+\\.openvine-app\\.pages\\.dev$") {
-    set obj.http.Access-Control-Allow-Origin = req.http.Origin;
-    set obj.http.Vary = "Origin";
-  }
+  set obj.http.Access-Control-Allow-Origin = "*";
   synthetic {"{"error":"Service temporarily unavailable","status":503}"};
   return(deliver);
 }

--- a/vcl/error.vcl
+++ b/vcl/error.vcl
@@ -6,7 +6,10 @@ if (obj.status == 503) {
   set obj.http.Access-Control-Allow-Methods = "GET, HEAD, PUT, POST, DELETE, OPTIONS";
   set obj.http.Access-Control-Allow-Headers = "Authorization, Content-Type, Range, X-Requested-With, X-Sha256";
   set obj.http.Access-Control-Max-Age = "86400";
-  if (req.http.Origin == "https://app.divine.video" ||
+  if ((req.method == "GET" || req.method == "HEAD" || req.method == "OPTIONS") &&
+      req.url ~ "^/[0-9a-fA-F]{64}($|[./])") {
+    set obj.http.Access-Control-Allow-Origin = "*";
+  } else if (req.http.Origin == "https://app.divine.video" ||
       req.http.Origin ~ "^https://[^.]+\\.openvine-app\\.pages\\.dev$") {
     set obj.http.Access-Control-Allow-Origin = req.http.Origin;
     set obj.http.Vary = "Origin";

--- a/vcl/error.vcl
+++ b/vcl/error.vcl
@@ -3,7 +3,14 @@
 
 if (obj.status == 503) {
   set obj.http.Content-Type = "application/json";
-  set obj.http.Access-Control-Allow-Origin = "*";
+  set obj.http.Access-Control-Allow-Methods = "GET, HEAD, PUT, POST, DELETE, OPTIONS";
+  set obj.http.Access-Control-Allow-Headers = "Authorization, Content-Type, Range, X-Requested-With, X-Sha256";
+  set obj.http.Access-Control-Max-Age = "86400";
+  if (req.http.Origin == "https://app.divine.video" ||
+      req.http.Origin ~ "^https://[^.]+\\.openvine-app\\.pages\\.dev$") {
+    set obj.http.Access-Control-Allow-Origin = req.http.Origin;
+    set obj.http.Vary = "Origin";
+  }
   synthetic {"{"error":"Service temporarily unavailable","status":503}"};
   return(deliver);
 }


### PR DESCRIPTION
## Summary
- replace wildcard Blossom CORS with explicit reflection for the managed web app origin and preview subdomains
- align Fastly VCL fallback behavior with the service allowlist instead of forcing `*`
- add regression coverage for allowed and rejected origins

## Test Plan
- [x] `cargo test --manifest-path /Users/rabble/code/divine/divine-blossom/.worktrees/web-app-cors-allowlist/Cargo.toml -- --nocapture`
