### PR TITLE
fix: honor NIP-98 viewer auth for age-gated media

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ The module runs on Cloud Run as a Flask/gunicorn service. The Dockerfile install
 
 ## Authentication
 
-Uses Nostr kind 24242 events:
+Management operations (`PUT /upload`, `DELETE /<sha256>`, GDPR vanish) use
+Blossom auth events (`kind 24242`):
 
 ```json
 {
@@ -224,6 +225,14 @@ Uses Nostr kind 24242 events:
 ```
 
 Send as: `Authorization: Nostr <base64_encoded_signed_event>`
+
+Viewer/list requests additionally accept valid NIP-98 HTTP auth (`kind 27235`)
+for the exact request URL and method. This is used to identify the caller's
+pubkey on media routes. `age_restricted` blobs are served to any authenticated
+viewer and return `401 {"error":"age_restricted"}` to anonymous requests.
+`restricted` blobs remain shadow-banned and only serve to the owner or an admin.
+Blossom does not currently read any hosted-session age-verification claim or
+external viewer adult-verification service when serving media.
 
 ## License
 

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -147,7 +147,7 @@ impl Config {
             transcription_retry_total_ms: parse_value(
                 &mut lookup,
                 "TRANSCRIPTION_RETRY_TOTAL_MS",
-                30_000,
+                180_000,
             )
             .max(1_000),
         }
