### PR TITLE
fix(media): add ingress auth diagnostics for protected routes

### DIFF
--- a/docs/superpowers/plans/2026-04-16-media-request-auth-observability.md
+++ b/docs/superpowers/plans/2026-04-16-media-request-auth-observability.md
@@ -1,0 +1,113 @@
+# Media Request Auth Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add targeted ingress diagnostics for media routes so one failing age-restricted request can be traced through auth presence, NIP-98 validation, and access outcome.
+
+**Architecture:** Keep the existing viewer auth contract intact, but introduce a small auth-diagnostics helper that classifies media request auth without logging secrets. Route handlers will log one structured line containing method, path, host, auth presence, normalized request URL, validation result, and access decision before returning. This keeps the change scoped to observability rather than policy changes.
+
+**Tech Stack:** Rust, Fastly Compute, existing auth helpers in `src/auth.rs`, viewer auth validation in `src/viewer_auth.rs`, media handlers in `src/main.rs`.
+
+---
+
+## Chunk 1: Auth Diagnostics Helper
+
+### Task 1: Add failing auth diagnostics tests
+
+**Files:**
+- Modify: `src/auth.rs`
+
+- [ ] **Step 1: Write failing tests for diagnostics classification**
+
+Add unit tests covering:
+- no Authorization header => `auth_present=false`, `auth_state=missing`
+- malformed Authorization header => `auth_present=true`, `auth_state=invalid_scheme`
+- valid NIP-98 header => `auth_present=true`, `auth_state=valid`, includes normalized request URL and pubkey
+- URL/method mismatch => `auth_present=true`, `auth_state=validation_failed`
+
+- [ ] **Step 2: Run the focused auth tests and confirm they fail**
+
+Run: `cargo test --lib auth::tests::`
+Expected: FAIL because diagnostics helper/types do not exist yet.
+
+- [ ] **Step 3: Implement minimal diagnostics helper**
+
+Add a helper that:
+- accepts a `Request`
+- records method/path/host and whether `Authorization` exists
+- normalizes the request URL the same way viewer auth validation does
+- validates viewer auth without logging secrets
+- returns both the existing pubkey result and a diagnostics struct suitable for logging
+
+- [ ] **Step 4: Re-run the focused auth tests**
+
+Run: `cargo test --lib auth::tests::`
+Expected: PASS
+
+## Chunk 2: Media Route Logging
+
+### Task 2: Log auth and access outcome on media GET routes
+
+**Files:**
+- Modify: `src/main.rs`
+- Test: `src/main.rs`
+
+- [ ] **Step 5: Write failing tests for the structured log formatter**
+
+Add unit tests for a pure formatter/helper covering:
+- anonymous auth diagnostics + `AgeGated` access outcome
+- valid viewer auth + `Allowed` outcome
+- validation failure + auth error outcome
+
+- [ ] **Step 6: Run the focused formatter tests and confirm they fail**
+
+Run: `cargo test --lib main::tests::`
+Expected: FAIL because the formatter/helper does not exist yet.
+
+- [ ] **Step 7: Implement structured media auth logging**
+
+Wire the diagnostics helper into the GET media handlers that can return `age_restricted`:
+- direct blob / thumbnail
+- HLS master / HLS content
+- transcript / subtitle by hash
+- audio / quality variant
+
+For each request, log one structured line with:
+- route name
+- method
+- path
+- host
+- auth_present
+- auth_state
+- normalized_request_url
+- viewer_pubkey_present
+- access outcome or auth error
+
+Do not log raw `Authorization` headers, signatures, or full events.
+
+- [ ] **Step 8: Re-run the focused formatter tests**
+
+Run: `cargo test --lib main::tests::`
+Expected: PASS
+
+## Chunk 3: Verification
+
+### Task 3: Verify the repo still builds and tests cleanly
+
+**Files:**
+- Modify: none unless small doc wording is needed
+
+- [ ] **Step 9: Run targeted verification**
+
+Run:
+- `cargo test --lib auth::tests::`
+- `cargo test --lib main::tests::`
+
+Expected: PASS
+
+- [ ] **Step 10: Run broader verification**
+
+Run:
+- `cargo test --lib`
+
+Expected: PASS

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,7 +4,8 @@
 use crate::blossom::{AuthAction, BlossomAuthEvent};
 use crate::error::{BlossomError, Result};
 use crate::viewer_auth::{
-    parse_auth_header, public_request_url, validate_blossom_event, validate_viewer_event,
+    diagnose_viewer_auth_request, parse_auth_header, validate_blossom_event, ViewerAuthDiagnostics,
+    ViewerAuthState,
 };
 use fastly::http::header::{AUTHORIZATION, HOST};
 use fastly::Request;
