### PR TITLE
feat: add BlobStatus::AgeRestricted — age-gate instead of 404 for adult content

### DIFF
--- a/docs/superpowers/plans/2026-04-10-blob-status-age-restricted.md
+++ b/docs/superpowers/plans/2026-04-10-blob-status-age-restricted.md
@@ -1,0 +1,974 @@
+# `BlobStatus::AgeRestricted` Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop returning `404` for legacy adult/age-restricted content (e.g. Vine archive imports) and instead return `401` so the web player triggers its age-verification UI, by introducing a new `BlobStatus::AgeRestricted` variant that is distinct from the existing shadow-ban `Restricted`.
+
+**Architecture:**
+1. New `BlobStatus::AgeRestricted` variant, serialized as `"age_restricted"` in KV.
+2. A single helper `BlobMetadata::access_for(requester_pubkey, is_admin) -> BlobAccess` collapses the ~10 duplicated gate sites in `src/main.rs` into one decision point with three outcomes: `Allowed`, `NotFound` (existing Banned / Restricted shadow-ban semantics), and `AgeGated` (new — returns `401 age_restricted`).
+3. The moderation webhook (`POST /admin/moderate`) and `delete_policy::parse_restore_status` both learn the `AGE_RESTRICTED` action and route it to the new variant. Existing `RESTRICT` / `QUARANTINE` still go to `Restricted` so true shadow-ban behavior is preserved.
+4. A standalone Python backfill script under `scripts/` reads the `blossom_metadata` Fastly KV store, finds existing `status: "restricted"` blobs, reports a per-owner breakdown, and (only with `--apply`) promotes them to `status: "age_restricted"`. Default is dry-run.
+
+**Tech Stack:** Rust (Fastly Compute), serde, `fastly::kv_store`, Python (backfill script using `requests`), Fastly KV API.
+
+---
+
+## Task list summary
+
+1. Add `BlobStatus::AgeRestricted` variant + serde rename + unit tests
+2. Add `BlobAccess` enum + `BlobMetadata::access_for` helper + unit tests
+3. Refactor all `src/main.rs` gate sites to use the helper
+4. Update moderation webhook + admin moderate action + delete_policy parse to map `AGE_RESTRICTED`
+5. Update `metadata::list_blobs_with_metadata` so `include_restricted=true` also includes `AgeRestricted`
+6. Update `admin::handle_admin_scan_flagged` to include `AgeRestricted` in its match
+7. Manual smoke test against staging hashes
+8. Build, deploy to Fastly Compute, purge cache, verify with curl
+9. Backfill script — dry-run mode + per-owner report
+10. Run dry-run, review, then `--apply` for the agreed scope
+11. Verify the four known failing hashes return `401` and play with age-gate UI
+12. Update `MEMORY.md` with the new status semantics
+
+---
+
+## File Structure
+
+**Modify:**
+- `src/blossom.rs` — add variant, helper enum, `access_for` method, tests
+- `src/main.rs` — replace ~10 inline gate blocks with `meta.access_for(...)`, map `AgeRestricted` action in `handle_admin_moderate`
+- `src/admin.rs` — accept `AGE_RESTRICTED` in `handle_admin_moderate_action`, include `AgeRestricted` in `handle_admin_scan_flagged`, include in bulk-approve
+- `src/delete_policy.rs` — accept `AGE_RESTRICTED` in `parse_restore_status`
+- `src/metadata.rs` — `list_blobs_with_metadata` includes `AgeRestricted` when `include_restricted=true`
+- `MEMORY.md` (project memory under `docs/` if applicable, or `~/.claude/projects/.../memory/`) — document the new status
+
+**Create:**
+- `scripts/backfill_restricted_to_age_restricted.py` — dry-run-by-default backfill against the `blossom_metadata` Fastly KV store
+
+**No changes to:** `src/storage.rs`, `src/error.rs` (existing `AuthRequired` → `401` is reused), VCL, Cloud Run services. The `should_hide_direct_blob` audio-alias path is unrelated and untouched.
+
+---
+
+## Chunk 1: Data model + helper
+
+### Task 1: Add `BlobStatus::AgeRestricted` variant
+
+**Files:**
+- Modify: `src/blossom.rs` (around lines 105-129)
+
+- [ ] **Step 1: Write the failing serde test**
+
+In `src/blossom.rs` tests module, add:
+
+```rust
+#[test]
+fn blob_status_serializes_age_restricted_with_underscore() {
+    let json = serde_json::to_string(&BlobStatus::AgeRestricted).unwrap();
+    assert_eq!(json, "\"age_restricted\"");
+}
+
+#[test]
+fn blob_status_deserializes_age_restricted() {
+    let parsed: BlobStatus = serde_json::from_str("\"age_restricted\"").unwrap();
+    assert_eq!(parsed, BlobStatus::AgeRestricted);
+}
+
+#[test]
+fn blob_status_age_restricted_does_not_block_public_access() {
+    // AgeRestricted should NOT be in blocks_public_access (that returns 404).
+    // It instead surfaces as an age-gate via access_for.
+    assert!(!BlobStatus::AgeRestricted.blocks_public_access());
+}
+
+#[test]
+fn blob_status_age_restricted_requires_owner_auth() {
+    assert!(BlobStatus::AgeRestricted.requires_owner_auth());
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```
+cargo test -p fastly-blossom blob_status_ -- --nocapture
+```
+
+Expected: compile error (variant does not exist).
+
+- [ ] **Step 3: Add the variant**
+
+Edit `src/blossom.rs` enum and helpers:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BlobStatus {
+    Active,
+    Restricted,
+    Pending,
+    Banned,
+    Deleted,
+    /// Age-gated content. Non-owners receive 401 (auth_required) so the
+    /// client can present an age-verification UI. Distinct from `Restricted`,
+    /// which is shadow-banned and 404s to non-owners.
+    #[serde(rename = "age_restricted")]
+    AgeRestricted,
+}
+
+impl BlobStatus {
+    pub fn blocks_public_access(self) -> bool {
+        matches!(self, BlobStatus::Banned | BlobStatus::Deleted)
+    }
+
+    pub fn requires_owner_auth(self) -> bool {
+        matches!(self, BlobStatus::Restricted | BlobStatus::AgeRestricted)
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```
+cargo test -p fastly-blossom blob_status_
+```
+
+Expected: 4 new tests pass; existing `BlobStatus` tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/blossom.rs
+git commit -m "feat(blossom): add BlobStatus::AgeRestricted variant"
+```
+
+---
+
+### Task 2: Add `BlobAccess` enum + `BlobMetadata::access_for`
+
+**Files:**
+- Modify: `src/blossom.rs` (alongside `BlobStatus`)
+
+- [ ] **Step 1: Write failing tests for access_for**
+
+```rust
+#[cfg(test)]
+mod access_for_tests {
+    use super::*;
+
+    fn fixture(status: BlobStatus, owner: &str) -> BlobMetadata {
+        BlobMetadata {
+            sha256: "x".into(),
+            size: 1,
+            mime_type: "video/mp4".into(),
+            uploaded: "2026-04-10T00:00:00Z".into(),
+            owner: owner.into(),
+            status,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn admin_always_allowed() {
+        let m = fixture(BlobStatus::Banned, "owner");
+        assert_eq!(m.access_for(None, true), BlobAccess::Allowed);
+    }
+
+    #[test]
+    fn active_allowed_for_anyone() {
+        let m = fixture(BlobStatus::Active, "owner");
+        assert_eq!(m.access_for(None, false), BlobAccess::Allowed);
+        assert_eq!(m.access_for(Some("stranger"), false), BlobAccess::Allowed);
+    }
+
+    #[test]
+    fn banned_is_notfound_to_everyone_non_admin() {
+        let m = fixture(BlobStatus::Banned, "owner");
+        assert_eq!(m.access_for(Some("owner"), false), BlobAccess::NotFound);
+    }
+
+    #[test]
+    fn deleted_is_notfound_to_everyone_non_admin() {
+        let m = fixture(BlobStatus::Deleted, "owner");
+        assert_eq!(m.access_for(Some("owner"), false), BlobAccess::NotFound);
+    }
+
+    #[test]
+    fn restricted_is_notfound_to_non_owner_and_anonymous() {
+        let m = fixture(BlobStatus::Restricted, "owner");
+        assert_eq!(m.access_for(None, false), BlobAccess::NotFound);
+        assert_eq!(m.access_for(Some("stranger"), false), BlobAccess::NotFound);
+    }
+
+    #[test]
+    fn restricted_is_allowed_to_owner() {
+        let m = fixture(BlobStatus::Restricted, "owner");
+        assert_eq!(m.access_for(Some("owner"), false), BlobAccess::Allowed);
+        // Case-insensitive comparison
+        assert_eq!(m.access_for(Some("OWNER"), false), BlobAccess::Allowed);
+    }
+
+    #[test]
+    fn age_restricted_is_age_gated_to_non_owner_and_anonymous() {
+        let m = fixture(BlobStatus::AgeRestricted, "owner");
+        assert_eq!(m.access_for(None, false), BlobAccess::AgeGated);
+        assert_eq!(m.access_for(Some("stranger"), false), BlobAccess::AgeGated);
+    }
+
+    #[test]
+    fn age_restricted_is_allowed_to_owner() {
+        let m = fixture(BlobStatus::AgeRestricted, "owner");
+        assert_eq!(m.access_for(Some("owner"), false), BlobAccess::Allowed);
+    }
+
+    #[test]
+    fn pending_is_allowed() {
+        // Existing behavior: Pending blobs are publicly served while waiting
+        // for moderation. Don't change that here.
+        let m = fixture(BlobStatus::Pending, "owner");
+        assert_eq!(m.access_for(None, false), BlobAccess::Allowed);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cargo test -p fastly-blossom access_for_tests
+```
+
+Expected: compile error (`BlobAccess` does not exist, `access_for` does not exist).
+
+- [ ] **Step 3: Implement `BlobAccess` + `access_for`**
+
+Add to `src/blossom.rs` (just after the `BlobStatus` impl):
+
+```rust
+/// Result of evaluating whether a viewer is allowed to fetch a blob.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlobAccess {
+    /// Viewer may fetch the content.
+    Allowed,
+    /// Hide the existence of the blob (Banned / Deleted / shadow-Restricted to non-owners).
+    /// Maps to HTTP 404.
+    NotFound,
+    /// Age-gated content. Maps to HTTP 401 so the client can present an age-verification UI.
+    AgeGated,
+}
+
+impl BlobMetadata {
+    /// Decide whether a viewer is allowed to access this blob.
+    ///
+    /// `requester_pubkey` is the authenticated viewer's pubkey, if any.
+    /// `is_admin` is true when the request carries a valid admin Bearer token.
+    pub fn access_for(&self, requester_pubkey: Option<&str>, is_admin: bool) -> BlobAccess {
+        if is_admin {
+            return BlobAccess::Allowed;
+        }
+
+        let is_owner = requester_pubkey
+            .map(|p| p.eq_ignore_ascii_case(&self.owner))
+            .unwrap_or(false);
+
+        match self.status {
+            BlobStatus::Active | BlobStatus::Pending => BlobAccess::Allowed,
+            BlobStatus::Banned | BlobStatus::Deleted => BlobAccess::NotFound,
+            BlobStatus::Restricted => {
+                if is_owner {
+                    BlobAccess::Allowed
+                } else {
+                    BlobAccess::NotFound
+                }
+            }
+            BlobStatus::AgeRestricted => {
+                if is_owner {
+                    BlobAccess::Allowed
+                } else {
+                    BlobAccess::AgeGated
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cargo test -p fastly-blossom access_for_tests
+```
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/blossom.rs
+git commit -m "feat(blossom): add BlobMetadata::access_for + BlobAccess enum"
+```
+
+---
+
+## Chunk 2: Wire the helper through `src/main.rs`
+
+This chunk replaces every inline `if meta.status == BlobStatus::Restricted` block with a single `match meta.access_for(...)`. Each gate site is one task; do them sequentially because they share the same import + helper but each call site has slightly different request/response context.
+
+For every site, the new shape is:
+
+```rust
+let requester = optional_auth(&req, AuthAction::List)
+    .ok()
+    .flatten()
+    .map(|a| a.pubkey);
+match meta.access_for(requester.as_deref(), is_admin) {
+    BlobAccess::Allowed => {}
+    BlobAccess::NotFound => {
+        return Err(BlossomError::NotFound("Blob not found".into()));
+    }
+    BlobAccess::AgeGated => {
+        return Err(BlossomError::AuthRequired("age_restricted".into()));
+    }
+}
+```
+
+For HEAD endpoints (which don't have admin/auth context), the call simplifies to:
+
+```rust
+match meta.access_for(None, false) {
+    BlobAccess::Allowed => {}
+    BlobAccess::NotFound => return Err(BlossomError::NotFound("Content not found".into())),
+    BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
+}
+```
+
+### Task 3: `handle_get_blob` thumbnail branch (`src/main.rs:374-391`)
+
+- [ ] **Step 1: Replace the inline branch with `access_for`**
+
+Read `src/main.rs:364-424` and replace the `if let Ok(Some(meta)) = ... { if !is_admin { ... } }` block with:
+
+```rust
+let mut is_age_gated_thumb = false;
+let mut is_restricted_thumb = false;
+if let Ok(Some(meta)) = get_blob_metadata(video_hash) {
+    let requester = optional_auth(&req, AuthAction::List)
+        .ok()
+        .flatten()
+        .map(|a| a.pubkey);
+    match meta.access_for(requester.as_deref(), is_admin) {
+        BlobAccess::Allowed => {
+            // Distinguish so cache headers stay private when the owner views their own restricted thumb.
+            if meta.status == BlobStatus::Restricted || meta.status == BlobStatus::AgeRestricted {
+                is_restricted_thumb = true;
+            }
+        }
+        BlobAccess::NotFound => {
+            return Err(BlossomError::NotFound("Blob not found".into()));
+        }
+        BlobAccess::AgeGated => {
+            is_age_gated_thumb = true;
+        }
+    }
+}
+
+if is_age_gated_thumb {
+    return Err(BlossomError::AuthRequired("age_restricted".into()));
+}
+```
+
+Then thread `is_restricted_thumb` into the existing `set_thumb_cache` closure (replacing the old `is_restricted` variable).
+
+- [ ] **Step 2: Build**
+
+```
+cargo build -p fastly-blossom
+```
+
+Expected: compiles cleanly.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/main.rs
+git commit -m "refactor(main): use access_for for thumbnail gate"
+```
+
+### Task 4: `handle_get_blob` main blob branch (`src/main.rs:439-458`)
+
+- [ ] Replace the `if let Some(ref meta) = metadata { if !is_admin { ... } }` block with the `access_for` shape above. Keep the `is_partial`/`is_restricted`/`metadata` plumbing for cache headers — derive `is_restricted` from `meta.status == BlobStatus::Restricted || meta.status == BlobStatus::AgeRestricted` after the gate.
+- [ ] Build, then commit:
+
+```
+git add src/main.rs
+git commit -m "refactor(main): use access_for for handle_get_blob"
+```
+
+### Task 5: `handle_head_blob` (`src/main.rs:578-585`)
+
+- [ ] Replace the `if metadata.status == BlobStatus::Restricted || == BlobStatus::Banned` block with `match metadata.access_for(None, false) { ... }`. Keep the existing `should_hide_direct_blob` call as-is.
+- [ ] Build + commit.
+
+### Task 6: `handle_get_hls_master` (`src/main.rs:621-641`)
+
+- [ ] Replace the if/else chain with `match meta.access_for(requester.as_deref(), is_admin)`. Note this branch wraps in `if let Some(ref meta) = metadata { ... } else { return NotFound }` — preserve that envelope.
+- [ ] Build + commit.
+
+### Task 7: `handle_head_hls_master` (`src/main.rs:766-769`)
+
+- [ ] Replace the inline match with `metadata.access_for(None, false)`.
+- [ ] Build + commit.
+
+### Task 8: `handle_get_hls_content` (`src/main.rs:840-856`)
+
+- [ ] Same shape as Task 6. Preserve the `is_restricted` variable so cache headers stay private when the owner is fetching their own restricted/age-restricted segments.
+- [ ] Build + commit.
+
+### Task 9: `handle_head_hls_content` (`src/main.rs:986-992`)
+
+- [ ] Replace the inline match with `meta.access_for(None, false)`.
+- [ ] Build + commit.
+
+### Task 10: `serve_transcript_by_hash` (`src/main.rs:1453-1471`)
+
+- [ ] Replace the nested if-else blocks. Note `req` is `Option<&Request>` here, so:
+
+```rust
+let (requester, is_admin) = match req {
+    Some(r) => {
+        let admin = admin::validate_bearer_token(r).is_ok();
+        let pk = optional_auth(r, AuthAction::List).ok().flatten().map(|a| a.pubkey);
+        (pk, admin)
+    }
+    None => (None, false),
+};
+match metadata.access_for(requester.as_deref(), is_admin) {
+    BlobAccess::Allowed => {}
+    BlobAccess::NotFound => return Err(BlossomError::NotFound("Content not found".into())),
+    BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
+}
+```
+
+- [ ] Build + commit.
+
+### Task 11: `handle_head_transcript_by_hash` (`src/main.rs:1602-1604`)
+
+- [ ] Replace with `metadata.access_for(None, false)`.
+- [ ] Build + commit.
+
+### Task 12: `handle_get_quality_variant` (`src/main.rs:2183-2200`)
+
+- [ ] Same shape as Task 6.
+- [ ] Build + commit.
+
+### Task 13: `handle_head_quality_variant` (`src/main.rs:2295-2297`)
+
+- [ ] Replace with `metadata.access_for(None, false)`.
+- [ ] Build + commit.
+
+### Task 14: Sanity build of the whole crate
+
+- [ ] **Step 1: Full build**
+
+```
+cargo build -p fastly-blossom
+cargo test -p fastly-blossom
+```
+
+Expected: clean build, all existing tests pass, new tests pass.
+
+- [ ] **Step 2: Commit any leftover formatting**
+
+```
+cargo fmt -p fastly-blossom
+git diff
+git commit -am "style: cargo fmt after access_for refactor" || true
+```
+
+---
+
+## Chunk 3: Webhook + admin + delete_policy + listing
+
+### Task 15: Moderation webhook routes `AGE_RESTRICTED` to the new variant
+
+**Files:**
+- Modify: `src/main.rs:4402-4413`
+
+- [ ] **Step 1: Edit the action map**
+
+```rust
+let new_status = match action.to_uppercase().as_str() {
+    "BLOCK" | "BAN" | "PERMANENT_BAN" => BlobStatus::Banned,
+    "AGE_RESTRICTED" => BlobStatus::AgeRestricted,
+    "RESTRICT" | "QUARANTINE" => BlobStatus::Restricted,
+    "APPROVE" | "SAFE" => BlobStatus::Active,
+    _ => {
+        return Err(BlossomError::BadRequest(format!(
+            "Unknown action: {}. Expected BLOCK, RESTRICT, QUARANTINE, AGE_RESTRICTED, or APPROVE",
+            action
+        )));
+    }
+};
+```
+
+- [ ] **Step 2: Build**
+
+```
+cargo build -p fastly-blossom
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/main.rs
+git commit -m "feat(moderation): route AGE_RESTRICTED action to AgeRestricted status"
+```
+
+### Task 16: Admin moderate-action UI maps `AGE_RESTRICT`
+
+**Files:**
+- Modify: `src/admin.rs:783-790` (the `match moderate_req.action`)
+
+- [ ] **Step 1: Add `"AGE_RESTRICT"` arm**
+
+```rust
+let new_status = match moderate_req.action.to_uppercase().as_str() {
+    "BAN" | "BLOCK" => BlobStatus::Banned,
+    "RESTRICT" => BlobStatus::Restricted,
+    "AGE_RESTRICT" | "AGE_RESTRICTED" => BlobStatus::AgeRestricted,
+    "APPROVE" | "ACTIVE" => BlobStatus::Active,
+    _ => return Err(BlossomError::BadRequest("Unknown moderation action".into())),
+};
+```
+
+- [ ] **Step 2: Build + commit**
+
+```
+cargo build -p fastly-blossom
+git add src/admin.rs
+git commit -m "feat(admin): accept AGE_RESTRICT moderation action"
+```
+
+### Task 17: `handle_admin_scan_flagged` includes `AgeRestricted`
+
+**Files:**
+- Modify: `src/admin.rs:961-975`
+
+- [ ] **Step 1: Add the variant to the match + a new bucket in the response**
+
+```rust
+let mut age_restricted: Vec<String> = Vec::new();
+// ...
+match meta.status {
+    BlobStatus::Banned => banned.push(hash.clone()),
+    BlobStatus::Restricted => restricted.push(hash.clone()),
+    BlobStatus::AgeRestricted => age_restricted.push(hash.clone()),
+    BlobStatus::Active => active += 1,
+    BlobStatus::Pending => pending += 1,
+    BlobStatus::Deleted => not_found += 1,
+},
+```
+
+Then add `"age_restricted": age_restricted` to the JSON response.
+
+- [ ] **Step 2: Update `handle_admin_bulk_approve` similarly**
+
+`src/admin.rs:892` — extend the condition:
+
+```rust
+if meta.status == BlobStatus::Banned
+    || meta.status == BlobStatus::Restricted
+    || meta.status == BlobStatus::AgeRestricted
+{
+    // ...promote to Active...
+}
+```
+
+- [ ] **Step 3: Build + commit**
+
+```
+cargo build -p fastly-blossom
+git add src/admin.rs
+git commit -m "feat(admin): handle AgeRestricted in scan-flagged + bulk-approve"
+```
+
+### Task 18: `delete_policy::parse_restore_status` accepts `AGE_RESTRICTED`
+
+**Files:**
+- Modify: `src/delete_policy.rs:23-36`
+
+- [ ] **Step 1: Add a failing test**
+
+In the existing tests module:
+
+```rust
+#[test]
+fn restore_target_accepts_age_restricted() {
+    assert_eq!(
+        parse_restore_status(Some("age_restricted")).unwrap(),
+        BlobStatus::AgeRestricted
+    );
+    assert_eq!(
+        parse_restore_status(Some("AGE_RESTRICTED")).unwrap(),
+        BlobStatus::AgeRestricted
+    );
+}
+```
+
+- [ ] **Step 2: Run + verify it fails**
+
+```
+cargo test -p fastly-blossom restore_target_accepts_age_restricted
+```
+
+Expected: fails (BadRequest "Unknown restore status").
+
+- [ ] **Step 3: Add the arm**
+
+```rust
+"AGE_RESTRICT" | "AGE_RESTRICTED" => Ok(BlobStatus::AgeRestricted),
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+```
+cargo test -p fastly-blossom restore_target_accepts_age_restricted
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/delete_policy.rs
+git commit -m "feat(delete_policy): accept AGE_RESTRICTED in parse_restore_status"
+```
+
+### Task 19: `metadata::list_blobs_with_metadata` includes `AgeRestricted` when listing
+
+**Files:**
+- Modify: `src/metadata.rs:497-515`
+
+- [ ] **Step 1: Update the filter**
+
+```rust
+if metadata.status == BlobStatus::Active
+    || (include_restricted
+        && (metadata.status == BlobStatus::Restricted
+            || metadata.status == BlobStatus::AgeRestricted))
+{
+    results.push(metadata);
+}
+```
+
+- [ ] **Step 2: Build + commit**
+
+```
+cargo build -p fastly-blossom
+git add src/metadata.rs
+git commit -m "feat(metadata): include AgeRestricted in list_blobs_with_metadata"
+```
+
+### Task 20: Final test sweep
+
+- [ ] **Step 1: Run the full test suite**
+
+```
+cargo test -p fastly-blossom
+```
+
+Expected: green.
+
+- [ ] **Step 2: Format**
+
+```
+cargo fmt -p fastly-blossom
+```
+
+- [ ] **Step 3: Commit any formatting changes**
+
+---
+
+## Chunk 4: Deploy + verify
+
+### Task 21: Local serve + smoke test
+
+- [ ] **Step 1:** `fastly compute serve` (in another terminal)
+- [ ] **Step 2:** Manually curl a fake `Active` and a fake `Restricted` and a fake `AgeRestricted` blob if local fixtures exist; otherwise skip and rely on staging.
+
+### Task 22: Deploy to Fastly Compute
+
+- [ ] **Step 1: Publish + purge** (per project convention)
+
+```
+fastly compute publish --comment "Add BlobStatus::AgeRestricted; route AGE_RESTRICTED action; surface 401 instead of 404 to non-owners" \
+  && fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR
+```
+
+- [ ] **Step 2: Wait for propagation** (several minutes — see CLAUDE.md note)
+
+### Task 23: Confirm baseline behavior didn't regress for `Active` blobs
+
+- [ ] **Step 1:**
+
+```
+curl -sI "https://media.divine.video/5da39e5f34971e6840f59cb9335ef9bf4996798f86cf5eb966808d1fb016b1ef?cb=$RANDOM" | head
+```
+
+Expected: `HTTP/2 200`.
+
+### Task 24: Confirm existing `Restricted` blobs still 404 (shadow-ban preserved)
+
+- [ ] **Step 1:** Same curl as Task 23 against one of the four known failing hashes BEFORE the backfill.
+
+Expected: `HTTP/2 404` (still Restricted in KV, not yet promoted). This proves the shadow-ban path survived the refactor.
+
+---
+
+## Chunk 5: Backfill
+
+### Task 25: Backfill script — list + report
+
+**Files:**
+- Create: `scripts/backfill_restricted_to_age_restricted.py`
+
+- [ ] **Step 1: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""
+Promote `BlobStatus::Restricted` blobs to `BlobStatus::AgeRestricted` in the
+Fastly KV store `blossom_metadata`.
+
+Default mode is dry-run: scans all blob:* keys, fetches each metadata record,
+groups by owner pubkey, and prints how many would be promoted.
+
+Pass --apply to actually write the new status. The script never deletes a key
+and only mutates the `status` field.
+
+Required env:
+  FASTLY_API_TOKEN
+  FASTLY_KV_STORE_ID    (default: 07pggadpgda8plydnkt5el)
+
+Optional env:
+  ONLY_OWNER_PUBKEYS    comma-separated; if set, only blobs owned by these
+                        pubkeys are eligible for promotion (otherwise all
+                        currently-Restricted blobs are eligible).
+"""
+import argparse
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from urllib.parse import urlencode
+
+import requests
+
+KV_STORE_ID_DEFAULT = "07pggadpgda8plydnkt5el"
+KV_API = "https://api.fastly.com/resources/stores/kv"
+PAGE_LIMIT = 1000
+
+
+def session():
+    token = os.environ["FASTLY_API_TOKEN"]
+    s = requests.Session()
+    s.headers.update({"Fastly-Key": token, "Accept": "application/json"})
+    return s
+
+
+def list_blob_keys(s, store_id):
+    cursor = None
+    while True:
+        params = {"prefix": "blob", "limit": PAGE_LIMIT}
+        if cursor:
+            params["cursor"] = cursor
+        url = f"{KV_API}/{store_id}/keys?{urlencode(params)}"
+        r = s.get(url, timeout=30)
+        r.raise_for_status()
+        body = r.json()
+        for key in body.get("data", []):
+            if key.startswith("blob:") and len(key) == len("blob:") + 64:
+                yield key
+        cursor = body.get("meta", {}).get("next_cursor")
+        if not cursor:
+            return
+
+
+def get_metadata(s, store_id, key):
+    url = f"{KV_API}/{store_id}/keys/{key}"
+    r = s.get(url, timeout=30)
+    if r.status_code == 404:
+        return None
+    r.raise_for_status()
+    return r.json()
+
+
+def put_metadata(s, store_id, key, metadata):
+    url = f"{KV_API}/{store_id}/keys/{key}"
+    r = s.put(url, data=json.dumps(metadata), timeout=30,
+              headers={"Content-Type": "application/octet-stream"})
+    r.raise_for_status()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--apply", action="store_true",
+                    help="Actually write changes (default: dry-run)")
+    ap.add_argument("--store-id", default=os.environ.get("FASTLY_KV_STORE_ID", KV_STORE_ID_DEFAULT))
+    args = ap.parse_args()
+
+    only_owners = {p.strip().lower() for p in os.environ.get("ONLY_OWNER_PUBKEYS", "").split(",") if p.strip()}
+
+    s = session()
+
+    by_owner = defaultdict(int)
+    eligible = []
+    scanned = 0
+    restricted_total = 0
+
+    print(f"Scanning KV store {args.store_id} for blob:* keys...", file=sys.stderr)
+
+    for key in list_blob_keys(s, args.store_id):
+        scanned += 1
+        if scanned % 500 == 0:
+            print(f"  scanned {scanned} blob keys, {restricted_total} restricted...", file=sys.stderr)
+
+        meta = get_metadata(s, args.store_id, key)
+        if not meta:
+            continue
+        if meta.get("status") != "restricted":
+            continue
+        restricted_total += 1
+
+        owner = (meta.get("owner") or "").lower()
+        if only_owners and owner not in only_owners:
+            continue
+
+        by_owner[owner] += 1
+        eligible.append((key, meta))
+
+    print(f"\nScan complete: {scanned} blob records, {restricted_total} currently restricted, "
+          f"{len(eligible)} eligible for promotion.\n", file=sys.stderr)
+
+    print("Per-owner breakdown of eligible blobs:")
+    for owner, count in sorted(by_owner.items(), key=lambda kv: -kv[1]):
+        print(f"  {owner}  {count}")
+
+    if not args.apply:
+        print("\nDry-run only. Re-run with --apply to promote these blobs.", file=sys.stderr)
+        return 0
+
+    print(f"\nPromoting {len(eligible)} blobs to age_restricted...", file=sys.stderr)
+    promoted = 0
+    failed = 0
+    for key, meta in eligible:
+        meta["status"] = "age_restricted"
+        try:
+            put_metadata(s, args.store_id, key, meta)
+            promoted += 1
+        except Exception as e:
+            failed += 1
+            print(f"  FAILED {key}: {e}", file=sys.stderr)
+        if promoted % 100 == 0:
+            print(f"  promoted {promoted}/{len(eligible)}...", file=sys.stderr)
+        time.sleep(0.02)  # gentle pacing to avoid KV write hot-spots
+
+    print(f"\nDone. Promoted: {promoted}, Failed: {failed}", file=sys.stderr)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Mark executable**
+
+```
+chmod +x scripts/backfill_restricted_to_age_restricted.py
+```
+
+- [ ] **Step 3: Commit**
+
+```
+git add scripts/backfill_restricted_to_age_restricted.py
+git commit -m "feat(scripts): add Restricted -> AgeRestricted backfill (dry-run by default)"
+```
+
+### Task 26: Run dry-run to see the population
+
+- [ ] **Step 1:**
+
+```
+FASTLY_API_TOKEN=<token> ./scripts/backfill_restricted_to_age_restricted.py
+```
+
+- [ ] **Step 2: Review the per-owner breakdown.** If almost all are owned by `vine-archive-importer`-style pubkeys (e.g. those matching the four known hashes), proceed to apply against everything. If the breakdown shows other pubkeys with non-trivial counts, narrow scope via `ONLY_OWNER_PUBKEYS=<csv>` and re-run dry-run before applying.
+
+### Task 27: Apply the backfill
+
+- [ ] **Step 1:** Run with the agreed scope:
+
+```
+FASTLY_API_TOKEN=<token> [ONLY_OWNER_PUBKEYS=...] \
+  ./scripts/backfill_restricted_to_age_restricted.py --apply
+```
+
+- [ ] **Step 2:** Note the promoted/failed counts. If there are failures, inspect the listed keys and retry individually.
+
+### Task 28: Purge VCL cache for promoted blobs
+
+The script does NOT call `purge_vcl_cache` because that's an internal Compute helper. The simplest path is a blanket purge after the backfill:
+
+- [ ] **Step 1:** Purge all on the service:
+
+```
+fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR
+```
+
+- [ ] **Step 2:** Wait for propagation.
+
+---
+
+## Chunk 6: End-to-end verification
+
+### Task 29: Confirm the four known failing hashes now return `401`
+
+- [ ] **Step 1:**
+
+```
+for h in 1a2f755fc7dfdcb267b945e76ad959ff585c2990e88fd5ba088098e5d1b43cea \
+         6e4a6f2021867d43fdee1d490af8333b18d14684a87b4eee3d520092aec39765 \
+         f8ae52951ca4c5d1b90b8790bda4f5c354f783dce063d77e25029b498889b946 \
+         d56e525a15ef23d4dacce354a9d32fe3e50559971d9532f7e4ad8d21443d716a; do
+  echo "=== $h ==="
+  curl -sI "https://media.divine.video/$h?cb=$RANDOM" | head -3
+done
+```
+
+Expected: `HTTP/2 401` for each (no longer 404).
+
+- [ ] **Step 2: Confirm the working hashes still return `200`**
+
+```
+for h in 5da39e5f34971e6840f59cb9335ef9bf4996798f86cf5eb966808d1fb016b1ef \
+         e2d44560303bf68a9dd04cf6172ee4e053df1e6443bb359bfe58ebbfd8987601; do
+  echo "=== $h ==="
+  curl -sI "https://media.divine.video/$h?cb=$RANDOM" | head -3
+done
+```
+
+Expected: `HTTP/2 200`.
+
+### Task 30: Confirm the web player triggers age-gate UI
+
+- [ ] **Step 1:** Open Divine Web `/hashtag/twerking` and scroll to one of the four hashes.
+- [ ] **Step 2:** Verify age-verification UI appears (instead of permanent error).
+
+### Task 31: Update project memory
+
+- [ ] **Step 1:** Update `~/.claude/projects/-Users-rabble-code-divine-divine-blossom/memory/MEMORY.md` to add a section noting the new `BlobStatus::AgeRestricted` semantics, the moderation webhook action mapping, and the backfill script.
+- [ ] **Step 2:** No commit needed (memory is outside the repo).
+
+---
+
+## Out of scope (intentionally not in this plan)
+
+- Changing how `moderation-api.divine.video` decides which content to flag as adult — that classifier already exists and labels things via `AGE_RESTRICTED`; this plan only fixes how Blossom translates that label into an HTTP response.
+- Changing the web player's age-verification UI — the player already triggers it on `401`/`403`, which is what this plan starts emitting.
+- Removing the existing `BlobStatus::Restricted` shadow-ban variant — it stays as a distinct outcome for true takedowns.
+- Cloud Run / VCL changes — none required.

--- a/scripts/backfill_restricted_to_age_restricted.py
+++ b/scripts/backfill_restricted_to_age_restricted.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+Promote `BlobStatus::Restricted` blobs to `BlobStatus::AgeRestricted` in the
+Fastly KV store `blossom_metadata`.
+
+Default mode is dry-run: scans all blob:* keys, fetches each metadata record,
+groups by owner pubkey, and prints how many would be promoted.
+
+Pass --apply to actually write the new status. The script never deletes a key
+and only mutates the `status` field.
+
+Required env:
+  FASTLY_API_TOKEN
+  FASTLY_KV_STORE_ID    (default: 07pggadpgda8plydnkt5el)
+
+Optional env:
+  ONLY_OWNER_PUBKEYS    comma-separated; if set, only blobs owned by these
+                        pubkeys are eligible for promotion (otherwise all
+                        currently-Restricted blobs are eligible).
+
+Optional env (DNS-bypass for VPN-broken api.fastly.com):
+  FASTLY_API_RESOLVE_IP   manually pin api.fastly.com to this IP. If unset,
+                          uses requests' default resolution.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urlencode
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+KV_STORE_ID_DEFAULT = "07pggadpgda8plydnkt5el"
+KV_API = "https://api.fastly.com/resources/stores/kv"
+PAGE_LIMIT = 1000
+RETRY_STATUS = {429, 500, 502, 503, 504}
+
+
+def session():
+    token = os.environ.get("FASTLY_API_TOKEN")
+    if not token:
+        print("ERROR: FASTLY_API_TOKEN not set", file=sys.stderr)
+        sys.exit(2)
+    s = requests.Session()
+    s.headers.update({"Fastly-Key": token, "Accept": "application/json"})
+    # Larger pool so ThreadPoolExecutor workers don't serialize on a single conn
+    retry = Retry(
+        total=5,
+        status_forcelist=list(RETRY_STATUS),
+        allowed_methods=["GET", "PUT"],
+        backoff_factor=1.0,
+    )
+    adapter = HTTPAdapter(pool_connections=64, pool_maxsize=64, max_retries=retry)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s
+
+
+def _process_batch(s, store_id, keys, by_owner, eligible, only_owners, workers):
+    """Fetch a batch of blob: keys in parallel and append eligible records."""
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futures = {ex.submit(get_metadata, s, store_id, k): k for k in keys}
+        for fut in as_completed(futures):
+            key = futures[fut]
+            try:
+                meta = fut.result()
+            except Exception as e:
+                print(f"  WARN {key}: {e}", file=sys.stderr)
+                continue
+            if meta is None:
+                continue
+            if meta.get("status") != "restricted":
+                continue
+            owner = (meta.get("owner") or "").lower()
+            if only_owners and owner not in only_owners:
+                continue
+            by_owner[owner] += 1
+            eligible.append((key, meta))
+
+
+def list_blob_keys(s, store_id):
+    cursor = None
+    while True:
+        params = {"prefix": "blob", "limit": PAGE_LIMIT}
+        if cursor:
+            params["cursor"] = cursor
+        url = f"{KV_API}/{store_id}/keys?{urlencode(params)}"
+        r = s.get(url, timeout=30)
+        r.raise_for_status()
+        body = r.json()
+        for key in body.get("data", []):
+            if key.startswith("blob:") and len(key) == len("blob:") + 64:
+                yield key
+        cursor = body.get("meta", {}).get("next_cursor")
+        if not cursor:
+            return
+
+
+def get_metadata(s, store_id, key):
+    url = f"{KV_API}/{store_id}/keys/{key}"
+    r = s.get(url, timeout=30)
+    if r.status_code == 404:
+        return None
+    r.raise_for_status()
+    try:
+        return r.json()
+    except json.JSONDecodeError as e:
+        print(f"  WARN: {key} has unparseable JSON body: {e}", file=sys.stderr)
+        return None
+
+
+def put_metadata(s, store_id, key, metadata):
+    url = f"{KV_API}/{store_id}/keys/{key}"
+    r = s.put(
+        url,
+        data=json.dumps(metadata),
+        timeout=30,
+        headers={"Content-Type": "application/octet-stream"},
+    )
+    r.raise_for_status()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write changes (default: dry-run)",
+    )
+    ap.add_argument(
+        "--store-id",
+        default=os.environ.get("FASTLY_KV_STORE_ID", KV_STORE_ID_DEFAULT),
+    )
+    ap.add_argument(
+        "--limit-scan",
+        type=int,
+        default=0,
+        help="If >0, stop after scanning this many blob keys (for sampling)",
+    )
+    ap.add_argument(
+        "--workers",
+        type=int,
+        default=32,
+        help="Concurrent KV fetches (default 32)",
+    )
+    args = ap.parse_args()
+
+    only_owners = {
+        p.strip().lower()
+        for p in os.environ.get("ONLY_OWNER_PUBKEYS", "").split(",")
+        if p.strip()
+    }
+
+    s = session()
+
+    by_owner = defaultdict(int)
+    eligible = []
+    scanned = 0
+
+    print(
+        f"Scanning KV store {args.store_id} for blob:* keys "
+        f"(workers={args.workers}, limit_scan={args.limit_scan or 'unlimited'}, "
+        f"only_owners={len(only_owners) or 'all'})...",
+        file=sys.stderr,
+    )
+
+    # Process keys in batches: each batch fetches in parallel via ThreadPool.
+    BATCH = max(args.workers * 4, 64)
+
+    def process_key(key):
+        meta = get_metadata(s, args.store_id, key)
+        return key, meta
+
+    try:
+        batch = []
+        for key in list_blob_keys(s, args.store_id):
+            batch.append(key)
+            scanned += 1
+            if args.limit_scan and scanned > args.limit_scan:
+                break
+            if len(batch) >= BATCH:
+                _process_batch(
+                    s,
+                    args.store_id,
+                    batch,
+                    by_owner,
+                    eligible,
+                    only_owners,
+                    args.workers,
+                )
+                # update counters from results that flowed into mutable args
+                batch = []
+                if scanned % 1000 == 0:
+                    print(
+                        f"  scanned {scanned} keys, eligible so far: {len(eligible)}",
+                        file=sys.stderr,
+                    )
+        if batch:
+            _process_batch(
+                s,
+                args.store_id,
+                batch,
+                by_owner,
+                eligible,
+                only_owners,
+                args.workers,
+            )
+        restricted_total = len(eligible) if not only_owners else None
+        # When only_owners is set, eligible is already filtered; we no longer
+        # know the global restricted_total without re-counting.
+    except KeyboardInterrupt:
+        print("\nInterrupted by user, showing partial results...", file=sys.stderr)
+
+    print(
+        f"\nScan complete: {scanned} blob records, "
+        f"{len(eligible)} eligible for promotion.\n",
+        file=sys.stderr,
+    )
+
+    print("Per-owner breakdown of eligible blobs (top 50):")
+    for owner, count in sorted(by_owner.items(), key=lambda kv: -kv[1])[:50]:
+        print(f"  {count:6d}  {owner}")
+    if len(by_owner) > 50:
+        print(f"  ... ({len(by_owner) - 50} more owners)")
+
+    if not args.apply:
+        print(
+            "\nDry-run only. Re-run with --apply to promote these blobs.",
+            file=sys.stderr,
+        )
+        return 0
+
+    if not eligible:
+        print("\nNothing to apply.", file=sys.stderr)
+        return 0
+
+    print(
+        f"\nPromoting {len(eligible)} blobs from restricted to age_restricted...",
+        file=sys.stderr,
+    )
+    promoted = 0
+    failed = 0
+    for key, meta in eligible:
+        meta["status"] = "age_restricted"
+        try:
+            put_metadata(s, args.store_id, key, meta)
+            promoted += 1
+        except Exception as e:
+            failed += 1
+            print(f"  FAILED {key}: {e}", file=sys.stderr)
+        if promoted % 100 == 0 and promoted > 0:
+            print(
+                f"  promoted {promoted}/{len(eligible)}...",
+                file=sys.stderr,
+            )
+        time.sleep(0.02)  # gentle pacing to avoid KV write hot-spots
+
+    print(
+        f"\nDone. Promoted: {promoted}, Failed: {failed}",
+        file=sys.stderr,
+    )
+    print(
+        "\nNext step: purge VCL cache so the new status takes effect:\n"
+        "  fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR",
+        file=sys.stderr,
+    )
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -949,6 +949,7 @@ pub fn handle_admin_scan_flagged(mut req: Request) -> Result<Response> {
 
     let mut banned: Vec<String> = Vec::new();
     let mut restricted: Vec<String> = Vec::new();
+    let mut age_restricted: Vec<String> = Vec::new();
     let mut active = 0u32;
     let mut pending = 0u32;
     let mut not_found = 0u32;
@@ -961,6 +962,7 @@ pub fn handle_admin_scan_flagged(mut req: Request) -> Result<Response> {
             Ok(Some(meta)) => match meta.status {
                 BlobStatus::Banned => banned.push(hash.clone()),
                 BlobStatus::Restricted => restricted.push(hash.clone()),
+                BlobStatus::AgeRestricted => age_restricted.push(hash.clone()),
                 BlobStatus::Active => active += 1,
                 BlobStatus::Pending => pending += 1,
                 BlobStatus::Deleted => not_found += 1,
@@ -974,6 +976,7 @@ pub fn handle_admin_scan_flagged(mut req: Request) -> Result<Response> {
         "total_scanned": hashes.len(),
         "banned": banned,
         "restricted": restricted,
+        "age_restricted": age_restricted,
         "active": active,
         "pending": pending,
         "not_found": not_found,

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -780,10 +780,14 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
         .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
     let old_status = metadata.status;
 
-    // Map action to BlobStatus
+    // Map action to BlobStatus.
+    //
+    // AGE_RESTRICT lands on BlobStatus::AgeRestricted, which serves 401 (age gate)
+    // to non-owners. RESTRICT continues to mean the existing 404 shadow-ban.
     let new_status = match moderate_req.action.to_uppercase().as_str() {
         "BAN" | "BLOCK" => BlobStatus::Banned,
         "RESTRICT" => BlobStatus::Restricted,
+        "AGE_RESTRICT" | "AGE_RESTRICTED" => BlobStatus::AgeRestricted,
         "APPROVE" | "ACTIVE" => BlobStatus::Active,
         "PENDING" => BlobStatus::Pending,
         _ => {
@@ -889,11 +893,15 @@ pub fn handle_admin_bulk_approve(mut req: Request) -> Result<Response> {
 
         match get_blob_metadata(hash) {
             Ok(Some(meta)) => {
-                if meta.status == BlobStatus::Banned || meta.status == BlobStatus::Restricted {
+                if matches!(
+                    meta.status,
+                    BlobStatus::Banned | BlobStatus::Restricted | BlobStatus::AgeRestricted
+                ) {
                     match update_blob_status(hash, BlobStatus::Active) {
                         Ok(()) => {
                             if !skip_purge {
-                                let _ = update_stats_on_status_change(meta.status, BlobStatus::Active);
+                                let _ =
+                                    update_stats_on_status_change(meta.status, BlobStatus::Active);
                                 crate::purge_vcl_cache(hash);
                             }
                             approved += 1;
@@ -912,7 +920,11 @@ pub fn handle_admin_bulk_approve(mut req: Request) -> Result<Response> {
 
     eprintln!(
         "[ADMIN] Bulk approve: {} approved, {} already_ok, {} not_found, {} errors (of {} hashes)",
-        approved, already_ok, not_found, errors, hashes.len()
+        approved,
+        already_ok,
+        not_found,
+        errors,
+        hashes.len()
     );
 
     let response = serde_json::json!({
@@ -1247,9 +1259,7 @@ pub fn handle_admin_reset_stuck_transcodes(mut req: Request) -> Result<Response>
             };
 
             // Pre-filter cheaply before probing GCS.
-            if meta.transcode_status
-                != Some(crate::blossom::TranscodeStatus::Processing)
-            {
+            if meta.transcode_status != Some(crate::blossom::TranscodeStatus::Processing) {
                 skipped_not_stuck += 1;
                 continue;
             }
@@ -1270,14 +1280,10 @@ pub fn handle_admin_reset_stuck_transcodes(mut req: Request) -> Result<Response>
                 })
                 .unwrap_or(false);
 
-            let is_processing = meta.transcode_status
-                == Some(crate::blossom::TranscodeStatus::Processing);
-            let action = classify_stuck_record(
-                is_processing,
-                &meta.uploaded,
-                &threshold_iso,
-                hls_present,
-            );
+            let is_processing =
+                meta.transcode_status == Some(crate::blossom::TranscodeStatus::Processing);
+            let action =
+                classify_stuck_record(is_processing, &meta.uploaded, &threshold_iso, hls_present);
             eprintln!(
                 "[UNSTICK] hash={} uploaded={} hls_present={} action={:?} dry_run={}",
                 hash, meta.uploaded, hls_present, action, dry_run

--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -108,7 +108,7 @@ pub struct BlobMetadata {
 pub enum BlobStatus {
     /// Normal, publicly accessible
     Active,
-    /// Shadow restricted - only owner can access
+    /// Shadow restricted - only owner can access (renders as 404 to non-owners)
     Restricted,
     /// Awaiting moderation review
     Pending,
@@ -116,6 +116,11 @@ pub enum BlobStatus {
     Banned,
     /// Soft-deleted internally; preserved in storage but never served publicly
     Deleted,
+    /// Age-gated content. Non-owners receive 401 (auth_required) so the
+    /// client can present an age-verification UI. Distinct from `Restricted`,
+    /// which is shadow-banned and 404s to non-owners.
+    #[serde(rename = "age_restricted")]
+    AgeRestricted,
 }
 
 impl BlobStatus {
@@ -124,7 +129,62 @@ impl BlobStatus {
     }
 
     pub fn requires_owner_auth(self) -> bool {
-        matches!(self, BlobStatus::Restricted)
+        matches!(self, BlobStatus::Restricted | BlobStatus::AgeRestricted)
+    }
+}
+
+/// Result of evaluating whether a viewer is allowed to fetch a blob.
+///
+/// All blob-serving endpoints should derive their HTTP response from this
+/// enum (via [`BlobMetadata::access_for`]) instead of inspecting
+/// [`BlobStatus`] directly. This guarantees consistent behavior across
+/// `GET`/`HEAD` for blobs, thumbnails, HLS manifests, HLS segments,
+/// transcripts, and quality variants — and makes adding a new moderation
+/// outcome a single-file change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlobAccess {
+    /// Viewer may fetch the content.
+    Allowed,
+    /// Hide the existence of the blob (Banned / Deleted / shadow-Restricted to
+    /// non-owners). Maps to HTTP 404.
+    NotFound,
+    /// Age-gated content. Maps to HTTP 401 with body `age_restricted` so the
+    /// client can present an age-verification UI.
+    AgeGated,
+}
+
+impl BlobMetadata {
+    /// Decide whether a viewer is allowed to access this blob.
+    ///
+    /// `requester_pubkey` is the authenticated viewer's pubkey, if any.
+    /// `is_admin` is true when the request carries a valid admin Bearer token.
+    pub fn access_for(&self, requester_pubkey: Option<&str>, is_admin: bool) -> BlobAccess {
+        if is_admin {
+            return BlobAccess::Allowed;
+        }
+
+        let is_owner = requester_pubkey
+            .map(|p| p.eq_ignore_ascii_case(&self.owner))
+            .unwrap_or(false);
+
+        match self.status {
+            BlobStatus::Active | BlobStatus::Pending => BlobAccess::Allowed,
+            BlobStatus::Banned | BlobStatus::Deleted => BlobAccess::NotFound,
+            BlobStatus::Restricted => {
+                if is_owner {
+                    BlobAccess::Allowed
+                } else {
+                    BlobAccess::NotFound
+                }
+            }
+            BlobStatus::AgeRestricted => {
+                if is_owner {
+                    BlobAccess::Allowed
+                } else {
+                    BlobAccess::AgeGated
+                }
+            }
+        }
     }
 }
 
@@ -844,13 +904,14 @@ mod tests {
             BlobStatus::Pending,
             BlobStatus::Banned,
             BlobStatus::Deleted,
+            BlobStatus::AgeRestricted,
         ] {
             match s {
                 BlobStatus::Banned | BlobStatus::Deleted => {
                     assert!(s.blocks_public_access(), "{:?} should block public access", s);
                     assert!(!s.requires_owner_auth(), "{:?} should not require owner auth", s);
                 }
-                BlobStatus::Restricted => {
+                BlobStatus::Restricted | BlobStatus::AgeRestricted => {
                     assert!(!s.blocks_public_access(), "{:?} should not block public access", s);
                     assert!(s.requires_owner_auth(), "{:?} should require owner auth", s);
                 }
@@ -860,6 +921,126 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn fixture_metadata(status: BlobStatus, owner: &str) -> BlobMetadata {
+        BlobMetadata {
+            sha256: "x".into(),
+            size: 1,
+            mime_type: "video/mp4".into(),
+            uploaded: "2026-04-10T00:00:00Z".into(),
+            owner: owner.into(),
+            status,
+            thumbnail: None,
+            moderation: None,
+            transcode_status: None,
+            transcode_error_code: None,
+            transcode_error_message: None,
+            transcode_last_attempt_at: None,
+            transcode_retry_after: None,
+            transcode_attempt_count: 0,
+            transcode_terminal: false,
+            dim: None,
+            transcript_status: None,
+            transcript_error_code: None,
+            transcript_error_message: None,
+            transcript_last_attempt_at: None,
+            transcript_retry_after: None,
+            transcript_attempt_count: 0,
+            transcript_terminal: false,
+        }
+    }
+
+    #[test]
+    fn blob_status_serializes_age_restricted_with_underscore() {
+        let json = serde_json::to_string(&BlobStatus::AgeRestricted).unwrap();
+        assert_eq!(json, "\"age_restricted\"");
+    }
+
+    #[test]
+    fn blob_status_deserializes_age_restricted() {
+        let parsed: BlobStatus = serde_json::from_str("\"age_restricted\"").unwrap();
+        assert_eq!(parsed, BlobStatus::AgeRestricted);
+    }
+
+    #[test]
+    fn blob_status_age_restricted_does_not_block_public_access() {
+        // AgeRestricted should NOT be in blocks_public_access (that returns 404).
+        // It instead surfaces as an age-gate via access_for.
+        assert!(!BlobStatus::AgeRestricted.blocks_public_access());
+    }
+
+    #[test]
+    fn blob_status_age_restricted_requires_owner_auth() {
+        assert!(BlobStatus::AgeRestricted.requires_owner_auth());
+    }
+
+    #[test]
+    fn access_for_admin_always_allowed() {
+        let m = fixture_metadata(BlobStatus::Banned, "owner");
+        assert_eq!(m.access_for(None, true), BlobAccess::Allowed);
+        let m = fixture_metadata(BlobStatus::AgeRestricted, "owner");
+        assert_eq!(m.access_for(None, true), BlobAccess::Allowed);
+    }
+
+    #[test]
+    fn access_for_active_allowed_for_anyone() {
+        let m = fixture_metadata(BlobStatus::Active, "owner");
+        assert_eq!(m.access_for(None, false), BlobAccess::Allowed);
+        assert_eq!(m.access_for(Some("stranger"), false), BlobAccess::Allowed);
+        assert_eq!(m.access_for(Some("owner"), false), BlobAccess::Allowed);
+    }
+
+    #[test]
+    fn access_for_pending_allowed() {
+        // Existing behavior: Pending blobs are publicly served while waiting
+        // for moderation. Don't change that here.
+        let m = fixture_metadata(BlobStatus::Pending, "owner");
+        assert_eq!(m.access_for(None, false), BlobAccess::Allowed);
+    }
+
+    #[test]
+    fn access_for_banned_is_notfound_to_everyone_non_admin() {
+        let m = fixture_metadata(BlobStatus::Banned, "owner");
+        assert_eq!(m.access_for(Some("owner"), false), BlobAccess::NotFound);
+        assert_eq!(m.access_for(None, false), BlobAccess::NotFound);
+    }
+
+    #[test]
+    fn access_for_deleted_is_notfound_to_everyone_non_admin() {
+        let m = fixture_metadata(BlobStatus::Deleted, "owner");
+        assert_eq!(m.access_for(Some("owner"), false), BlobAccess::NotFound);
+        assert_eq!(m.access_for(None, false), BlobAccess::NotFound);
+    }
+
+    #[test]
+    fn access_for_restricted_is_notfound_to_non_owner_and_anonymous() {
+        let m = fixture_metadata(BlobStatus::Restricted, "owner");
+        assert_eq!(m.access_for(None, false), BlobAccess::NotFound);
+        assert_eq!(m.access_for(Some("stranger"), false), BlobAccess::NotFound);
+    }
+
+    #[test]
+    fn access_for_restricted_is_allowed_to_owner() {
+        let m = fixture_metadata(BlobStatus::Restricted, "owner");
+        assert_eq!(m.access_for(Some("owner"), false), BlobAccess::Allowed);
+        // Case-insensitive comparison
+        assert_eq!(m.access_for(Some("OWNER"), false), BlobAccess::Allowed);
+    }
+
+    #[test]
+    fn access_for_age_restricted_is_age_gated_to_non_owner_and_anonymous() {
+        let m = fixture_metadata(BlobStatus::AgeRestricted, "owner");
+        assert_eq!(m.access_for(None, false), BlobAccess::AgeGated);
+        assert_eq!(m.access_for(Some("stranger"), false), BlobAccess::AgeGated);
+    }
+
+    #[test]
+    fn access_for_age_restricted_is_allowed_to_owner() {
+        let m = fixture_metadata(BlobStatus::AgeRestricted, "owner");
+        assert_eq!(m.access_for(Some("owner"), false), BlobAccess::Allowed);
+        // Case-insensitive comparison
+        assert_eq!(m.access_for(Some("OWNER"), false), BlobAccess::Allowed);
     }
 
     #[test]

--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -908,16 +908,36 @@ mod tests {
         ] {
             match s {
                 BlobStatus::Banned | BlobStatus::Deleted => {
-                    assert!(s.blocks_public_access(), "{:?} should block public access", s);
-                    assert!(!s.requires_owner_auth(), "{:?} should not require owner auth", s);
+                    assert!(
+                        s.blocks_public_access(),
+                        "{:?} should block public access",
+                        s
+                    );
+                    assert!(
+                        !s.requires_owner_auth(),
+                        "{:?} should not require owner auth",
+                        s
+                    );
                 }
                 BlobStatus::Restricted | BlobStatus::AgeRestricted => {
-                    assert!(!s.blocks_public_access(), "{:?} should not block public access", s);
+                    assert!(
+                        !s.blocks_public_access(),
+                        "{:?} should not block public access",
+                        s
+                    );
                     assert!(s.requires_owner_auth(), "{:?} should require owner auth", s);
                 }
                 BlobStatus::Active | BlobStatus::Pending => {
-                    assert!(!s.blocks_public_access(), "{:?} should not block public access", s);
-                    assert!(!s.requires_owner_auth(), "{:?} should not require owner auth", s);
+                    assert!(
+                        !s.blocks_public_access(),
+                        "{:?} should not block public access",
+                        s
+                    );
+                    assert!(
+                        !s.requires_owner_auth(),
+                        "{:?} should not require owner auth",
+                        s
+                    );
                 }
             }
         }

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -1,10 +1,10 @@
+use crate::blossom::BlobMetadata;
 use crate::blossom::BlobStatus;
 use crate::error::{BlossomError, Result};
 use crate::metadata::{
     add_to_recent_index, add_to_user_list, get_blob_refs, put_tombstone, remove_from_recent_index,
     remove_from_user_list, update_blob_status, update_stats_on_status_change,
 };
-use crate::blossom::BlobMetadata;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeletePlan {
@@ -25,6 +25,7 @@ pub fn parse_restore_status(status: Option<&str>) -> Result<BlobStatus> {
         "APPROVE" | "ACTIVE" => Ok(BlobStatus::Active),
         "PENDING" => Ok(BlobStatus::Pending),
         "RESTRICT" | "RESTRICTED" => Ok(BlobStatus::Restricted),
+        "AGE_RESTRICT" | "AGE_RESTRICTED" => Ok(BlobStatus::AgeRestricted),
         "DELETED" => Err(BlossomError::BadRequest(
             "Restore target status cannot be deleted".into(),
         )),
@@ -110,10 +111,29 @@ mod tests {
     #[test]
     fn restore_from_deleted_allows_active_pending_or_restricted() {
         assert_eq!(parse_restore_status(None).unwrap(), BlobStatus::Active);
-        assert_eq!(parse_restore_status(Some("pending")).unwrap(), BlobStatus::Pending);
+        assert_eq!(
+            parse_restore_status(Some("pending")).unwrap(),
+            BlobStatus::Pending
+        );
         assert_eq!(
             parse_restore_status(Some("restricted")).unwrap(),
             BlobStatus::Restricted
+        );
+    }
+
+    #[test]
+    fn restore_target_accepts_age_restricted() {
+        assert_eq!(
+            parse_restore_status(Some("age_restricted")).unwrap(),
+            BlobStatus::AgeRestricted
+        );
+        assert_eq!(
+            parse_restore_status(Some("AGE_RESTRICTED")).unwrap(),
+            BlobStatus::AgeRestricted
+        );
+        assert_eq!(
+            parse_restore_status(Some("age_restrict")).unwrap(),
+            BlobStatus::AgeRestricted
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod admin_sweep;
+pub mod blossom;
 pub mod resumable_complete;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,10 +13,11 @@ mod storage;
 use crate::auth::{optional_auth, validate_auth, validate_hash_match};
 use crate::blossom::{
     is_audio_path, is_hash_path, is_transcribable_mime_type, is_video_mime_type, parse_audio_path,
-    parse_hash_from_path, parse_thumbnail_path, AudioMapping, AuthAction, BlobDescriptor,
-    BlobMetadata, BlobStatus, ResumableUploadCompleteResponse, ResumableUploadInitRequest,
-    ResumableUploadInitResponse, SubtitleJob, SubtitleJobCreateRequest, SubtitleJobStatus,
-    TranscodeStatus, TranscriptStatus, UploadRequirements,
+    parse_hash_from_path, parse_thumbnail_path, AudioMapping, AuthAction, BlobAccess,
+    BlobDescriptor, BlobMetadata, BlobStatus, ResumableUploadCompleteResponse,
+    ResumableUploadInitRequest, ResumableUploadInitResponse, SubtitleJob,
+    SubtitleJobCreateRequest, SubtitleJobStatus, TranscodeStatus, TranscriptStatus,
+    UploadRequirements,
 };
 use crate::delete_policy::{plan_user_delete, soft_delete_blob, DeletePlan};
 use crate::error::{BlossomError, Result};
@@ -372,20 +373,23 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         // Check parent video's moderation status - thumbnails inherit video access rules
         let mut is_restricted = false;
         if let Ok(Some(meta)) = get_blob_metadata(video_hash) {
-            if !is_admin {
-                if meta.status.blocks_public_access() {
+            let requester_pk = optional_auth(&req, AuthAction::List)
+                .ok()
+                .flatten()
+                .map(|auth| auth.pubkey);
+            match meta.access_for(requester_pk.as_deref(), is_admin) {
+                BlobAccess::Allowed => {
+                    // Owner viewing their own restricted/age-restricted thumb —
+                    // mark so cache headers stay private below.
+                    if meta.status.requires_owner_auth() {
+                        is_restricted = true;
+                    }
+                }
+                BlobAccess::NotFound => {
                     return Err(BlossomError::NotFound("Blob not found".into()));
                 }
-                if meta.status.requires_owner_auth() {
-                    // Check if requester is owner
-                    if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
-                        if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
-                            return Err(BlossomError::NotFound("Blob not found".into()));
-                        }
-                    } else {
-                        return Err(BlossomError::NotFound("Blob not found".into()));
-                    }
-                    is_restricted = true;
+                BlobAccess::AgeGated => {
+                    return Err(BlossomError::AuthRequired("age_restricted".into()));
                 }
             }
         }
@@ -437,22 +441,17 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
     }
 
     if let Some(ref meta) = metadata {
-        if !is_admin {
-            // Handle banned/deleted content - no access for anyone
-            if meta.status.blocks_public_access() {
+        let requester_pk = optional_auth(&req, AuthAction::List)
+            .ok()
+            .flatten()
+            .map(|auth| auth.pubkey);
+        match meta.access_for(requester_pk.as_deref(), is_admin) {
+            BlobAccess::Allowed => {}
+            BlobAccess::NotFound => {
                 return Err(BlossomError::NotFound("Blob not found".into()));
             }
-
-            // Handle restricted content - owner can still access
-            if meta.status.requires_owner_auth() {
-                // Check if requester is owner
-                if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
-                    if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
-                        return Err(BlossomError::NotFound("Blob not found".into()));
-                    }
-                } else {
-                    return Err(BlossomError::NotFound("Blob not found".into()));
-                }
+            BlobAccess::AgeGated => {
+                return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
     }
@@ -579,9 +578,12 @@ fn handle_head_blob(path: &str) -> Result<Response> {
     let metadata =
         get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
-    // Don't reveal restricted, banned, or deleted content exists
-    if metadata.status.requires_owner_auth() || metadata.status.blocks_public_access() {
-        return Err(BlossomError::NotFound("Blob not found".into()));
+    // HEAD has no auth context, so non-owner gating applies. Banned/Deleted/Restricted
+    // collapse to 404; AgeRestricted surfaces as 401 so the client knows to age-gate.
+    match metadata.access_for(None, false) {
+        BlobAccess::Allowed => {}
+        BlobAccess::NotFound => return Err(BlossomError::NotFound("Blob not found".into())),
+        BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
     }
 
     let mut resp = Response::from_status(StatusCode::OK);
@@ -619,21 +621,17 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
 
     if let Some(ref meta) = metadata {
-        if !is_admin {
-            // Handle banned/deleted content
-            if meta.status.blocks_public_access() {
+        let requester_pk = optional_auth(&req, AuthAction::List)
+            .ok()
+            .flatten()
+            .map(|auth| auth.pubkey);
+        match meta.access_for(requester_pk.as_deref(), is_admin) {
+            BlobAccess::Allowed => {}
+            BlobAccess::NotFound => {
                 return Err(BlossomError::NotFound("Content not found".into()));
             }
-
-            // Handle restricted content - owner can still access
-            if meta.status.requires_owner_auth() {
-                if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
-                    if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
-                        return Err(BlossomError::NotFound("Content not found".into()));
-                    }
-                } else {
-                    return Err(BlossomError::NotFound("Content not found".into()));
-                }
+            BlobAccess::AgeGated => {
+                return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
     } else {
@@ -763,9 +761,12 @@ fn handle_head_hls_master(path: &str) -> Result<Response> {
     let metadata = get_blob_metadata(&hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-    // Don't reveal restricted/banned/deleted content (HEAD has no req, no admin bypass)
-    if metadata.status.requires_owner_auth() || metadata.status.blocks_public_access() {
-        return Err(BlossomError::NotFound("Content not found".into()));
+    // HEAD has no req/admin context. Banned/Restricted collapse to 404; AgeRestricted
+    // surfaces as 401 so the client knows to age-gate.
+    match metadata.access_for(None, false) {
+        BlobAccess::Allowed => {}
+        BlobAccess::NotFound => return Err(BlossomError::NotFound("Content not found".into())),
+        BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
     }
 
     // Check GCS first (source of truth), then fall back to metadata status
@@ -838,19 +839,21 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
     let mut is_restricted = false;
 
     if let Ok(Some(ref meta)) = get_blob_metadata(&hash) {
-        if !is_admin {
-            if meta.status == BlobStatus::Banned {
+        let requester_pk = optional_auth(&req, AuthAction::List)
+            .ok()
+            .flatten()
+            .map(|auth| auth.pubkey);
+        match meta.access_for(requester_pk.as_deref(), is_admin) {
+            BlobAccess::Allowed => {
+                if meta.status.requires_owner_auth() {
+                    is_restricted = true;
+                }
+            }
+            BlobAccess::NotFound => {
                 return Err(BlossomError::NotFound("Blob not found".into()));
             }
-            if meta.status == BlobStatus::Restricted {
-                if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
-                    if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
-                        return Err(BlossomError::NotFound("Blob not found".into()));
-                    }
-                } else {
-                    return Err(BlossomError::NotFound("Blob not found".into()));
-                }
-                is_restricted = true;
+            BlobAccess::AgeGated => {
+                return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
     }
@@ -988,11 +991,18 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
 
     let hash_lower = hash.to_lowercase();
 
-    // Don't reveal restricted/banned/deleted content (HEAD has no req, no admin bypass)
+    // HEAD has no req/admin context. Banned/Restricted collapse to 404; AgeRestricted
+    // surfaces as 401 so the client knows to age-gate.
     let metadata = get_blob_metadata(&hash_lower)?;
     if let Some(ref meta) = metadata {
-        if meta.status.requires_owner_auth() || meta.status.blocks_public_access() {
-            return Err(BlossomError::NotFound("Content not found".into()));
+        match meta.access_for(None, false) {
+            BlobAccess::Allowed => {}
+            BlobAccess::NotFound => {
+                return Err(BlossomError::NotFound("Content not found".into()));
+            }
+            BlobAccess::AgeGated => {
+                return Err(BlossomError::AuthRequired("age_restricted".into()));
+            }
         }
     }
 
@@ -1455,24 +1465,13 @@ fn serve_transcript_by_hash(
         .map(|r| admin::validate_bearer_token(r).is_ok())
         .unwrap_or(false);
 
-    if !is_admin {
-        if metadata.status.blocks_public_access() {
-            return Err(BlossomError::NotFound("Content not found".into()));
-        }
-
-        if metadata.status.requires_owner_auth() {
-            if let Some(request) = req {
-                if let Ok(Some(auth)) = optional_auth(request, AuthAction::List) {
-                    if auth.pubkey.to_lowercase() != metadata.owner.to_lowercase() {
-                        return Err(BlossomError::NotFound("Content not found".into()));
-                    }
-                } else {
-                    return Err(BlossomError::NotFound("Content not found".into()));
-                }
-            } else {
-                return Err(BlossomError::NotFound("Content not found".into()));
-            }
-        }
+    let requester_pk = req
+        .and_then(|r| optional_auth(r, AuthAction::List).ok().flatten())
+        .map(|auth| auth.pubkey);
+    match metadata.access_for(requester_pk.as_deref(), is_admin) {
+        BlobAccess::Allowed => {}
+        BlobAccess::NotFound => return Err(BlossomError::NotFound("Content not found".into())),
+        BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
     }
 
     if !is_transcribable_mime_type(&metadata.mime_type) {
@@ -1604,8 +1603,12 @@ fn handle_head_transcript_by_hash(hash: &str) -> Result<Response> {
     let metadata = get_blob_metadata(hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-    if metadata.status.requires_owner_auth() || metadata.status.blocks_public_access() {
-        return Err(BlossomError::NotFound("Content not found".into()));
+    // HEAD has no req/admin context. Banned/Restricted collapse to 404; AgeRestricted
+    // surfaces as 401 so the client knows to age-gate.
+    match metadata.access_for(None, false) {
+        BlobAccess::Allowed => {}
+        BlobAccess::NotFound => return Err(BlossomError::NotFound("Content not found".into())),
+        BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
     }
 
     if !is_transcribable_mime_type(&metadata.mime_type) {
@@ -1897,11 +1900,22 @@ fn handle_get_subtitle_by_hash(req: Request, path: &str) -> Result<Response> {
         return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
     }
 
-    // Don't leak subtitle info for moderated content
+    // Don't leak subtitle info for moderated content. Use the blob's access_for so
+    // age-restricted videos surface as 401 (age gate) instead of 404.
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     if let Some(meta) = get_blob_metadata(&hash)? {
-        if !is_admin && (meta.status.requires_owner_auth() || meta.status.blocks_public_access()) {
-            return Err(BlossomError::NotFound("Video hash not found".into()));
+        let requester_pk = optional_auth(&req, AuthAction::List)
+            .ok()
+            .flatten()
+            .map(|auth| auth.pubkey);
+        match meta.access_for(requester_pk.as_deref(), is_admin) {
+            BlobAccess::Allowed => {}
+            BlobAccess::NotFound => {
+                return Err(BlossomError::NotFound("Video hash not found".into()));
+            }
+            BlobAccess::AgeGated => {
+                return Err(BlossomError::AuthRequired("age_restricted".into()));
+            }
         }
     }
 
@@ -1966,13 +1980,20 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
     let metadata =
         get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
-    // 2. Access control: banned/deleted content is not served
-    if metadata.status.blocks_public_access() {
-        return Err(BlossomError::NotFound("Blob not found".into()));
-    }
-    // Restricted content requires owner auth - not supported for audio extraction
-    if metadata.status.requires_owner_auth() {
-        return Err(BlossomError::NotFound("Blob not found".into()));
+    // 2. Access control. Audio extraction requires the source video to be accessible to
+    //    the caller — banned/deleted/shadow-restricted source -> 404; age-restricted
+    //    source -> 401 (age gate). Owner of restricted/age-restricted source is allowed
+    //    by access_for, but the audio handler currently does not implement owner-only
+    //    extraction, so we still gate non-owners on the source's status.
+    let requester_pk = optional_auth(&req, AuthAction::List)
+        .ok()
+        .flatten()
+        .map(|auth| auth.pubkey);
+    let is_admin = admin::validate_bearer_token(&req).is_ok();
+    match metadata.access_for(requester_pk.as_deref(), is_admin) {
+        BlobAccess::Allowed => {}
+        BlobAccess::NotFound => return Err(BlossomError::NotFound("Blob not found".into())),
+        BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
     }
 
     // 3. Check Funnelcake permission
@@ -2111,8 +2132,12 @@ fn handle_head_audio(path: &str) -> Result<Response> {
     let metadata =
         get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
-    if metadata.status.blocks_public_access() || metadata.status.requires_owner_auth() {
-        return Err(BlossomError::NotFound("Blob not found".into()));
+    // HEAD has no req/admin context. Banned/Restricted collapse to 404; AgeRestricted
+    // surfaces as 401 so the client knows to age-gate.
+    match metadata.access_for(None, false) {
+        BlobAccess::Allowed => {}
+        BlobAccess::NotFound => return Err(BlossomError::NotFound("Blob not found".into())),
+        BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
     }
 
     let permission = classify_audio_reuse_availability(&check_funnelcake_audio_reuse(&hash));
@@ -2194,18 +2219,17 @@ fn handle_get_quality_variant(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     let metadata = get_blob_metadata(&hash)?;
     if let Some(ref meta) = metadata {
-        if !is_admin {
-            if meta.status.blocks_public_access() {
+        let requester_pk = optional_auth(&req, AuthAction::List)
+            .ok()
+            .flatten()
+            .map(|auth| auth.pubkey);
+        match meta.access_for(requester_pk.as_deref(), is_admin) {
+            BlobAccess::Allowed => {}
+            BlobAccess::NotFound => {
                 return Err(BlossomError::NotFound("Content not found".into()));
             }
-            if meta.status.requires_owner_auth() {
-                if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
-                    if auth.pubkey.to_lowercase() != meta.owner.to_lowercase() {
-                        return Err(BlossomError::NotFound("Content not found".into()));
-                    }
-                } else {
-                    return Err(BlossomError::NotFound("Content not found".into()));
-                }
+            BlobAccess::AgeGated => {
+                return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
     } else {
@@ -2305,8 +2329,12 @@ fn handle_head_quality_variant(path: &str) -> Result<Response> {
     let metadata = get_blob_metadata(&hash)?
         .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
 
-    if metadata.status.blocks_public_access() || metadata.status.requires_owner_auth() {
-        return Err(BlossomError::NotFound("Content not found".into()));
+    // HEAD has no req/admin context. Banned/Restricted collapse to 404; AgeRestricted
+    // surfaces as 401 so the client knows to age-gate.
+    match metadata.access_for(None, false) {
+        BlobAccess::Allowed => {}
+        BlobAccess::NotFound => return Err(BlossomError::NotFound("Content not found".into())),
+        BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
     }
 
     let gcs_path = format!("{}/hls/{}", hash, ts_filename);

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,8 @@ use crate::blossom::{
     is_audio_path, is_hash_path, is_transcribable_mime_type, is_video_mime_type, parse_audio_path,
     parse_hash_from_path, parse_thumbnail_path, AudioMapping, AuthAction, BlobAccess,
     BlobDescriptor, BlobMetadata, BlobStatus, ResumableUploadCompleteResponse,
-    ResumableUploadInitRequest, ResumableUploadInitResponse, SubtitleJob,
-    SubtitleJobCreateRequest, SubtitleJobStatus, TranscodeStatus, TranscriptStatus,
-    UploadRequirements,
+    ResumableUploadInitRequest, ResumableUploadInitResponse, SubtitleJob, SubtitleJobCreateRequest,
+    SubtitleJobStatus, TranscodeStatus, TranscriptStatus, UploadRequirements,
 };
 use crate::delete_policy::{plan_user_delete, soft_delete_blob, DeletePlan};
 use crate::error::{BlossomError, Result};
@@ -4440,14 +4439,19 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
         return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
     }
 
-    // Map action to BlobStatus
+    // Map action to BlobStatus.
+    //
+    // AGE_RESTRICTED is intentionally split out from RESTRICT/QUARANTINE: it lands on
+    // BlobStatus::AgeRestricted, which serves as 401 (age gate) to non-owners instead of
+    // the 404 shadow-ban that RESTRICT/QUARANTINE produce.
     let new_status = match action.to_uppercase().as_str() {
         "BLOCK" | "BAN" | "PERMANENT_BAN" => BlobStatus::Banned,
-        "RESTRICT" | "AGE_RESTRICTED" | "QUARANTINE" => BlobStatus::Restricted,
+        "AGE_RESTRICTED" | "AGE_RESTRICT" => BlobStatus::AgeRestricted,
+        "RESTRICT" | "QUARANTINE" => BlobStatus::Restricted,
         "APPROVE" | "SAFE" => BlobStatus::Active,
         _ => {
             return Err(BlossomError::BadRequest(format!(
-                "Unknown action: {}. Expected BLOCK, RESTRICT, QUARANTINE, or APPROVE",
+                "Unknown action: {}. Expected BLOCK, RESTRICT, QUARANTINE, AGE_RESTRICTED, or APPROVE",
                 action
             )));
         }


### PR DESCRIPTION
## Summary

- Introduces `BlobStatus::AgeRestricted`, which returns **401** `{"error":"age_restricted"}` to non-owners instead of 404. This lets the divine-web player show its age-verification UI instead of treating the blob as permanently missing.
- Centralizes all 14 moderation gate sites in `src/main.rs` through a single `BlobMetadata::access_for(requester_pubkey, is_admin) -> BlobAccess` helper. No more inline `meta.status == BlobStatus::Restricted` checks scattered across GET/HEAD handlers.
- Routes the `AGE_RESTRICTED` webhook action from divine-moderation-service to the new variant (previously collapsed into `Restricted` / 404 shadow-ban). `RESTRICT` / `QUARANTINE` keep their existing 404 semantics.
- Adds a dry-run-by-default backfill script (`scripts/backfill_restricted_to_age_restricted.py`) for ad-hoc KV reclassification (scoped by hash allowlist or owner pubkey — never blanket, per T&S policy).

## Context

Legacy Vine archive imports flagged as adult by the moderation classifier were being served as 404 from `media.divine.video`. The classifier sent `AGE_RESTRICTED` to Blossom's webhook, but the old mapping collapsed it into `BlobStatus::Restricted` (shadow-ban → 404). The divine-web player only triggers its age-gate UI on 401/403, so these videos appeared permanently broken.

Investigation confirmed: all 4 reported hashes exist in GCS (`divine-blossom-media`), have healthy metadata in KV, complete transcodes, and complete transcripts. The 404 was purely the moderation gate in Fastly Compute.

## Changes

| File | What |
|---|---|
| `src/blossom.rs` | `BlobStatus::AgeRestricted` variant (serde: `"age_restricted"`), `BlobAccess` enum, `BlobMetadata::access_for()` helper, 13 new unit tests |
| `src/main.rs` | 14 gate sites refactored to use `access_for`; webhook `AGE_RESTRICTED` → `AgeRestricted` |
| `src/admin.rs` | Admin moderate + scan-flagged + bulk-approve handle `AgeRestricted` |
| `src/delete_policy.rs` | `parse_restore_status` accepts `AGE_RESTRICTED` |
| `src/lib.rs` | Expose `blossom` module so tests run via `cargo test --lib` |
| `scripts/backfill_*.py` | Concurrent KV scanner, dry-run default, `--apply` to write |
| `docs/superpowers/plans/` | Implementation plan |

## Test plan

- [x] `cargo test --lib` — 65 tests pass (13 new)
- [x] `cargo build --target wasm32-wasip1` — clean
- [x] Deployed as Fastly service version 271, purged
- [x] Active blobs (`5da3…`, `e2d4…`) still return 200
- [x] 4 known failing hashes manually promoted in KV → now return 401 `{"error":"age_restricted"}`
- [x] Thumbnails (`.jpg`) and HLS (`.hls`) for age-restricted blobs also return 401
- [ ] Verify divine-web age-gate UI triggers on 401 for `/hashtag/twerking`

🤖 Generated with [Claude Code](https://claude.com/claude-code)