### PR TITLE
fix(transcoder): increase Gemini transcription timeout from 30s to 120s

### DIFF
--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -147,7 +147,7 @@ impl Config {
             transcription_retry_total_ms: parse_value(
                 &mut lookup,
                 "TRANSCRIPTION_RETRY_TOTAL_MS",
-                30_000,
+                180_000,
             )
             .max(1_000),
         }
@@ -2332,7 +2332,7 @@ async fn transcribe_via_gemini(
         .post(&url)
         .bearer_auth(&access_token)
         .json(&body)
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(120))
         .send()
         .await
         .map_err(|e| {


### PR DESCRIPTION
## Summary

- Increase per-request Vertex AI timeout from 30s to 120s for Gemini 2.5 Pro transcription
- Increase default total retry budget from 30s to 180s (`TRANSCRIPTION_RETRY_TOTAL_MS`)

## Context

After switching transcription to Gemini 2.5 Pro (PR #76), we're seeing 5 Vertex AI timeout failures per day on small videos (2-7s, 0.3-2.1MB). Gemini 2.5 Pro is a thinking model that can exceed 30s even on short audio clips.

The previous configuration had per-request timeout (30s) equal to total retry budget (30s), meaning a single timeout exhausted all retries — zero headroom for retry attempts.

## Evidence from Cloud Run logs (2026-04-13)

| Error | Count | Root cause |
|-------|-------|------------|
| Vertex AI timeout | 5 | **This PR fixes** — 30s too short for Gemini 2.5 Pro |
| "no usable text" | 15 | Separate issue — Gemini returning empty segments |
| ffmpeg extraction | 13 | Single corrupt 5KB file retrying (pre-existing) |

All 5 timeout videos were tiny (2.4s–6.5s), confirming the issue is Gemini thinking time, not payload size.

## Test plan

- [x] `cargo test` passes (32 tests)
- [ ] Deploy to Cloud Run and verify timeout errors stop
- [ ] Monitor Sentry/logs for 24h post-deploy


🤖 Generated with [Claude Code](https://claude.com/claude-code)