@@ -23,22 +24,31 @@ pub fn validate_auth(req: &Request, required_action: AuthAction) -> Result<Bloss
 /// (kind 27235). If an auth header is present but invalid, this returns an
 /// error instead of silently treating the request as anonymous.
 pub fn viewer_pubkey(req: &Request) -> Result<Option<String>> {
-    if req.get_header(AUTHORIZATION).is_none() {
-        return Ok(None);
-    }
+    let diagnostics = diagnose_viewer_auth(req)?;
 
-    let event = parse_request_auth_event(req)?;
-    let request_url = public_request_url(
-        &req.get_url().to_string(),
-        req.get_header(HOST).and_then(|h| h.to_str().ok()),
-    )?;
-    validate_viewer_event(
-        &event,
+    match diagnostics.auth_state {
+        ViewerAuthState::Missing => Ok(None),
+        ViewerAuthState::Valid => Ok(diagnostics.viewer_pubkey),
+        ViewerAuthState::InvalidScheme
+        | ViewerAuthState::ParseFailed
+        | ViewerAuthState::RequestUrlInvalid
+        | ViewerAuthState::ValidationFailed => Err(BlossomError::AuthInvalid(
+            diagnostics
+                .auth_error
+                .unwrap_or_else(|| "Invalid viewer authorization".into()),
+        )),
+    }
+}
+
+pub fn diagnose_viewer_auth(req: &Request) -> Result<ViewerAuthDiagnostics> {
+    Ok(diagnose_viewer_auth_request(
         req.get_method().as_str(),
-        &request_url,
+        req.get_path(),
+        req.get_header(HOST).and_then(|h| h.to_str().ok()),
+        &req.get_url().to_string(),
+        req.get_header(AUTHORIZATION).and_then(|h| h.to_str().ok()),
         unix_now(),
-    )?;
-    Ok(Some(event.pubkey))
+    ))
 }
 
 fn parse_request_auth_event(req: &Request) -> Result<BlossomAuthEvent> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod admin_sweep;
 pub mod blossom;
 pub mod error;
+pub mod media_auth_log;
 pub mod resumable_complete;
 pub mod viewer_auth;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,12 @@ mod auth;
 mod blossom;
 mod delete_policy;
 mod error;
+mod media_auth_log;
 mod metadata;
 mod storage;
 mod viewer_auth;
 