@@ -2332,7 +2332,7 @@ async fn transcribe_via_gemini(
         .post(&url)
         .bearer_auth(&access_token)
         .json(&body)
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(120))
         .send()
         .await
         .map_err(|e| {

--- a/docs/superpowers/plans/2026-04-16-media-age-auth-debug.md
+++ b/docs/superpowers/plans/2026-04-16-media-age-auth-debug.md
@@ -1,0 +1,107 @@
+# Media Age Auth Debug Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make blossom authenticate the media requests the web client actually sends, stop silently downgrading bad auth to anonymous, and lock in the intended age-gate contract with regression coverage.
+
+**Architecture:** `divine-web` sends NIP-98 HTTP auth (`kind 27235`) for media fetches, but blossom currently only accepts Blossom auth (`kind 24242`) and most media routes ignore auth-validation errors by calling `optional_auth(...).ok().flatten()`. The fix is to centralize viewer auth parsing for media/list routes, accept both Blossom list auth and valid NIP-98 auth, and change `BlobStatus::AgeRestricted` to mean "any authenticated viewer" while preserving `Restricted` as the owner/admin-only shadow-ban path.
+
+**Tech Stack:** Rust, Fastly Compute, existing auth helpers in `src/auth.rs`, media route handlers in `src/main.rs`, blob access policy in `src/blossom.rs`.
+
+---
+
+## Chunk 1: Viewer Auth Contract
+
+### Task 1: Add failing auth-mode tests
+
+**Files:**
+- Modify: `src/auth.rs`
+
+- [ ] **Step 1: Write failing tests for viewer auth parsing**
+
+Add unit tests that prove:
+- a valid Blossom list event is accepted
+- a valid NIP-98 GET event is accepted for the matching URL/method
+- a NIP-98 event with the wrong URL or method is rejected
+- a `kind 27235` event is not treated as anonymous when an auth header is present but invalid
+
+- [ ] **Step 2: Run the focused test target and confirm it fails for the intended reason**
+
+Run: `cargo test --lib`
+
+Expected: new auth tests fail because auth only supports `kind 24242`.
+
+### Task 2: Implement dual-mode viewer auth
+
+**Files:**
+- Modify: `src/auth.rs`
+
+- [ ] **Step 3: Add a viewer-auth helper**
+
+Implement a helper that:
+- returns `Ok(None)` when no `Authorization` header is present
+- validates Blossom list auth (`kind 24242`, `t=list`) when present
+- validates NIP-98 auth (`kind 27235`) for the exact absolute URL and HTTP method when present
+- returns an error instead of `None` when auth is present but invalid
+
+- [ ] **Step 4: Re-run the focused auth tests**
+
+Run: `cargo test --lib`
+
+Expected: auth tests pass.
+
+## Chunk 2: Route Wiring
+
+### Task 3: Route media fetches through strict viewer auth
+
+**Files:**
+- Modify: `src/main.rs`
+
+- [ ] **Step 5: Write failing pure tests around route auth decisions**
+
+Add tests for the route-facing auth helper / access decision layer covering:
+- no auth header on age-restricted content => `age_restricted`
+- invalid auth header => auth error, not anonymous fallback
+- valid NIP-98 auth for non-owner age-restricted content => allowed
+- valid auth for owner/admin => allowed
+
+- [ ] **Step 6: Run the focused test target and confirm the invalid-auth case fails first**
+
+Run: `cargo test --lib`
+
+Expected: invalid-auth case still behaves like anonymous before the fix.
+
+- [ ] **Step 7: Replace `optional_auth(...).ok().flatten()` on viewer/media routes**
+
+Wire the blob, thumbnail, HLS, transcript, subtitles-by-hash, audio, and quality-variant GET routes through the new strict viewer-auth helper.
+
+- [ ] **Step 8: Re-run the focused test target**
+
+Run: `cargo test --lib`
+
+Expected: new auth-routing tests pass.
+
+## Chunk 3: Verification And Contract
+
+### Task 4: Verify the supported build/test commands and capture the contract
+
+**Files:**
+- Modify: `README.md` if auth contract text needs correction
+
+- [ ] **Step 9: Run supported verification commands**
+
+Run:
+- `cargo test --lib`
+- `cargo check --target wasm32-wasi`
+
+Expected:
+- unit tests pass
+- wasm target compiles cleanly for the Fastly service
+
+- [ ] **Step 10: Update docs if needed**
+
+Document that:
+- blossom accepts Blossom auth and NIP-98 for viewer/list requests
+- `BlobStatus::AgeRestricted` serves any authenticated viewer while anonymous requests get `401 age_restricted`
+- `BlobStatus::Restricted` remains owner/admin-only and 404s for everyone else
+- blossom does not currently inspect hosted-session age claims or any viewer adult-verification service

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,165 +1,58 @@
-// ABOUTME: Nostr authentication for Blossom (kind 24242)
-// ABOUTME: Validates signatures, expiration, and authorization events using k256
+// ABOUTME: Request-bound auth wrappers for Blossom media and management routes
+// ABOUTME: Uses pure validation helpers from viewer_auth and adapts Fastly Request inputs
 
 use crate::blossom::{AuthAction, BlossomAuthEvent};
 use crate::error::{BlossomError, Result};
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use crate::viewer_auth::{parse_auth_header, validate_blossom_event, validate_viewer_event};
 use fastly::http::header::AUTHORIZATION;
 use fastly::Request;
-use k256::schnorr::{Signature, VerifyingKey};
-use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-/// Blossom auth event kind
-const BLOSSOM_AUTH_KIND: u32 = 24242;
-
-/// Extract and validate Blossom auth from request
+/// Extract and validate Blossom auth from request.
 pub fn validate_auth(req: &Request, required_action: AuthAction) -> Result<BlossomAuthEvent> {
+    let event = parse_request_auth_event(req)?;
+    validate_blossom_event(&event, required_action, unix_now())?;
+    Ok(event)
+}
+
+/// Extract the authenticated viewer pubkey for media/list requests.
+///
+/// Supports both Blossom list auth (kind 24242) and NIP-98 HTTP auth
+/// (kind 27235). If an auth header is present but invalid, this returns an
+/// error instead of silently treating the request as anonymous.
+pub fn viewer_pubkey(req: &Request) -> Result<Option<String>> {
+    if req.get_header(AUTHORIZATION).is_none() {
+        return Ok(None);
+    }
+
+    let event = parse_request_auth_event(req)?;
+    validate_viewer_event(
+        &event,
+        req.get_method().as_str(),
+        &req.get_url().to_string(),
+        unix_now(),
+    )?;
+    Ok(Some(event.pubkey))
+}
+
+fn parse_request_auth_event(req: &Request) -> Result<BlossomAuthEvent> {
     let auth_header = req
         .get_header(AUTHORIZATION)
         .ok_or_else(|| BlossomError::AuthRequired("Authorization header required".into()))?
         .to_str()
         .map_err(|_| BlossomError::AuthInvalid("Invalid authorization header".into()))?;
 
-    // Parse "Nostr <base64>" format
-    let base64_event = auth_header.strip_prefix("Nostr ").ok_or_else(|| {
-        BlossomError::AuthInvalid("Authorization must start with 'Nostr '".into())
-    })?;
-
-    // Decode base64
-    let event_json = BASE64
-        .decode(base64_event)
-        .map_err(|_| BlossomError::AuthInvalid("Invalid base64 in authorization".into()))?;
-
-    // Parse JSON
-    let event: BlossomAuthEvent = serde_json::from_slice(&event_json)
-        .map_err(|e| BlossomError::AuthInvalid(format!("Invalid event JSON: {}", e)))?;
-
-    // Validate the event
-    validate_event(&event, required_action)?;
-
-    Ok(event)
+    parse_auth_header(auth_header)
 }
 
-/// Validate a Blossom auth event
-fn validate_event(event: &BlossomAuthEvent, required_action: AuthAction) -> Result<()> {
-    // Check kind
-    if event.kind != BLOSSOM_AUTH_KIND {
-        return Err(BlossomError::AuthInvalid(format!(
-            "Invalid event kind: expected {}, got {}",
-            BLOSSOM_AUTH_KIND, event.kind
-        )));
-    }
-
-    // Check action tag
-    let action = event
-        .get_action()
-        .ok_or_else(|| BlossomError::AuthInvalid("Missing action tag".into()))?;
-
-    if action != required_action {
-        return Err(BlossomError::AuthInvalid(format!(
-            "Action mismatch: expected {:?}, got {:?}",
-            required_action, action
-        )));
-    }
-
-    // Check expiration
-    if let Some(expiration) = event.get_expiration() {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-
-        if now > expiration {
-            return Err(BlossomError::AuthInvalid("Authorization expired".into()));
-        }
-    }
-
-    // Verify event ID
-    let computed_id = compute_event_id(event)?;
-    if computed_id != event.id {
-        return Err(BlossomError::AuthInvalid("Invalid event ID".into()));
-    }
-
-    // Verify signature
-    verify_signature(event)?;
-
-    Ok(())
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
-/// Compute the event ID (sha256 of serialized event)
-fn compute_event_id(event: &BlossomAuthEvent) -> Result<String> {
-    // NIP-01 serialization: [0, pubkey, created_at, kind, tags, content]
-    let serialized = serde_json::to_string(&(
-        0u8,
-        &event.pubkey,
-        event.created_at,
-        event.kind,
-        &event.tags,
-        &event.content,
-    ))
-    .map_err(|e| BlossomError::Internal(format!("Failed to serialize event: {}", e)))?;
-
-    let mut hasher = Sha256::new();
-    hasher.update(serialized.as_bytes());
-    let hash = hasher.finalize();
-
-    Ok(hex::encode(hash))
-}
-
-/// Verify the Schnorr signature using k256
-fn verify_signature(event: &BlossomAuthEvent) -> Result<()> {
-    // Parse public key (32 bytes, x-only)
-    let pubkey_bytes = hex::decode(&event.pubkey)
-        .map_err(|_| BlossomError::AuthInvalid("Invalid public key hex".into()))?;
-
-    if pubkey_bytes.len() != 32 {
-        return Err(BlossomError::AuthInvalid(format!(
-            "Invalid public key length: expected 32, got {}",
-            pubkey_bytes.len()
-        )));
-    }
-
-    let verifying_key = VerifyingKey::from_bytes(&pubkey_bytes)
-        .map_err(|_| BlossomError::AuthInvalid("Invalid public key".into()))?;
-
-    // Parse signature (64 bytes)
-    let sig_bytes = hex::decode(&event.sig)
-        .map_err(|_| BlossomError::AuthInvalid("Invalid signature hex".into()))?;
-
-    if sig_bytes.len() != 64 {
-        return Err(BlossomError::AuthInvalid(format!(
-            "Invalid signature length: expected 64, got {}",
-            sig_bytes.len()
-        )));
-    }
-
-    let signature = Signature::try_from(sig_bytes.as_slice())
-        .map_err(|_| BlossomError::AuthInvalid("Invalid signature format".into()))?;
-
-    // Parse message (event ID as raw bytes - this is already a SHA-256 hash)
-    let msg_bytes = hex::decode(&event.id)
-        .map_err(|_| BlossomError::AuthInvalid("Invalid event ID hex".into()))?;
-
-    // Verify using BIP-340 Schnorr with prehashed message
-    // The event ID is already a SHA-256 hash, so we use verify_prehash
-    use k256::schnorr::signature::hazmat::PrehashVerifier;
-    verifying_key
-        .verify_prehash(&msg_bytes, &signature)
-        .map_err(|_| BlossomError::AuthInvalid("Invalid signature".into()))?;
-
-    Ok(())
-}
-
-/// Optional auth - returns None if no auth header, error if invalid auth
-pub fn optional_auth(req: &Request, action: AuthAction) -> Result<Option<BlossomAuthEvent>> {
-    if req.get_header(AUTHORIZATION).is_none() {
-        return Ok(None);
-    }
-    validate_auth(req, action).map(Some)
-}
-
-/// Validate that the auth event matches a specific blob hash (for delete)
+/// Validate that the auth event matches a specific blob hash (for delete).
 pub fn validate_hash_match(event: &BlossomAuthEvent, expected_hash: &str) -> Result<()> {
     let event_hash = event
         .get_hash()
@@ -172,26 +65,4 @@ pub fn validate_hash_match(event: &BlossomAuthEvent, expected_hash: &str) -> Res
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_compute_event_id() {
-        // This is a simplified test - real tests would use known test vectors
-        let event = BlossomAuthEvent {
-            id: "test".into(),
-            pubkey: "a".repeat(64),
-            created_at: 1234567890,
-            kind: 24242,
-            tags: vec![vec!["t".into(), "upload".into()]],
-            content: "test".into(),
-            sig: "b".repeat(128),
-        };
-
-        let id = compute_event_id(&event).unwrap();
-        assert_eq!(id.len(), 64); // SHA-256 hex
-    }
 }

--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -116,7 +116,7 @@ pub enum BlobStatus {
     Banned,
     /// Soft-deleted internally; preserved in storage but never served publicly
     Deleted,
-    /// Age-gated content. Non-owners receive 401 (auth_required) so the
+    /// Age-gated content. Anonymous viewers receive 401 (auth_required) so the
     /// client can present an age-verification UI. Distinct from `Restricted`,
     /// which is shadow-banned and 404s to non-owners.
     #[serde(rename = "age_restricted")]
@@ -128,7 +128,7 @@ impl BlobStatus {
         matches!(self, BlobStatus::Banned | BlobStatus::Deleted)
     }
 
-    pub fn requires_owner_auth(self) -> bool {
+    pub fn requires_private_cache(self) -> bool {
         matches!(self, BlobStatus::Restricted | BlobStatus::AgeRestricted)
     }
 }
@@ -178,7 +178,7 @@ impl BlobMetadata {
                 }
             }
             BlobStatus::AgeRestricted => {
-                if is_owner {
+                if requester_pubkey.is_some() {
                     BlobAccess::Allowed
                 } else {
                     BlobAccess::AgeGated
@@ -862,7 +862,7 @@ mod tests {
     #[test]
     fn test_active_status_allows_public_access() {
         assert!(!BlobStatus::Active.blocks_public_access());
-        assert!(!BlobStatus::Active.requires_owner_auth());
+        assert!(!BlobStatus::Active.requires_private_cache());
     }
 
     #[test]
@@ -870,7 +870,8 @@ mod tests {
         assert!(BlobStatus::Banned.blocks_public_access());
         assert!(BlobStatus::Deleted.blocks_public_access());
         assert!(!BlobStatus::Restricted.blocks_public_access());
-        assert!(BlobStatus::Restricted.requires_owner_auth());
+        assert!(BlobStatus::Restricted.requires_private_cache());
+        assert!(BlobStatus::AgeRestricted.requires_private_cache());
         assert!(!BlobStatus::Pending.blocks_public_access());
     }
 
@@ -884,12 +885,11 @@ mod tests {
             BlobStatus::Banned.blocks_public_access(),
         );
         assert_eq!(
-            BlobStatus::Deleted.requires_owner_auth(),
-            BlobStatus::Banned.requires_owner_auth(),
+            BlobStatus::Deleted.requires_private_cache(),
+            BlobStatus::Banned.requires_private_cache(),
         );
-        // Neither should allow owner access
-        assert!(!BlobStatus::Deleted.requires_owner_auth());
-        assert!(!BlobStatus::Banned.requires_owner_auth());
+        assert!(!BlobStatus::Deleted.requires_private_cache());
+        assert!(!BlobStatus::Banned.requires_private_cache());
     }
 
     #[test]
@@ -914,18 +914,34 @@ mod tests {
                         s
                     );
                     assert!(
-                        !s.requires_owner_auth(),
-                        "{:?} should not require owner auth",
+                        !s.requires_private_cache(),
+                        "{:?} should not require private cache",
                         s
                     );
                 }
-                BlobStatus::Restricted | BlobStatus::AgeRestricted => {
+                BlobStatus::Restricted => {
                     assert!(
                         !s.blocks_public_access(),
                         "{:?} should not block public access",
                         s
                     );
-                    assert!(s.requires_owner_auth(), "{:?} should require owner auth", s);
+                    assert!(
+                        s.requires_private_cache(),
+                        "{:?} should require private cache",
+                        s
+                    );
+                }
+                BlobStatus::AgeRestricted => {
+                    assert!(
+                        !s.blocks_public_access(),
+                        "{:?} should not block public access",
+                        s
+                    );
+                    assert!(
+                        s.requires_private_cache(),
+                        "{:?} should require private cache",
+                        s
+                    );
                 }
                 BlobStatus::Active | BlobStatus::Pending => {
                     assert!(
@@ -934,8 +950,8 @@ mod tests {
                         s
                     );
                     assert!(
-                        !s.requires_owner_auth(),
-                        "{:?} should not require owner auth",
+                        !s.requires_private_cache(),
+                        "{:?} should not require private cache",
                         s
                     );
                 }
@@ -991,8 +1007,8 @@ mod tests {
     }
 
     #[test]
-    fn blob_status_age_restricted_requires_owner_auth() {
-        assert!(BlobStatus::AgeRestricted.requires_owner_auth());
+    fn blob_status_age_restricted_requires_private_cache_not_owner_auth() {
+        assert!(BlobStatus::AgeRestricted.requires_private_cache());
     }
 
     #[test]
@@ -1049,10 +1065,15 @@ mod tests {
     }
 
     #[test]
-    fn access_for_age_restricted_is_age_gated_to_non_owner_and_anonymous() {
+    fn access_for_age_restricted_is_age_gated_to_anonymous_only() {
         let m = fixture_metadata(BlobStatus::AgeRestricted, "owner");
         assert_eq!(m.access_for(None, false), BlobAccess::AgeGated);
-        assert_eq!(m.access_for(Some("stranger"), false), BlobAccess::AgeGated);
+    }
+
+    #[test]
+    fn access_for_age_restricted_is_allowed_to_any_authenticated_viewer() {
+        let m = fixture_metadata(BlobStatus::AgeRestricted, "owner");
+        assert_eq!(m.access_for(Some("stranger"), false), BlobAccess::Allowed);
     }
 
     #[test]
@@ -1462,6 +1483,6 @@ mod tests {
         assert!(desc.hls.is_some());
         assert!(desc.vtt.is_some());
         assert!(!meta.status.blocks_public_access());
-        assert!(!meta.status.requires_owner_auth());
+        assert!(!meta.status.requires_private_cache());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod admin_sweep;
 pub mod blossom;
+pub mod error;
 pub mod resumable_complete;
+pub mod viewer_auth;
 
 #[cfg(test)]
 mod tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,9 @@ mod delete_policy;
 mod error;
 mod metadata;
 mod storage;
+mod viewer_auth;
 
-use crate::auth::{optional_auth, validate_auth, validate_hash_match};
+use crate::auth::{validate_auth, validate_hash_match, viewer_pubkey};
 use crate::blossom::{
     is_audio_path, is_hash_path, is_transcribable_mime_type, is_video_mime_type, parse_audio_path,
     parse_hash_from_path, parse_thumbnail_path, AudioMapping, AuthAction, BlobAccess,
@@ -27,7 +28,7 @@ use crate::metadata::{
     get_audio_mapping, get_audio_source_refs, get_auth_event, get_blob_metadata, get_blob_refs,
     get_subtitle_job, get_subtitle_job_by_hash, get_tombstone, get_user_blobs,
     list_blobs_with_metadata, put_audio_mapping, put_auth_event, put_blob_metadata,
-    put_subtitle_job, put_tombstone, remove_from_audio_source_refs, remove_from_blob_refs,
+    put_subtitle_job, remove_from_audio_source_refs, remove_from_blob_refs,
     remove_from_recent_index, remove_from_user_index, remove_from_user_list,
     set_subtitle_job_id_for_hash, update_blob_status, update_stats_on_add, update_stats_on_remove,
     TranscodeMetadataUpdate, TranscriptMetadataUpdate,
@@ -271,6 +272,7 @@ fn audio_reuse_denied_response() -> Response {
 fn add_audio_response_headers(
     resp: &mut Response,
     source_hash: &str,
+    private_cache: bool,
     mime_type: &str,
     size_bytes: u64,
     duration_seconds: f64,
@@ -283,7 +285,11 @@ fn add_audio_response_headers(
     resp.set_header("X-Audio-Duration", format!("{}", duration_seconds));
     resp.set_header("X-Audio-Size", size_bytes.to_string());
     resp.set_header("Accept-Ranges", "bytes");
-    add_cache_headers(resp, source_hash);
+    if private_cache {
+        add_private_cache_headers(resp, source_hash);
+    } else {
+        add_cache_headers(resp, source_hash);
+    }
     add_cors_headers(resp);
 }
 
@@ -372,15 +378,12 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         // Check parent video's moderation status - thumbnails inherit video access rules
         let mut is_restricted = false;
         if let Ok(Some(meta)) = get_blob_metadata(video_hash) {
-            let requester_pk = optional_auth(&req, AuthAction::List)
-                .ok()
-                .flatten()
-                .map(|auth| auth.pubkey);
+            let requester_pk = viewer_pubkey(&req)?;
             match meta.access_for(requester_pk.as_deref(), is_admin) {
                 BlobAccess::Allowed => {
-                    // Owner viewing their own restricted/age-restricted thumb —
-                    // mark so cache headers stay private below.
-                    if meta.status.requires_owner_auth() {
+                    // Authenticated access to restricted/age-restricted thumbnails
+                    // must stay private in cache below.
+                    if meta.status.requires_private_cache() {
                         is_restricted = true;
                     }
                 }
@@ -440,10 +443,7 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
     }
 
     if let Some(ref meta) = metadata {
-        let requester_pk = optional_auth(&req, AuthAction::List)
-            .ok()
-            .flatten()
-            .map(|auth| auth.pubkey);
+        let requester_pk = viewer_pubkey(&req)?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
             BlobAccess::Allowed => {}
             BlobAccess::NotFound => {
@@ -620,10 +620,7 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
 
     if let Some(ref meta) = metadata {
-        let requester_pk = optional_auth(&req, AuthAction::List)
-            .ok()
-            .flatten()
-            .map(|auth| auth.pubkey);
+        let requester_pk = viewer_pubkey(&req)?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
             BlobAccess::Allowed => {}
             BlobAccess::NotFound => {
@@ -662,7 +659,11 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
                 .map(|s| s.to_string());
 
             resp.set_header("Content-Type", "application/vnd.apple.mpegurl");
-            add_cache_headers(&mut resp, &hash);
+            if is_admin || meta.status.requires_private_cache() {
+                add_private_cache_headers(&mut resp, &hash);
+            } else {
+                add_cache_headers(&mut resp, &hash);
+            }
             resp.set_header("X-Sha256", &hash);
             if let Some(c2pa) = c2pa_manifest_id {
                 resp.set_header("X-C2PA-Manifest-Id", &c2pa);
@@ -838,13 +839,10 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
     let mut is_restricted = false;
 
     if let Ok(Some(ref meta)) = get_blob_metadata(&hash) {
-        let requester_pk = optional_auth(&req, AuthAction::List)
-            .ok()
-            .flatten()
-            .map(|auth| auth.pubkey);
+        let requester_pk = viewer_pubkey(&req)?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
             BlobAccess::Allowed => {
-                if meta.status.requires_owner_auth() {
+                if meta.status.requires_private_cache() {
                     is_restricted = true;
                 }
             }
@@ -1464,9 +1462,10 @@ fn serve_transcript_by_hash(
         .map(|r| admin::validate_bearer_token(r).is_ok())
         .unwrap_or(false);
 
-    let requester_pk = req
-        .and_then(|r| optional_auth(r, AuthAction::List).ok().flatten())
-        .map(|auth| auth.pubkey);
+    let requester_pk = match req {
+        Some(request) => viewer_pubkey(request)?,
+        None => None,
+    };
     match metadata.access_for(requester_pk.as_deref(), is_admin) {
         BlobAccess::Allowed => {}
         BlobAccess::NotFound => return Err(BlossomError::NotFound("Content not found".into())),
@@ -1495,7 +1494,11 @@ fn serve_transcript_by_hash(
                 );
             }
             resp.set_header("Content-Type", "text/vtt; charset=utf-8");
-            add_cache_headers(&mut resp, &hash);
+            if is_admin || metadata.status.requires_private_cache() {
+                add_private_cache_headers(&mut resp, &hash);
+            } else {
+                add_cache_headers(&mut resp, &hash);
+            }
             add_cors_headers(&mut resp);
             Ok(resp)
         }
@@ -1903,10 +1906,7 @@ fn handle_get_subtitle_by_hash(req: Request, path: &str) -> Result<Response> {
     // age-restricted videos surface as 401 (age gate) instead of 404.
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     if let Some(meta) = get_blob_metadata(&hash)? {
-        let requester_pk = optional_auth(&req, AuthAction::List)
-            .ok()
-            .flatten()
-            .map(|auth| auth.pubkey);
+        let requester_pk = viewer_pubkey(&req)?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
             BlobAccess::Allowed => {}
             BlobAccess::NotFound => {
@@ -1980,14 +1980,10 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
         get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     // 2. Access control. Audio extraction requires the source video to be accessible to
-    //    the caller — banned/deleted/shadow-restricted source -> 404; age-restricted
-    //    source -> 401 (age gate). Owner of restricted/age-restricted source is allowed
-    //    by access_for, but the audio handler currently does not implement owner-only
-    //    extraction, so we still gate non-owners on the source's status.
-    let requester_pk = optional_auth(&req, AuthAction::List)
-        .ok()
-        .flatten()
-        .map(|auth| auth.pubkey);
+    //    the caller — banned/deleted/shadow-restricted source -> 404; anonymous
+    //    age-restricted source -> 401 (age gate). Any authenticated viewer may access
+    //    age-restricted content, while shadow-restricted content stays owner/admin only.
+    let requester_pk = viewer_pubkey(&req)?;
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     match metadata.access_for(requester_pk.as_deref(), is_admin) {
         BlobAccess::Allowed => {}
@@ -2009,6 +2005,8 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
         AudioReuseAvailability::Denied => return Ok(audio_reuse_denied_response()),
         AudioReuseAvailability::LookupUnavailable => return Ok(audio_lookup_unavailable_response()),
     }
+
+    let private_cache = is_admin || metadata.status.requires_private_cache();
 
     // 4. Must be a video source
     if !is_video_mime_type(&metadata.mime_type) {
@@ -2037,6 +2035,7 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
             add_audio_response_headers(
                 &mut resp,
                 &hash,
+                private_cache,
                 &mapping.mime_type,
                 mapping.size_bytes,
                 mapping.duration_seconds,
@@ -2119,7 +2118,7 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
     // 8. Download and serve the audio
     let result = download_blob_with_fallback(&audio_sha256, range.as_deref())?;
     let mut resp = result.response;
-    add_audio_response_headers(&mut resp, &hash, &mime_type, size, duration);
+    add_audio_response_headers(&mut resp, &hash, private_cache, &mime_type, size, duration);
     Ok(resp)
 }
 
@@ -2165,6 +2164,7 @@ fn handle_head_audio(path: &str) -> Result<Response> {
             add_audio_response_headers(
                 &mut resp,
                 &hash,
+                metadata.status.requires_private_cache(),
                 &mapping.mime_type,
                 mapping.size_bytes,
                 mapping.duration_seconds,
@@ -2218,10 +2218,7 @@ fn handle_get_quality_variant(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     let metadata = get_blob_metadata(&hash)?;
     if let Some(ref meta) = metadata {
-        let requester_pk = optional_auth(&req, AuthAction::List)
-            .ok()
-            .flatten()
-            .map(|auth| auth.pubkey);
+        let requester_pk = viewer_pubkey(&req)?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
             BlobAccess::Allowed => {}
             BlobAccess::NotFound => {
@@ -2247,7 +2244,11 @@ fn handle_get_quality_variant(req: Request, path: &str) -> Result<Response> {
     match download_hls_content(&gcs_path, range.as_deref()) {
         Ok(mut resp) => {
             resp.set_header("Content-Type", content_type);
-            add_cache_headers(&mut resp, &hash);
+            if is_admin || meta.status.requires_private_cache() {
+                add_private_cache_headers(&mut resp, &hash);
+            } else {
+                add_cache_headers(&mut resp, &hash);
+            }
             resp.set_header("Accept-Ranges", "bytes");
             add_cors_headers(&mut resp);
             Ok(resp)
@@ -3752,7 +3753,7 @@ fn execute_vanish(pubkey: &str) -> (u32, u32, u32) {
 
 /// DELETE /vanish - User-initiated GDPR right to erasure
 fn handle_vanish(req: Request) -> Result<Response> {
-    // Validate auth (NIP-98/Blossom)
+    // Validate Blossom delete auth.
     let auth = validate_auth(&req, AuthAction::Delete)?;
     let auth_event_json = serde_json::to_string(&auth).unwrap_or_default();
 
@@ -3831,11 +3832,9 @@ fn handle_list(req: Request, path: &str) -> Result<Response> {
         .ok_or_else(|| BlossomError::BadRequest("Invalid list path".into()))?;
 
     // Check if authenticated as the owner (to include restricted blobs)
-    let is_owner = if let Ok(Some(auth)) = optional_auth(&req, AuthAction::List) {
-        auth.pubkey.to_lowercase() == pubkey.to_lowercase()
-    } else {
-        false
-    };
+    let is_owner = viewer_pubkey(&req)?
+        .map(|viewer| viewer.eq_ignore_ascii_case(pubkey))
+        .unwrap_or(false);
 
     // Get blobs with metadata
     let blobs = list_blobs_with_metadata(pubkey, is_owner)?;
@@ -4442,8 +4441,8 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
     // Map action to BlobStatus.
     //
     // AGE_RESTRICTED is intentionally split out from RESTRICT/QUARANTINE: it lands on
-    // BlobStatus::AgeRestricted, which serves as 401 (age gate) to non-owners instead of
-    // the 404 shadow-ban that RESTRICT/QUARANTINE produce.
+    // BlobStatus::AgeRestricted, which serves as a 401 age gate to anonymous viewers
+    // instead of the 404 shadow-ban that RESTRICT/QUARANTINE produce.
     let new_status = match action.to_uppercase().as_str() {
         "BLOCK" | "BAN" | "PERMANENT_BAN" => BlobStatus::Banned,
         "AGE_RESTRICTED" | "AGE_RESTRICT" => BlobStatus::AgeRestricted,
@@ -5068,7 +5067,7 @@ fn handle_landing_page() -> Response {
             <div class="features">
                 <div class="feature">
                     <h3>Nostr Authentication</h3>
-                    <p>Secure uploads using NIP-98 HTTP Auth with Schnorr signatures.</p>
+                    <p>Viewer requests accept Blossom list auth or NIP-98 HTTP auth. Upload and delete operations require signed Blossom events (kind <code>24242</code>).</p>
                 </div>
                 <div class="feature">
                     <h3>Content Moderation</h3>
@@ -5151,8 +5150,8 @@ fn add_cache_headers(resp: &mut Response, hash: &str) {
     resp.set_header("Surrogate-Key", hash);
 }
 
-/// Like add_cache_headers but for restricted content served only to the owner.
-/// Uses private/no-store so VCL doesn't cache it, but still sets Surrogate-Key for purging.
+/// Like add_cache_headers but for authenticated or admin-only content that must
+/// not be stored in shared caches.
 fn add_private_cache_headers(resp: &mut Response, hash: &str) {
     resp.set_header("Cache-Control", "private, no-store");
     resp.set_header("Surrogate-Control", "no-store");

--- a/src/viewer_auth.rs
+++ b/src/viewer_auth.rs
@@ -1,0 +1,328 @@
+// ABOUTME: Pure Nostr HTTP auth validation for Blossom media viewers
+// ABOUTME: Supports Divine Blossom auth (kind 24242) and NIP-98 (kind 27235)
+
+use crate::blossom::{AuthAction, BlossomAuthEvent};
+use crate::error::{BlossomError, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use k256::schnorr::{Signature, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+/// Divine Blossom auth event kind.
+pub const BLOSSOM_AUTH_KIND: u32 = 24242;
+/// NIP-98 HTTP auth event kind.
+pub const NIP98_AUTH_KIND: u32 = 27235;
+/// Suggested freshness window from NIP-98.
+pub const NIP98_MAX_AGE_SECS: u64 = 60;
+
+pub fn parse_auth_header(auth_header: &str) -> Result<BlossomAuthEvent> {
+    let base64_event = auth_header.strip_prefix("Nostr ").ok_or_else(|| {
+        BlossomError::AuthInvalid("Authorization must start with 'Nostr '".into())
+    })?;
+
+    let event_json = BASE64
+        .decode(base64_event)
+        .map_err(|_| BlossomError::AuthInvalid("Invalid base64 in authorization".into()))?;
+
+    serde_json::from_slice(&event_json)
+        .map_err(|e| BlossomError::AuthInvalid(format!("Invalid event JSON: {}", e)))
+}
+
+pub fn validate_blossom_event(
+    event: &BlossomAuthEvent,
+    required_action: AuthAction,
+    now: u64,
+) -> Result<()> {
+    if event.kind != BLOSSOM_AUTH_KIND {
+        return Err(BlossomError::AuthInvalid(format!(
+            "Invalid event kind: expected {}, got {}",
+            BLOSSOM_AUTH_KIND, event.kind
+        )));
+    }
+
+    let action = event
+        .get_action()
+        .ok_or_else(|| BlossomError::AuthInvalid("Missing action tag".into()))?;
+    if action != required_action {
+        return Err(BlossomError::AuthInvalid(format!(
+            "Action mismatch: expected {:?}, got {:?}",
+            required_action, action
+        )));
+    }
+
+    if let Some(expiration) = event.get_expiration() {
+        if now > expiration {
+            return Err(BlossomError::AuthInvalid("Authorization expired".into()));
+        }
+    }
+
+    validate_event_integrity(event)
+}
+
+pub fn validate_nip98_event(
+    event: &BlossomAuthEvent,
+    request_method: &str,
+    request_url: &str,
+    now: u64,
+) -> Result<()> {
+    if event.kind != NIP98_AUTH_KIND {
+        return Err(BlossomError::AuthInvalid(format!(
+            "Invalid event kind: expected {}, got {}",
+            NIP98_AUTH_KIND, event.kind
+        )));
+    }
+
+    let oldest_allowed = now.saturating_sub(NIP98_MAX_AGE_SECS);
+    let newest_allowed = now.saturating_add(NIP98_MAX_AGE_SECS);
+    if event.created_at < oldest_allowed || event.created_at > newest_allowed {
+        return Err(BlossomError::AuthInvalid(
+            "Authorization timestamp outside allowed NIP-98 window".into(),
+        ));
+    }
+
+    let event_url = get_tag_value(event, "u")
+        .ok_or_else(|| BlossomError::AuthInvalid("Missing u tag".into()))?;
+    if event_url != request_url {
+        return Err(BlossomError::AuthInvalid(format!(
+            "URL mismatch: expected {}, got {}",
+            request_url, event_url
+        )));
+    }
+
+    let event_method = get_tag_value(event, "method")
+        .ok_or_else(|| BlossomError::AuthInvalid("Missing method tag".into()))?;
+    if event_method != request_method {
+        return Err(BlossomError::AuthInvalid(format!(
+            "Method mismatch: expected {}, got {}",
+            request_method, event_method
+        )));
+    }
+
+    validate_event_integrity(event)
+}
+
+pub fn validate_viewer_event(
+    event: &BlossomAuthEvent,
+    request_method: &str,
+    request_url: &str,
+    now: u64,
+) -> Result<()> {
+    match event.kind {
+        BLOSSOM_AUTH_KIND => validate_blossom_event(event, AuthAction::List, now),
+        NIP98_AUTH_KIND => validate_nip98_event(event, request_method, request_url, now),
+        kind => Err(BlossomError::AuthInvalid(format!(
+            "Invalid event kind: expected {} or {}, got {}",
+            BLOSSOM_AUTH_KIND, NIP98_AUTH_KIND, kind
+        ))),
+    }
+}
+
+fn get_tag_value<'a>(event: &'a BlossomAuthEvent, tag_name: &str) -> Option<&'a str> {
+    event.tags.iter().find_map(|tag| {
+        if tag.len() >= 2 && tag[0] == tag_name {
+            Some(tag[1].as_str())
+        } else {
+            None
+        }
+    })
+}
+
+fn validate_event_integrity(event: &BlossomAuthEvent) -> Result<()> {
+    let computed_id = compute_event_id(event)?;
+    if computed_id != event.id {
+        return Err(BlossomError::AuthInvalid("Invalid event ID".into()));
+    }
+
+    verify_signature(event)?;
+    Ok(())
+}
+
+fn compute_event_id(event: &BlossomAuthEvent) -> Result<String> {
+    let serialized = serde_json::to_string(&(
+        0u8,
+        &event.pubkey,
+        event.created_at,
+        event.kind,
+        &event.tags,
+        &event.content,
+    ))
+    .map_err(|e| BlossomError::Internal(format!("Failed to serialize event: {}", e)))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(serialized.as_bytes());
+    let hash = hasher.finalize();
+
+    Ok(hex::encode(hash))
+}
+
+fn verify_signature(event: &BlossomAuthEvent) -> Result<()> {
+    let pubkey_bytes = hex::decode(&event.pubkey)
+        .map_err(|_| BlossomError::AuthInvalid("Invalid public key hex".into()))?;
+    if pubkey_bytes.len() != 32 {
+        return Err(BlossomError::AuthInvalid(format!(
+            "Invalid public key length: expected 32, got {}",
+            pubkey_bytes.len()
+        )));
+    }
+
+    let verifying_key = VerifyingKey::from_bytes(&pubkey_bytes)
+        .map_err(|_| BlossomError::AuthInvalid("Invalid public key".into()))?;
+
+    let sig_bytes = hex::decode(&event.sig)
+        .map_err(|_| BlossomError::AuthInvalid("Invalid signature hex".into()))?;
+    if sig_bytes.len() != 64 {
+        return Err(BlossomError::AuthInvalid(format!(
+            "Invalid signature length: expected 64, got {}",
+            sig_bytes.len()
+        )));
+    }
+
+    let signature = Signature::try_from(sig_bytes.as_slice())
+        .map_err(|_| BlossomError::AuthInvalid("Invalid signature format".into()))?;
+
+    let msg_bytes = hex::decode(&event.id)
+        .map_err(|_| BlossomError::AuthInvalid("Invalid event ID hex".into()))?;
+
+    use k256::schnorr::signature::hazmat::PrehashVerifier;
+    verifying_key
+        .verify_prehash(&msg_bytes, &signature)
+        .map_err(|_| BlossomError::AuthInvalid("Invalid signature".into()))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k256::schnorr::{signature::hazmat::PrehashSigner, SigningKey};
+
+    const TEST_URL: &str =
+        "https://media.divine.video/4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e";
+
+    #[test]
+    fn blossom_list_auth_is_valid_for_viewer_requests() {
+        let event = signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "list".into()],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        );
+
+        assert!(validate_viewer_event(&event, "GET", TEST_URL, 1_100).is_ok());
+    }
+
+    #[test]
+    fn nip98_auth_is_valid_for_matching_request() {
+        let event = signed_event(
+            NIP98_AUTH_KIND,
+            vec![
+                vec!["u".into(), TEST_URL.into()],
+                vec!["method".into(), "GET".into()],
+            ],
+            1_000,
+        );
+
+        assert!(validate_viewer_event(&event, "GET", TEST_URL, 1_000).is_ok());
+    }
+
+    #[test]
+    fn nip98_auth_rejects_url_mismatch() {
+        let event = signed_event(
+            NIP98_AUTH_KIND,
+            vec![
+                vec!["u".into(), "https://media.divine.video/different".into()],
+                vec!["method".into(), "GET".into()],
+            ],
+            1_000,
+        );
+
+        let error = validate_viewer_event(&event, "GET", TEST_URL, 1_000)
+            .expect_err("url mismatch should fail");
+        assert_eq!(
+            error.message(),
+            "URL mismatch: expected https://media.divine.video/4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e, got https://media.divine.video/different"
+        );
+    }
+
+    #[test]
+    fn nip98_auth_rejects_method_mismatch() {
+        let event = signed_event(
+            NIP98_AUTH_KIND,
+            vec![
+                vec!["u".into(), TEST_URL.into()],
+                vec!["method".into(), "HEAD".into()],
+            ],
+            1_000,
+        );
+
+        let error = validate_viewer_event(&event, "GET", TEST_URL, 1_000)
+            .expect_err("method mismatch should fail");
+        assert_eq!(error.message(), "Method mismatch: expected GET, got HEAD");
+    }
+
+    #[test]
+    fn nip98_auth_rejects_stale_timestamp() {
+        let event = signed_event(
+            NIP98_AUTH_KIND,
+            vec![
+                vec!["u".into(), TEST_URL.into()],
+                vec!["method".into(), "GET".into()],
+            ],
+            900,
+        );
+
+        let error = validate_viewer_event(&event, "GET", TEST_URL, 1_000)
+            .expect_err("stale timestamp should fail");
+        assert_eq!(
+            error.message(),
+            "Authorization timestamp outside allowed NIP-98 window"
+        );
+    }
+
+    #[test]
+    fn blossom_only_validation_rejects_nip98() {
+        let event = signed_event(
+            NIP98_AUTH_KIND,
+            vec![
+                vec!["u".into(), TEST_URL.into()],
+                vec!["method".into(), "DELETE".into()],
+            ],
+            1_000,
+        );
+
+        let error = validate_blossom_event(&event, AuthAction::Delete, 1_000)
+            .expect_err("delete routes should still require Blossom auth");
+        assert_eq!(
+            error.message(),
+            "Invalid event kind: expected 24242, got 27235"
+        );
+    }
+
+    #[test]
+    fn parse_auth_header_rejects_wrong_scheme() {
+        let error = parse_auth_header("Bearer nope").expect_err("wrong scheme should fail");
+        assert_eq!(error.message(), "Authorization must start with 'Nostr '");
+    }
+
+    fn signed_event(kind: u32, tags: Vec<Vec<String>>, created_at: u64) -> BlossomAuthEvent {
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]).expect("test key should be valid");
+        let mut event = BlossomAuthEvent {
+            id: String::new(),
+            pubkey: hex::encode(signing_key.verifying_key().to_bytes()),
+            created_at,
+            kind,
+            tags,
+            content: String::new(),
+            sig: String::new(),
+        };
+
+        event.id = compute_event_id(&event).expect("event id should compute");
+        let id_bytes = hex::decode(&event.id).expect("event id should be valid hex");
+        let signature: Signature = signing_key
+            .sign_prehash(&id_bytes)
+            .expect("event id prehash should sign");
+        event.sig = hex::encode(signature.to_bytes());
+        event
+    }
+}


### PR DESCRIPTION
## Summary
- accept NIP-98 HTTP auth as viewer auth on media and list routes instead of silently downgrading invalid auth to anonymous
- change `age_restricted` media policy to serve any authenticated viewer while preserving `restricted` as the owner/admin-only shadow-ban path
- keep authenticated and admin media responses off shared caches across blobs, thumbnails, HLS, VTT, audio, and quality variants

## Test Plan
- [x] `cargo test --lib`
- [x] `cargo check --target wasm32-wasi`