-use crate::auth::{validate_auth, validate_hash_match, viewer_pubkey};
+use crate::auth::{diagnose_viewer_auth, validate_auth, validate_hash_match, viewer_pubkey};
 use crate::blossom::{
     is_audio_path, is_hash_path, is_transcribable_mime_type, is_video_mime_type, parse_audio_path,
     parse_hash_from_path, parse_thumbnail_path, AudioMapping, AuthAction, BlobAccess,
@@ -21,6 +22,7 @@ use crate::blossom::{
 };
 use crate::delete_policy::{plan_user_delete, soft_delete_blob, DeletePlan};
 use crate::error::{BlossomError, Result};
+use crate::media_auth_log::format_media_auth_log;
 use crate::metadata::{
     add_to_audio_source_refs, add_to_blob_refs, add_to_recent_index, add_to_user_index,
     add_to_user_list, delete_audio_mapping, delete_audio_source_refs, delete_auth_events,
@@ -39,6 +41,7 @@ use crate::storage::{
     trigger_audit_anonymize, trigger_cloud_run_bulk_delete, trigger_cloud_run_delete_blob,
     upload_blob, write_audit_log,
 };
+use crate::viewer_auth::{ViewerAuthDiagnostics, ViewerAuthState};
 use fastly_blossom::resumable_complete::parse_resumable_complete_request_body;
 
 use fastly::cache::simple as simple_cache;
@@ -187,7 +190,9 @@ fn handle_request(req: Request) -> Result<Response> {
             admin::handle_admin_blob_content(req, hash)
         }
         // Admin bypass for transcoded quality variants (720p.mp4, 480p.mp4, etc.)
-        (Method::GET, p) if p.starts_with("/admin/api/blob/") && is_admin_quality_variant_path(p) => {
+        (Method::GET, p)
+            if p.starts_with("/admin/api/blob/") && is_admin_quality_variant_path(p) =>
+        {
             handle_admin_quality_variant(req, p)
         }
         // Admin bypass for HLS content (master.m3u8, segments, etc.)
@@ -223,6 +228,34 @@ enum AudioReuseAvailability {
     Allowed,
     Denied,
     LookupUnavailable,
+}
+
+fn media_viewer_context(
+    req: &Request,
+    route: &str,
+) -> Result<(Option<String>, ViewerAuthDiagnostics)> {
+    let diagnostics = diagnose_viewer_auth(req)?;
+
+    match diagnostics.auth_state {
+        ViewerAuthState::Missing => Ok((None, diagnostics)),
+        ViewerAuthState::Valid => Ok((diagnostics.viewer_pubkey.clone(), diagnostics)),
+        _ => {
+            eprintln!(
+                "{}",
+                format_media_auth_log(route, &diagnostics, "auth_invalid")
+            );
+            Err(BlossomError::AuthInvalid(
+                diagnostics
+                    .auth_error
+                    .clone()
+                    .unwrap_or_else(|| "Invalid viewer authorization".into()),
+            ))
+        }
+    }
+}
+
+fn log_media_outcome(route: &str, diagnostics: &ViewerAuthDiagnostics, outcome: &str) {
+    eprintln!("{}", format_media_auth_log(route, diagnostics, outcome));
 }
 
 fn classify_audio_reuse_availability(result: &Result<bool>) -> AudioReuseAvailability {
@@ -386,9 +419,10 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         // Check parent video's moderation status - thumbnails inherit video access rules
         let mut is_restricted = false;
         if let Ok(Some(meta)) = get_blob_metadata(video_hash) {
-            let requester_pk = viewer_pubkey(&req)?;
+            let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "thumbnail")?;
             match meta.access_for(requester_pk.as_deref(), is_admin) {
                 BlobAccess::Allowed => {
+                    log_media_outcome("thumbnail", &auth_diagnostics, "allowed");
                     // Authenticated access to restricted/age-restricted thumbnails
                     // must stay private in cache below.
                     if meta.status.requires_private_cache() {
@@ -396,9 +430,11 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
                     }
                 }
                 BlobAccess::NotFound => {
+                    log_media_outcome("thumbnail", &auth_diagnostics, "not_found");
                     return Err(BlossomError::NotFound("Blob not found".into()));
                 }
                 BlobAccess::AgeGated => {
+                    log_media_outcome("thumbnail", &auth_diagnostics, "age_gated");
                     return Err(BlossomError::AuthRequired("age_restricted".into()));
                 }
             }
@@ -451,13 +487,15 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
     }
 
     if let Some(ref meta) = metadata {
-        let requester_pk = viewer_pubkey(&req)?;
+        let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "blob")?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
-            BlobAccess::Allowed => {}
+            BlobAccess::Allowed => log_media_outcome("blob", &auth_diagnostics, "allowed"),
             BlobAccess::NotFound => {
+                log_media_outcome("blob", &auth_diagnostics, "not_found");
                 return Err(BlossomError::NotFound("Blob not found".into()));
             }
             BlobAccess::AgeGated => {
+                log_media_outcome("blob", &auth_diagnostics, "age_gated");
                 return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
@@ -628,13 +666,15 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
 
     if let Some(ref meta) = metadata {
-        let requester_pk = viewer_pubkey(&req)?;
+        let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "hls_master")?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
-            BlobAccess::Allowed => {}
+            BlobAccess::Allowed => log_media_outcome("hls_master", &auth_diagnostics, "allowed"),
             BlobAccess::NotFound => {
+                log_media_outcome("hls_master", &auth_diagnostics, "not_found");
                 return Err(BlossomError::NotFound("Content not found".into()));
             }
             BlobAccess::AgeGated => {
+                log_media_outcome("hls_master", &auth_diagnostics, "age_gated");
                 return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
@@ -847,17 +887,20 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
     let mut is_restricted = false;
 
     if let Ok(Some(ref meta)) = get_blob_metadata(&hash) {
-        let requester_pk = viewer_pubkey(&req)?;
+        let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "hls_content")?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
             BlobAccess::Allowed => {
+                log_media_outcome("hls_content", &auth_diagnostics, "allowed");
                 if meta.status.requires_private_cache() {
                     is_restricted = true;
                 }
             }
             BlobAccess::NotFound => {
+                log_media_outcome("hls_content", &auth_diagnostics, "not_found");
                 return Err(BlossomError::NotFound("Blob not found".into()));
             }
             BlobAccess::AgeGated => {
+                log_media_outcome("hls_content", &auth_diagnostics, "age_gated");
                 return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
@@ -1459,6 +1502,7 @@ fn derivative_failure_head_response(
 
 fn serve_transcript_by_hash(
     req: Option<&Request>,
+    route: &str,
     hash: &str,
     can_trigger: bool,
 ) -> Result<Response> {
@@ -1470,14 +1514,31 @@ fn serve_transcript_by_hash(
         .map(|r| admin::validate_bearer_token(r).is_ok())
         .unwrap_or(false);
 
-    let requester_pk = match req {
-        Some(request) => viewer_pubkey(request)?,
-        None => None,
+    let (requester_pk, auth_diagnostics) = match req {
+        Some(request) => {
+            let (requester_pk, diagnostics) = media_viewer_context(request, route)?;
+            (requester_pk, Some(diagnostics))
+        }
+        None => (None, None),
     };
     match metadata.access_for(requester_pk.as_deref(), is_admin) {
-        BlobAccess::Allowed => {}
-        BlobAccess::NotFound => return Err(BlossomError::NotFound("Content not found".into())),
-        BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
+        BlobAccess::Allowed => {
+            if let Some(ref diagnostics) = auth_diagnostics {
+                log_media_outcome(route, diagnostics, "allowed");
+            }
+        }
+        BlobAccess::NotFound => {
+            if let Some(ref diagnostics) = auth_diagnostics {
+                log_media_outcome(route, diagnostics, "not_found");
+            }
+            return Err(BlossomError::NotFound("Content not found".into()));
+        }
+        BlobAccess::AgeGated => {
+            if let Some(ref diagnostics) = auth_diagnostics {
+                log_media_outcome(route, diagnostics, "age_gated");
+            }
+            return Err(BlossomError::AuthRequired("age_restricted".into()));
+        }
     }
 
     if !is_transcribable_mime_type(&metadata.mime_type) {
@@ -1585,7 +1646,7 @@ fn serve_transcript_by_hash(
 fn handle_get_transcript(req: Request, path: &str) -> Result<Response> {
     let hash = parse_transcript_path(path)
         .ok_or_else(|| BlossomError::BadRequest("Invalid transcript path".into()))?;
-    serve_transcript_by_hash(Some(&req), &hash, true)
+    serve_transcript_by_hash(Some(&req), "transcript_file", &hash, true)
 }
 
 /// HEAD /<sha256>/VTT - Check transcript existence/status
@@ -1599,7 +1660,7 @@ fn handle_head_transcript(path: &str) -> Result<Response> {
 fn handle_get_transcript_file(req: Request, path: &str) -> Result<Response> {
     let hash = parse_vtt_file_path(path)
         .ok_or_else(|| BlossomError::BadRequest("Invalid VTT path".into()))?;
-    serve_transcript_by_hash(Some(&req), &hash, true)
+    serve_transcript_by_hash(Some(&req), "transcript", &hash, true)
 }
 
 /// HEAD /<sha256>.vtt - Check transcript file URL status
@@ -1914,13 +1975,17 @@ fn handle_get_subtitle_by_hash(req: Request, path: &str) -> Result<Response> {
     // age-restricted videos surface as 401 (age gate) instead of 404.
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     if let Some(meta) = get_blob_metadata(&hash)? {
-        let requester_pk = viewer_pubkey(&req)?;
+        let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "subtitle_by_hash")?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
-            BlobAccess::Allowed => {}
+            BlobAccess::Allowed => {
+                log_media_outcome("subtitle_by_hash", &auth_diagnostics, "allowed")
+            }
             BlobAccess::NotFound => {
+                log_media_outcome("subtitle_by_hash", &auth_diagnostics, "not_found");
                 return Err(BlossomError::NotFound("Video hash not found".into()));
             }
             BlobAccess::AgeGated => {
+                log_media_outcome("subtitle_by_hash", &auth_diagnostics, "age_gated");
                 return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
@@ -1991,12 +2056,18 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
     //    the caller — banned/deleted/shadow-restricted source -> 404; anonymous
     //    age-restricted source -> 401 (age gate). Any authenticated viewer may access
     //    age-restricted content, while shadow-restricted content stays owner/admin only.
-    let requester_pk = viewer_pubkey(&req)?;
+    let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "audio")?;
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     match metadata.access_for(requester_pk.as_deref(), is_admin) {
-        BlobAccess::Allowed => {}
-        BlobAccess::NotFound => return Err(BlossomError::NotFound("Blob not found".into())),
-        BlobAccess::AgeGated => return Err(BlossomError::AuthRequired("age_restricted".into())),
+        BlobAccess::Allowed => log_media_outcome("audio", &auth_diagnostics, "allowed"),
+        BlobAccess::NotFound => {
+            log_media_outcome("audio", &auth_diagnostics, "not_found");
+            return Err(BlossomError::NotFound("Blob not found".into()));
+        }
+        BlobAccess::AgeGated => {
+            log_media_outcome("audio", &auth_diagnostics, "age_gated");
+            return Err(BlossomError::AuthRequired("age_restricted".into()));
+        }
     }
 
     // 3. Check Funnelcake permission
@@ -2226,13 +2297,17 @@ fn handle_get_quality_variant(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     let metadata = get_blob_metadata(&hash)?;
     if let Some(ref meta) = metadata {
-        let requester_pk = viewer_pubkey(&req)?;
+        let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "quality_variant")?;
         match meta.access_for(requester_pk.as_deref(), is_admin) {
-            BlobAccess::Allowed => {}
+            BlobAccess::Allowed => {
+                log_media_outcome("quality_variant", &auth_diagnostics, "allowed")
+            }
             BlobAccess::NotFound => {
+                log_media_outcome("quality_variant", &auth_diagnostics, "not_found");
                 return Err(BlossomError::NotFound("Content not found".into()));
             }
             BlobAccess::AgeGated => {
+                log_media_outcome("quality_variant", &auth_diagnostics, "age_gated");
                 return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
@@ -2395,8 +2470,8 @@ fn handle_admin_quality_variant(req: Request, path: &str) -> Result<Response> {
         .ok_or_else(|| BlossomError::BadRequest("Invalid admin quality variant path".into()))?;
 
     // Verify blob exists (but don't check moderation status)
-    let meta = get_blob_metadata(&hash)?
-        .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
+    let meta =
+        get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     let gcs_path = format!("{}/hls/{}", hash, ts_filename);
 
@@ -2443,14 +2518,14 @@ fn handle_admin_quality_variant(req: Request, path: &str) -> Result<Response> {
                 meta.transcode_terminal,
                 unix_timestamp_secs(),
             ) {
-                TranscodeFetchAction::Terminal => {
-                    Ok(derivative_failure_response(
-                        meta.transcode_error_code.as_deref(),
-                        meta.transcode_error_message.as_deref(),
-                        "Video transcoding permanently failed",
-                    ))
-                }
-                TranscodeFetchAction::Accepted { retry_after_secs, .. } => {
+                TranscodeFetchAction::Terminal => Ok(derivative_failure_response(
+                    meta.transcode_error_code.as_deref(),
+                    meta.transcode_error_message.as_deref(),
+                    "Video transcoding permanently failed",
+                )),
+                TranscodeFetchAction::Accepted {
+                    retry_after_secs, ..
+                } => {
                     let mut resp = Response::from_status(StatusCode::ACCEPTED);
                     resp.set_header("Retry-After", retry_after_secs.to_string());
                     resp.set_header("Content-Type", "application/json");
@@ -2459,7 +2534,9 @@ fn handle_admin_quality_variant(req: Request, path: &str) -> Result<Response> {
                     add_cors_headers(&mut resp);
                     Ok(resp)
                 }
-                TranscodeFetchAction::Trigger { retry_after_secs, .. } => {
+                TranscodeFetchAction::Trigger {
+                    retry_after_secs, ..
+                } => {
                     use crate::metadata::update_transcode_status;
                     let _ = update_transcode_status(&hash, TranscodeStatus::Processing);
                     let _ = trigger_on_demand_transcoding(&hash, &meta.owner);
@@ -2467,7 +2544,9 @@ fn handle_admin_quality_variant(req: Request, path: &str) -> Result<Response> {
                     let mut resp = Response::from_status(StatusCode::ACCEPTED);
                     resp.set_header("Retry-After", retry_after_secs.to_string());
                     resp.set_header("Content-Type", "application/json");
-                    resp.set_body(r#"{"status":"processing","message":"Transcoding started, please retry"}"#);
+                    resp.set_body(
+                        r#"{"status":"processing","message":"Transcoding started, please retry"}"#,
+                    );
                     add_no_cache_headers(&mut resp);
                     add_cors_headers(&mut resp);
                     Ok(resp)
@@ -2489,7 +2568,9 @@ fn handle_admin_hls_content(req: Request, path: &str) -> Result<Response> {
         .ok_or_else(|| BlossomError::BadRequest("Invalid admin HLS path".into()))?;
     let parts: Vec<&str> = rest.splitn(3, '/').collect();
     if parts.len() < 3 || parts[1] != "hls" {
-        return Err(BlossomError::BadRequest("Invalid admin HLS path format".into()));
+        return Err(BlossomError::BadRequest(
+            "Invalid admin HLS path format".into(),
+        ));
     }
 
     let hash = parts[0];
@@ -2501,8 +2582,8 @@ fn handle_admin_hls_content(req: Request, path: &str) -> Result<Response> {
     let hash = hash.to_lowercase();
 
     // Verify blob exists (but don't check moderation status)
-    let meta = get_blob_metadata(&hash)?
-        .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
+    let meta =
+        get_blob_metadata(&hash)?.ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
 
     let gcs_path = format!("{}/hls/{}", hash, filename);
 
@@ -2537,16 +2618,22 @@ fn handle_admin_hls_content(req: Request, path: &str) -> Result<Response> {
                     meta.transcode_error_message.as_deref(),
                     "HLS generation failed for this blob",
                 )),
-                TranscodeFetchAction::Accepted { retry_after_secs, .. } => {
+                TranscodeFetchAction::Accepted {
+                    retry_after_secs, ..
+                } => {
                     let mut resp = Response::from_status(StatusCode::ACCEPTED);
                     resp.set_header("Retry-After", retry_after_secs.to_string());
                     resp.set_header("Content-Type", "application/json");
-                    resp.set_body(r#"{"status":"processing","message":"HLS transcoding in progress"}"#);
+                    resp.set_body(
+                        r#"{"status":"processing","message":"HLS transcoding in progress"}"#,
+                    );
                     add_no_cache_headers(&mut resp);
                     add_cors_headers(&mut resp);
                     Ok(resp)
                 }
-                TranscodeFetchAction::Trigger { retry_after_secs, .. } => {
+                TranscodeFetchAction::Trigger {
+                    retry_after_secs, ..
+                } => {
                     use crate::metadata::update_transcode_status;
                     let _ = update_transcode_status(&hash, TranscodeStatus::Processing);
                     let _ = trigger_on_demand_transcoding(&hash, &meta.owner);

--- a/src/media_auth_log.rs
+++ b/src/media_auth_log.rs
@@ -1,0 +1,89 @@
+use crate::viewer_auth::{ViewerAuthDiagnostics, ViewerAuthState};
+
+pub fn format_media_auth_log(
+    route: &str,
+    diagnostics: &ViewerAuthDiagnostics,
+    outcome: &str,
+) -> String {
+    format!(
+        concat!(
+            "[MEDIA AUTH] ",
+            "route={} method={} path={} host={} auth_present={} auth_state={} ",
+            "normalized_request_url={} viewer_pubkey_present={} auth_error={:?} outcome={}"
+        ),
+        route,
+        diagnostics.method,
+        diagnostics.path,
+        diagnostics.host.as_deref().unwrap_or("-"),
+        diagnostics.auth_present,
+        auth_state_label(diagnostics.auth_state),
+        diagnostics.normalized_request_url.as_deref().unwrap_or("-"),
+        diagnostics.viewer_pubkey.is_some(),
+        diagnostics.auth_error.as_deref().unwrap_or("-"),
+        outcome,
+    )
+}
+
+fn auth_state_label(state: ViewerAuthState) -> &'static str {
+    match state {
+        ViewerAuthState::Missing => "missing",
+        ViewerAuthState::InvalidScheme => "invalid_scheme",
+        ViewerAuthState::ParseFailed => "parse_failed",
+        ViewerAuthState::RequestUrlInvalid => "request_url_invalid",
+        ViewerAuthState::ValidationFailed => "validation_failed",
+        ViewerAuthState::Valid => "valid",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn diagnostics(auth_state: ViewerAuthState) -> ViewerAuthDiagnostics {
+        ViewerAuthDiagnostics {
+            method: "GET".into(),
+            path: "/abc123".into(),
+            host: Some("media.divine.video".into()),
+            auth_present: auth_state != ViewerAuthState::Missing,
+            auth_state,
+            normalized_request_url: Some("https://media.divine.video/abc123".into()),
+            viewer_pubkey: (auth_state == ViewerAuthState::Valid).then(|| "pubkey".into()),
+            auth_error: (auth_state == ViewerAuthState::ValidationFailed)
+                .then(|| "Method mismatch: expected GET, got HEAD".into()),
+        }
+    }
+
+    #[test]
+    fn format_media_auth_log_renders_anonymous_age_gate() {
+        let line =
+            format_media_auth_log("blob", &diagnostics(ViewerAuthState::Missing), "age_gated");
+
+        assert!(line.contains("route=blob"));
+        assert!(line.contains("auth_present=false"));
+        assert!(line.contains("auth_state=missing"));
+        assert!(line.contains("outcome=age_gated"));
+    }
+
+    #[test]
+    fn format_media_auth_log_renders_valid_viewer_access() {
+        let line = format_media_auth_log("blob", &diagnostics(ViewerAuthState::Valid), "allowed");
+
+        assert!(line.contains("auth_present=true"));
+        assert!(line.contains("auth_state=valid"));
+        assert!(line.contains("viewer_pubkey_present=true"));
+        assert!(line.contains("outcome=allowed"));
+    }
+
+    #[test]
+    fn format_media_auth_log_renders_validation_failure() {
+        let line = format_media_auth_log(
+            "blob",
+            &diagnostics(ViewerAuthState::ValidationFailed),
+            "auth_invalid",
+        );
+
+        assert!(line.contains("auth_state=validation_failed"));
+        assert!(line.contains("auth_error=\"Method mismatch: expected GET, got HEAD\""));
+        assert!(line.contains("outcome=auth_invalid"));
+    }
+}

--- a/src/viewer_auth.rs
+++ b/src/viewer_auth.rs
@@ -16,6 +16,28 @@ pub const NIP98_MAX_AGE_SECS: u64 = 60;
 /// Public hostname clients use for media viewer requests.
 pub const PUBLIC_MEDIA_HOST: &str = "media.divine.video";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ViewerAuthState {
+    Missing,
+    InvalidScheme,
+    ParseFailed,
+    RequestUrlInvalid,
+    ValidationFailed,
+    Valid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ViewerAuthDiagnostics {
+    pub method: String,
+    pub path: String,
+    pub host: Option<String>,
+    pub auth_present: bool,
+    pub auth_state: ViewerAuthState,
+    pub normalized_request_url: Option<String>,
+    pub viewer_pubkey: Option<String>,
+    pub auth_error: Option<String>,
+}
+
 pub fn parse_auth_header(auth_header: &str) -> Result<BlossomAuthEvent> {
     let base64_event = auth_header.strip_prefix("Nostr ").ok_or_else(|| {
         BlossomError::AuthInvalid("Authorization must start with 'Nostr '".into())
@@ -142,8 +164,75 @@ pub fn public_request_url(request_url: &str, host_override: Option<&str>) -> Res
     Ok(format!("{}{}{}", scheme, effective_authority, suffix))
 }
 
+pub fn diagnose_viewer_auth_request(
+    method: &str,
+    path: &str,
+    host: Option<&str>,
+    request_url: &str,
+    auth_header: Option<&str>,
+    now: u64,
+) -> ViewerAuthDiagnostics {
+    let host = host.map(|s| s.to_string());
+    let mut diagnostics = ViewerAuthDiagnostics {
+        method: method.to_string(),
+        path: path.to_string(),
+        host: host.clone(),
+        auth_present: auth_header.is_some(),
+        auth_state: ViewerAuthState::Missing,
+        normalized_request_url: None,
+        viewer_pubkey: None,
+        auth_error: None,
+    };
+
+    let Some(auth_header) = auth_header else {
+        return diagnostics;
+    };
+
+    let event = match parse_auth_header(auth_header) {
+        Ok(event) => event,
+        Err(err) => {
+            diagnostics.auth_state = classify_parse_error(err.message());
+            diagnostics.auth_error = Some(err.message().to_string());
+            return diagnostics;
+        }
+    };
+
+    let request_url = match public_request_url(request_url, host.as_deref()) {
+        Ok(url) => {
+            diagnostics.normalized_request_url = Some(url.clone());
+            url
+        }
+        Err(err) => {
+            diagnostics.auth_state = ViewerAuthState::RequestUrlInvalid;
+            diagnostics.auth_error = Some(err.message().to_string());
+            return diagnostics;
+        }
+    };
+
+    match validate_viewer_event(&event, method, &request_url, now) {
+        Ok(()) => {
+            diagnostics.auth_state = ViewerAuthState::Valid;
+            diagnostics.viewer_pubkey = Some(event.pubkey);
+        }
+        Err(err) => {
+            diagnostics.auth_state = ViewerAuthState::ValidationFailed;
+            diagnostics.auth_error = Some(err.message().to_string());
+        }
+    }
+
+    diagnostics
+}
+
 fn is_internal_edge_host(authority: &str) -> bool {
     authority.ends_with(".edgecompute.app")
+}
+
+fn classify_parse_error(error_message: &str) -> ViewerAuthState {
+    if error_message == "Authorization must start with 'Nostr '" {
+        ViewerAuthState::InvalidScheme
+    } else {
+        ViewerAuthState::ParseFailed
+    }
 }
 
 fn get_tag_value<'a>(event: &'a BlossomAuthEvent, tag_name: &str) -> Option<&'a str> {
@@ -339,8 +428,8 @@ mod tests {
     fn public_request_url_rewrites_internal_edge_host_to_public_host() {
         let internal =
             "https://separately-robust-roughy.edgecompute.app/4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e";
-        let public = public_request_url(internal, None)
-            .expect("public host rewrite should succeed");
+        let public =
+            public_request_url(internal, None).expect("public host rewrite should succeed");
 
         assert_eq!(public, TEST_URL);
     }
@@ -351,7 +440,10 @@ mod tests {
         let public = public_request_url(internal, Some("media.divine.video:8443"))
             .expect("public host rewrite should succeed");
 
-        assert_eq!(public, "https://media.divine.video:8443/path/to/blob?foo=bar");
+        assert_eq!(
+            public,
+            "https://media.divine.video:8443/path/to/blob?foo=bar"
+        );
     }
 
     #[test]
@@ -362,6 +454,106 @@ mod tests {
             .expect("edge host override should fall back to public media host");
 
         assert_eq!(public, TEST_URL);
+    }
+
+    #[test]
+    fn viewer_auth_diagnostics_reports_missing_authorization() {
+        let diagnostics = diagnose_viewer_auth_request(
+            "GET",
+            "/blob",
+            Some("media.divine.video"),
+            TEST_URL,
+            None,
+            1_000,
+        );
+
+        assert!(!diagnostics.auth_present);
+        assert_eq!(diagnostics.auth_state, ViewerAuthState::Missing);
+        assert_eq!(diagnostics.viewer_pubkey.as_deref(), None);
+    }
+
+    #[test]
+    fn viewer_auth_diagnostics_reports_invalid_scheme() {
+        let diagnostics = diagnose_viewer_auth_request(
+            "GET",
+            "/blob",
+            Some("media.divine.video"),
+            TEST_URL,
+            Some("Bearer nope"),
+            1_000,
+        );
+
+        assert!(diagnostics.auth_present);
+        assert_eq!(diagnostics.auth_state, ViewerAuthState::InvalidScheme);
+        assert_eq!(
+            diagnostics.auth_error.as_deref(),
+            Some("Authorization must start with 'Nostr '")
+        );
+    }
+
+    #[test]
+    fn viewer_auth_diagnostics_reports_valid_nip98_request() {
+        let event = signed_event(
+            NIP98_AUTH_KIND,
+            vec![
+                vec!["u".into(), TEST_URL.into()],
+                vec!["method".into(), "GET".into()],
+            ],
+            1_000,
+        );
+        let auth_header = format!(
+            "Nostr {}",
+            BASE64.encode(serde_json::to_vec(&event).expect("serialize auth event"))
+        );
+
+        let diagnostics = diagnose_viewer_auth_request(
+            "GET",
+            "/blob",
+            Some("media.divine.video"),
+            TEST_URL,
+            Some(&auth_header),
+            1_000,
+        );
+
+        assert!(diagnostics.auth_present);
+        assert_eq!(diagnostics.auth_state, ViewerAuthState::Valid);
+        assert!(diagnostics.viewer_pubkey.is_some());
+        assert_eq!(
+            diagnostics.normalized_request_url.as_deref(),
+            Some(TEST_URL)
+        );
+    }
+
+    #[test]
+    fn viewer_auth_diagnostics_reports_validation_failure() {
+        let event = signed_event(
+            NIP98_AUTH_KIND,
+            vec![
+                vec!["u".into(), TEST_URL.into()],
+                vec!["method".into(), "HEAD".into()],
+            ],
+            1_000,
+        );
+        let auth_header = format!(
+            "Nostr {}",
+            BASE64.encode(serde_json::to_vec(&event).expect("serialize auth event"))
+        );
+
+        let diagnostics = diagnose_viewer_auth_request(
+            "GET",
+            "/blob",
+            Some("media.divine.video"),
+            TEST_URL,
+            Some(&auth_header),
+            1_000,
+        );
+
+        assert!(diagnostics.auth_present);
+        assert_eq!(diagnostics.auth_state, ViewerAuthState::ValidationFailed);
+        assert_eq!(
+            diagnostics.auth_error.as_deref(),
+            Some("Method mismatch: expected GET, got HEAD")
+        );
     }
 
     fn signed_event(kind: u32, tags: Vec<Vec<String>>, created_at: u64) -> BlossomAuthEvent {


### PR DESCRIPTION
## Summary
- add viewer auth diagnostics that classify missing, invalid, and valid media auth without logging secrets
- add structured media auth log lines for blob, thumbnail, HLS, transcript, subtitle, audio, and quality-variant GET routes
- include a short implementation plan doc for the observability work

## Test Plan
- [x] cargo test --lib
- [x] cargo check --target wasm32-wasi
