### PR TITLE
feat(admin): creator-delete DELETE action on /admin/api/moderate

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Client → Fastly Compute (Rust WASM) → GCS (blobs) + Fastly KV (metadata)
 rustup target add wasm32-wasi
 ```
 
-### Configure secrets
+### Configure secrets and config
 
 1. Create a GCS bucket with HMAC credentials
 2. Set up Fastly stores:
@@ -65,6 +65,12 @@ fastly config-store create --name blossom_config
 # Create secret store with GCS HMAC credentials
 fastly secret-store create --name blossom_secrets
 ```
+
+**Config store flags:**
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `ENABLE_PHYSICAL_DELETE` | When `"true"`, creator-delete actions via `/admin/api/moderate` physically remove bytes from GCS and purge edge caches. When `"false"`, status flip only (bytes preserved). Admin DMCA via `/admin/api/delete` is unconditionally soft-delete regardless of this flag. | `"false"` |
 
 ### Local development
 

--- a/config-store-data.json
+++ b/config-store-data.json
@@ -1,5 +1,6 @@
 {
   "gcs_bucket": "divine-blossom-local",
   "gcs_project_id": "local",
-  "local_mode": "true"
+  "local_mode": "true",
+  "ENABLE_PHYSICAL_DELETE": "false"
 }

--- a/docs/superpowers/plans/2026-04-16-creator-delete-action-plan.md
+++ b/docs/superpowers/plans/2026-04-16-creator-delete-action-plan.md
@@ -1,175 +1,112 @@
-# Blossom `DELETE` Action Implementation Plan
+# Blossom `DELETE` Action Implementation Plan (revised)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Wire a `DELETE` action into Blossom's `/admin/api/moderate` endpoint that dispatches to a shared physical-delete helper extracted from the existing admin DMCA cascade. Gate the destructive step on a new `ENABLE_PHYSICAL_DELETE` config flag (default off) so the first production deploy is inert.
+**Goal:** Wire a `DELETE` action into Blossom's `/admin/api/moderate` endpoint that composes `soft_delete_blob` (stops serving) with physical GCS byte removal (when the `ENABLE_PHYSICAL_DELETE` flag is on). New helper lives in `delete_policy.rs` alongside the existing soft-delete helper.
 
-**Architecture:** Extract `perform_physical_delete(hash, actor, reason, legal_hold)` from `handle_admin_force_delete` into a shared helper. Both admin DMCA (unconditional) and creator-delete (flag-gated) call it. Creator-delete ingress stays on the existing `/admin/api/moderate` endpoint so moderation-service's single call pattern is preserved.
+**Architecture:** `perform_physical_delete` = `soft_delete_blob` + byte destruction. DELETE handled as a special-case branch in `handle_admin_moderate_action` (not a new arm in the bare-status-flip match). Admin DMCA endpoint and GDPR vanish are untouched.
 
-**Tech Stack:** Rust on Fastly Compute (WASM), `fastly` crate, `serde_json`. Tests via inline `#[cfg(test)] mod tests` — standard Rust pattern. Local dev via MinIO + `fastly compute serve`.
+**Tech Stack:** Rust on Fastly Compute (WASM target `wasm32-wasip1`), `fastly` crate, `serde_json`. Tests via `cargo check --tests --locked` (the edge crate's FFI symbols don't link for `cargo test` on host). Local e2e via MinIO + `fastly compute serve`.
 
-**Spec:** `docs/superpowers/specs/2026-04-16-creator-delete-action-design.md` on this branch.
+**Spec:** `docs/superpowers/specs/2026-04-16-creator-delete-action-design.md` (revised).
 
 ---
 
 ## File Structure
 
 **Files to modify:**
-- `src/main.rs` — extract `perform_physical_delete` helper (~55 lines moved from `handle_admin_force_delete`), update `handle_admin_force_delete` to call it.
-- `src/admin.rs` — add `reason` field to `ModerateRequest` struct, wire `DELETE` action dispatch with `ENABLE_PHYSICAL_DELETE` flag check.
-- `config-store-data.json` — add `ENABLE_PHYSICAL_DELETE = "false"` for local dev.
+- `src/delete_policy.rs` — add `perform_physical_delete` (new public function, ~20 lines)
+- `src/admin.rs` — add `reason` field to `ModerateRequest`; add DELETE special-case branch in `handle_admin_moderate_action` (~40 lines)
+- `config-store-data.json` — add `ENABLE_PHYSICAL_DELETE = "false"` for local dev
+- `README.md` — document the flag
 
-**Files to create:**
-- None. Tests live alongside production code in `#[cfg(test)]` modules within the modified files.
+**Files NOT modified:**
+- `src/main.rs` — no changes. `handle_admin_force_delete` stays soft-delete. `execute_vanish` stays inline.
 
 ---
 
-## Guardrails — do not do these without checkpointing with Matt first
-
-### Scope
+## Guardrails
 
 - Do not add new dependencies in `Cargo.toml`.
-- Do not refactor any file not listed above.
-- Do not modify `handle_admin_force_delete`'s behavior — only its internals (extract to helper; caller is equivalent).
-- Do not change the auth path on `/admin/api/moderate`. Existing Bearer auth (admin_token OR webhook_secret) remains.
-- Do not modify `BlobStatus` enum. `Deleted` already exists.
-- Do not change any existing tests. Add new tests; don't reshape existing.
-- Do not change the Fastly Purge logic (`purge_vcl_cache`). Reuse it verbatim.
-- Do not add new logging beyond the eprintln lines specified in the spec.
-
-### Safety measures — DO NOT REMOVE OR SIMPLIFY
-
-These are required by the spec:
-
-- `ENABLE_PHYSICAL_DELETE` flag check in the creator-delete DELETE branch. Flag off → status flip only, return `physical_delete_skipped: true`.
-- `actor: "creator_delete"` passed to `perform_physical_delete` (and `"admin"` from the force-delete endpoint). This is the audit-log distinguisher.
-- `legal_hold: false` on the creator-delete ingress (creator re-upload is not blocked).
-- Failure of `perform_physical_delete` is logged but does NOT block the 200 response — the status flip is the load-bearing compliance guarantee.
-- `get_config("ENABLE_PHYSICAL_DELETE")` comparison uses `eq_ignore_ascii_case` on the value OR exact `== Some("true")`; pick ONE and be consistent. The spec uses `as_deref() == Some("true")` — follow it.
-
-### When in doubt
-
-Stop and ask. A checkpoint question is cheaper than reverting a commit.
-
----
-
-## Per-task review checklist (orchestrator uses this on every subagent output)
-
-- [ ] Tests written before implementation (visible in git history or commit body).
-- [ ] `cargo test` passes all tests (existing + new).
-- [ ] `cargo build --target wasm32-wasi --release` succeeds (or the repo's documented build command).
-- [ ] No new dependencies in `Cargo.toml`.
-- [ ] No files touched outside the task's "Files" list.
-- [ ] Safety measures from Guardrails present and unaltered.
-- [ ] Existing `handle_admin_force_delete` test (if any) still passes after the refactor — behavior equivalence.
-- [ ] Commit message follows existing Blossom convention (check `git log --oneline -10` on main for style; no Claude attribution).
-- [ ] Rust doc comments on new public/pub(crate) functions.
-
-### Red flags to escalate
-
-- Subagent adds a dependency, refactors an unrelated file, or changes `BlobStatus`.
-- `handle_admin_force_delete`'s tests or behavior change beyond the extraction.
-- The DELETE branch returns anything other than 200 on status-flip-only or full-cascade success.
-- The flag check is bypassed, inverted, or gated on the wrong value.
+- Do not modify `handle_admin_force_delete` or `execute_vanish`.
+- Do not modify any existing tests.
+- Do not delete the metadata row via `delete_blob_metadata`. Metadata stays with `status: Deleted` for audit.
+- Do not delete KV artifacts via `delete_blob_kv_artifacts`. Same reason.
+- `ENABLE_PHYSICAL_DELETE` flag check uses `get_config("ENABLE_PHYSICAL_DELETE").as_deref() == Some("true")`.
+- `write_audit_log` call: action = `"creator_delete"`, actor_pubkey = `&metadata.owner`. Do NOT pass actor into the action slot.
+- `legal_hold: false` on all creator-delete calls. Tombstone is a legal mechanism.
+- Failure of `perform_physical_delete` is logged but does NOT block the 200 response.
+- Build target: `wasm32-wasip1` (NOT `wasm32-wasi`).
+- Verification: `cargo check --tests --locked` (NOT `cargo test`).
 
 ---
 
 ## Staging Preflight
 
-- [ ] **Build works at baseline.** `cargo build --target wasm32-wasi --release` on the current branch (before any changes) succeeds. Note the current Fastly CLI version (`fastly version`) — the local dev loop wants ≥14.0.4.
-
-- [ ] **Local dev loop operational.** `docker compose -f docker-compose.local.yml up minio minio-init -d` starts MinIO on :9000. `cp fastly.toml.local fastly.toml` then `fastly compute serve` brings Blossom up on :7676. `curl http://localhost:7676/admin/api/stats -H 'Authorization: Bearer <admin_token>'` returns 200 (admin auth configured for local).
-
-- [ ] **Existing DELETE action confirms baseline.** `curl -X POST http://localhost:7676/admin/api/moderate -H 'Content-Type: application/json' -H 'Authorization: Bearer <admin_token>' -d '{"sha256":"aaaa...","action":"DELETE"}'` returns `400 Unknown action: DELETE`. This is the state this PR changes.
-
-- [ ] **Existing `handle_admin_force_delete` works.** `curl -X POST http://localhost:7676/admin/api/delete -d '{"sha256":"...","reason":"preflight"}'` against a test blob shows the existing cascade. Record the response shape so the refactor in Task 1 can be verified equivalent.
-
-Any preflight failure is a redirect signal.
+- [ ] `cargo build --target wasm32-wasip1 --release` succeeds on the current branch (baseline).
+- [ ] `cargo check --tests --locked` succeeds (baseline).
+- [ ] Local dev: `docker compose -f docker-compose.local.yml up minio minio-init -d` + `cp fastly.toml.local fastly.toml` + `fastly compute serve` starts Blossom on :7676.
+- [ ] `POST /admin/api/moderate` with `action: "DELETE"` returns `400 Unknown action: DELETE` (pre-change baseline).
 
 ---
 
-## Task 1: Extract `perform_physical_delete` helper
+## Task 1: Add `perform_physical_delete` to `delete_policy.rs`
 
-**Files:**
-- Modify: `src/main.rs`
+**Files:** Modify `src/delete_policy.rs`
 
-Refactor `handle_admin_force_delete` (currently ~89 lines, `main.rs:3152-3240`) so its cascade body lives in a new `pub(crate) fn perform_physical_delete(...)` called by the handler. Behavior must be equivalent.
+- [ ] **Step 1: Read the existing helpers.** `soft_delete_blob` is at line 39. Understand its signature, what it does, what it imports. Read the module's `use crate::...` block at the top — you'll need additional imports for the byte-destruction functions.
 
-- [ ] **Step 1: Locate the current function**
+- [ ] **Step 2: Add imports for byte-destruction helpers.** At the top of `delete_policy.rs`, the existing imports include `update_blob_status`, `remove_from_user_list`, etc. Add the functions `perform_physical_delete` will call that aren't already imported. These live in `crate` (main.rs) and will need `pub(crate)` visibility there:
+    - `crate::cleanup_derived_audio_for_source`
+    - `crate::storage_delete`
+    - `crate::delete_blob_gcs_artifacts`
+    - `crate::purge_vcl_cache`
 
-    ```bash
-    grep -n "^fn handle_admin_force_delete\|^pub fn handle_admin_force_delete" src/main.rs
-    ```
+    Check whether these are already `pub(crate)` in main.rs. If they're private (`fn` without `pub`), add `pub(crate)` to each. Do NOT change their signatures or behavior; only their visibility.
 
-    Confirm the line range (should be roughly 3152-3240). Read it top-to-bottom to understand the flow.
-
-- [ ] **Step 2: Add `perform_physical_delete` above `handle_admin_force_delete`**
-
-    Insert the helper verbatim from the spec (Component 1 code block). Signature:
+- [ ] **Step 3: Add `perform_physical_delete` below `soft_delete_blob`.**
 
     ```rust
-    pub(crate) fn perform_physical_delete(
+    /// Physical deletion: soft-delete (stops serving) + GCS byte removal.
+    /// Metadata row is preserved (status=Deleted) for audit/support visibility.
+    pub fn perform_physical_delete(
         hash: &str,
-        actor: &str,
+        metadata: &BlobMetadata,
         reason: &str,
         legal_hold: bool,
-    ) -> Result<()> { /* body */ }
+    ) -> Result<()> {
+        soft_delete_blob(hash, metadata, reason, legal_hold)?;
+        crate::cleanup_derived_audio_for_source(hash);
+        let _ = crate::storage_delete(hash);
+        crate::delete_blob_gcs_artifacts(hash);
+        crate::purge_vcl_cache(hash);
+        Ok(())
+    }
     ```
 
-    The body mirrors `handle_admin_force_delete`'s cascade exactly (from "Get metadata before deletion for audit" through "Purge VCL cache"), with `actor` parameterized (was hardcoded `"admin_delete"` / `"admin"`).
-
-- [ ] **Step 3: Update `handle_admin_force_delete` to call the helper**
-
-    Replace the extracted body (between "Get metadata before deletion for audit" and "Purge VCL cache" inclusive) with a single call:
-
-    ```rust
-    perform_physical_delete(&hash, "admin", reason, legal_hold)?;
-    ```
-
-    The surrounding code (hash validation, response construction) stays as-is.
-
-- [ ] **Step 4: Build and verify existing tests pass**
+- [ ] **Step 4: Build.**
 
     ```bash
-    cargo build --target wasm32-wasi --release
-    cargo test
+    cargo build --target wasm32-wasip1 --release
+    cargo check --tests --locked
     ```
+    Expected: success (new function is defined but not yet called — dead code warning is OK).
 
-    Expected: build succeeds, all existing tests pass. The refactor is behavior-equivalent — any test failure here indicates we dropped something in the move.
-
-- [ ] **Step 5: Manual equivalence check against preflight baseline**
-
-    If you captured a response shape from the preflight `handle_admin_force_delete` call, compare the post-refactor response. Should match field-for-field.
-
-- [ ] **Step 6: Commit**
-
-    ```bash
-    git add src/main.rs
-    git commit -m "refactor: extract perform_physical_delete helper from handle_admin_force_delete"
-    ```
+- [ ] **Step 5: Commit.** (Matt commits from his shell.)
 
 ---
 
 ## Task 2: Add optional `reason` to `ModerateRequest`
 
-**Files:**
-- Modify: `src/admin.rs`
+**Files:** Modify `src/admin.rs`
 
-The creator-delete ingress will eventually want to pass a reason for audit purposes. Struct extension is minimal and safe — existing callers that omit `reason` continue to work via `Option<String>`.
+- [ ] **Step 1: Find the struct.**
 
-- [ ] **Step 1: Update the struct**
-
-    Find `struct ModerateRequest` in `src/admin.rs` (around line 728-732). Change from:
-
-    ```rust
-    #[derive(Deserialize)]
-    struct ModerateRequest {
-        sha256: String,
-        action: String,
-    }
+    ```bash
+    grep -n "struct ModerateRequest" src/admin.rs
     ```
 
-    to:
+- [ ] **Step 2: Add the field.**
 
     ```rust
     #[derive(Deserialize)]
@@ -181,271 +118,187 @@ The creator-delete ingress will eventually want to pass a reason for audit purpo
     }
     ```
 
-- [ ] **Step 2: Build**
+- [ ] **Step 3: Build.** `cargo build --target wasm32-wasip1 --release`. Expected: succeeds. No callers changed.
 
-    ```bash
-    cargo build --target wasm32-wasi --release
-    ```
-    Expected: succeeds. No callers changed; `reason` defaults to `None`.
-
-- [ ] **Step 3: Commit**
-
-    ```bash
-    git add src/admin.rs
-    git commit -m "feat(admin): accept optional reason field in ModerateRequest"
-    ```
+- [ ] **Step 4: Commit.** (Matt commits.)
 
 ---
 
-## Task 3: Wire DELETE action with `ENABLE_PHYSICAL_DELETE` flag check
+## Task 3: Wire DELETE special-case in `handle_admin_moderate_action`
 
-**Files:**
-- Modify: `src/admin.rs`
+**Files:** Modify `src/admin.rs`
 
-Add the new action to `BLOSSOM_ACTION_MAP` (implicit via the match in `handle_admin_moderate_action`) and dispatch to `perform_physical_delete` when the flag is on.
+This is the core wiring task. DELETE is a special-case branch BEFORE the existing action-map match.
 
-- [ ] **Step 1: Write the failing test first**
+- [ ] **Step 1: Read the current handler.** Find `handle_admin_moderate_action` (around line 848). Read the full function to understand the flow: auth, parse, validate sha256, fetch metadata, action match, status flip, response.
 
-    Add to `src/admin.rs` inside the existing `#[cfg(test)] mod tests` block:
-
-    ```rust
-    #[test]
-    fn test_delete_action_with_flag_off_returns_physical_delete_skipped() {
-        // Build a ModerateRequest with action "DELETE"
-        // Mock get_config to return None for ENABLE_PHYSICAL_DELETE
-        // Call handle_admin_moderate_action
-        // Assert: 200 status, body contains physical_delete_skipped: true,
-        //         blob status updated to Deleted.
-        todo!("build minimal viceroy mocks or use real local fastly dev harness");
-    }
-
-    #[test]
-    fn test_delete_action_with_flag_on_invokes_physical_delete() {
-        // Mock get_config to return Some("true") for ENABLE_PHYSICAL_DELETE
-        // Call handle_admin_moderate_action with action "DELETE"
-        // Assert: 200 status, body contains physical_deleted: true
-        // Assert: audit log written with actor="creator_delete"
-        todo!("same mocking as above");
-    }
-    ```
-
-    These are marked `todo!()` to serve as failing-test stubs. If the repo has a mocking harness for `get_config` + storage, expand them. Otherwise, replace `todo!()` with integration tests via local `fastly compute serve` driven by a test script.
-
-    **Fallback if Viceroy/Rust mocking is too heavy:** run the test cases manually via `curl` in the preflight loop and document results in the commit body. Rust mocks for `fastly::config_store` are non-trivial; pragmatic manual verification is acceptable for this narrowly-scoped behavior.
-
-- [ ] **Step 2: Run tests — confirm they're marked todo / fail as expected**
-
-    ```bash
-    cargo test
-    ```
-
-- [ ] **Step 3: Implement the DELETE branch**
-
-    Find `handle_admin_moderate_action` in `src/admin.rs` (around line 734). After the existing `update_blob_status` + `update_stats_on_status_change` + `purge_vcl_cache` calls, AND BEFORE the existing `json_response(StatusCode::OK, &response)` return, insert the DELETE dispatch per the spec Component 2 code block:
+- [ ] **Step 2: Add necessary imports at the top of `admin.rs`.**
 
     ```rust
+    use crate::delete_policy::{perform_physical_delete, soft_delete_blob};
+    use crate::storage::write_audit_log;
+    ```
+
+    Check whether these are already imported. Add only what's missing.
+
+- [ ] **Step 3: Insert the DELETE branch.** After the `metadata` fetch and BEFORE the `let new_status = match ...` block, add:
+
+    ```rust
+    // Creator-delete: special-case because DELETE needs soft_delete_blob's full
+    // index/user-list cleanup, not the bare update_blob_status the action-map
+    // match provides for BAN/RESTRICT/etc.
     if moderate_req.action.eq_ignore_ascii_case("DELETE") {
+        let reason = moderate_req
+            .reason
+            .as_deref()
+            .unwrap_or("Creator-initiated deletion via kind 5");
+
+        let meta_json = serde_json::to_string(&metadata).ok();
+        crate::write_audit_log(
+            &moderate_req.sha256,
+            "creator_delete",
+            &metadata.owner,
+            None,
+            meta_json.as_deref(),
+            Some(reason),
+        );
+
         let physical_delete_enabled = get_config("ENABLE_PHYSICAL_DELETE")
             .as_deref()
             == Some("true");
 
         if physical_delete_enabled {
-            let reason = moderate_req
-                .reason
-                .as_deref()
-                .unwrap_or("Creator-initiated deletion via kind 5");
-
-            if let Err(e) = crate::perform_physical_delete(
+            if let Err(e) = perform_physical_delete(
                 &moderate_req.sha256,
-                "creator_delete",
+                &metadata,
                 reason,
                 false,
             ) {
                 eprintln!(
-                    "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
-                     Status is still Deleted; bytes may remain. Operator follow-up required.",
+                    "[CREATOR-DELETE] perform_physical_delete failed for {}: {}",
                     moderate_req.sha256, e
                 );
             }
-
-            let response = serde_json::json!({
-                "success": true,
-                "sha256": moderate_req.sha256,
-                "old_status": format!("{:?}", old_status).to_lowercase(),
-                "new_status": format!("{:?}", new_status).to_lowercase(),
-                "physical_deleted": true
-            });
-            return json_response(StatusCode::OK, &response);
         } else {
-            let response = serde_json::json!({
-                "success": true,
-                "sha256": moderate_req.sha256,
-                "old_status": format!("{:?}", old_status).to_lowercase(),
-                "new_status": format!("{:?}", new_status).to_lowercase(),
-                "physical_delete_skipped": true
-            });
-            return json_response(StatusCode::OK, &response);
+            if let Err(e) = soft_delete_blob(
+                &moderate_req.sha256,
+                &metadata,
+                reason,
+                false,
+            ) {
+                eprintln!(
+                    "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
+                    moderate_req.sha256, e
+                );
+                return Err(e);
+            }
         }
+
+        let response = serde_json::json!({
+            "success": true,
+            "sha256": moderate_req.sha256,
+            "old_status": format!("{:?}", old_status).to_lowercase(),
+            "new_status": "deleted",
+            "physical_deleted": physical_delete_enabled,
+            "physical_delete_skipped": !physical_delete_enabled
+        });
+        return json_response(StatusCode::OK, &response);
     }
     ```
 
-    The existing action-map match in `handle_admin_moderate_action` handles `DELETE` by mapping to `BlobStatus::Deleted` (once the arm is added). Find the match that sets `new_status` from the action string and add a `"DELETE" | "delete"` arm:
-
-    ```rust
-    let new_status = match moderate_req.action.to_uppercase().as_str() {
-        "BAN" | "BLOCK" => BlobStatus::Banned,
-        "RESTRICT" => BlobStatus::Restricted,
-        "APPROVE" | "ACTIVE" => BlobStatus::Active,
-        "PENDING" => BlobStatus::Pending,
-        "AGE_RESTRICTED" | "AGERESTRICTED" => BlobStatus::AgeRestricted,
-        "DELETE" => BlobStatus::Deleted,  // NEW
-        _ => {
-            return Err(BlossomError::BadRequest(format!(
-                "Unknown action: {}",
-                moderate_req.action
-            )))
-        }
-    };
-    ```
-
-    (The exact existing match arms may vary; confirm against the current file and add `"DELETE" => BlobStatus::Deleted` consistent with the style.)
-
-- [ ] **Step 4: Build**
+- [ ] **Step 4: Build.**
 
     ```bash
-    cargo build --target wasm32-wasi --release
+    cargo build --target wasm32-wasip1 --release
+    cargo check --tests --locked
     ```
-    Expected: succeeds.
+    Expected: success. The dead-code warning on `perform_physical_delete` should be gone (it's now called).
 
-- [ ] **Step 5: Local e2e validation (manual)**
+- [ ] **Step 5: Local e2e test — flag off.**
 
-    Start the local dev stack (per preflight). Then:
+    Start local dev stack (MinIO + `fastly compute serve`). Upload a test blob if one doesn't exist. Then:
 
     ```bash
-    # Flag off (default): expect physical_delete_skipped=true, blob still in GCS
     curl -X POST http://localhost:7676/admin/api/moderate \
       -H 'Content-Type: application/json' \
-      -H "Authorization: Bearer $ADMIN_TOKEN" \
+      -H "Authorization: Bearer <admin_token_from_secret_store_data>" \
       -d '{"sha256":"<test_blob_hash>","action":"DELETE"}'
-    # Expect: 200 {..., "physical_delete_skipped": true}
-    # Verify: minio bucket still has the blob (mc ls local/divine-blossom-local)
-    # Verify: Blossom serves 404 on the blob URL (status = Deleted)
+    ```
 
-    # Flag on: expect physical_deleted=true, blob gone from GCS
-    # Set ENABLE_PHYSICAL_DELETE=true in config-store-data.json (see Task 4)
-    # Restart fastly compute serve
+    Expected: 200 with `"physical_delete_skipped": true`, `"new_status": "deleted"`. Blob serves 404 on `http://localhost:7676/<hash>`. MinIO bucket still has the bytes.
+
+- [ ] **Step 6: Local e2e test — flag on.**
+
+    Edit `config-store-data.json` to set `"ENABLE_PHYSICAL_DELETE": "true"`. Restart `fastly compute serve`. Upload a NEW test blob (different hash since the first is now `Deleted`).
+
+    ```bash
     curl -X POST http://localhost:7676/admin/api/moderate \
       -H 'Content-Type: application/json' \
-      -H "Authorization: Bearer $ADMIN_TOKEN" \
-      -d '{"sha256":"<different_test_blob>","action":"DELETE"}'
-    # Expect: 200 {..., "physical_deleted": true}
-    # Verify: minio bucket no longer has the blob
+      -H "Authorization: Bearer <admin_token>" \
+      -d '{"sha256":"<new_test_blob_hash>","action":"DELETE"}'
     ```
 
-    Record both results in the commit body.
+    Expected: 200 with `"physical_deleted": true`. MinIO bucket no longer has the blob bytes. Thumbnail and VTT also gone (verify via `mc ls`).
 
-- [ ] **Step 6: Run cargo test**
+- [ ] **Step 7: Verify existing actions still work.**
 
     ```bash
-    cargo test
+    # BAN should still work as before
+    curl -X POST http://localhost:7676/admin/api/moderate \
+      -H 'Content-Type: application/json' \
+      -H "Authorization: Bearer <admin_token>" \
+      -d '{"sha256":"<another_hash>","action":"BAN"}'
     ```
-    Existing tests must still pass. If the `todo!()` tests from Step 1 are still stubs, they'll panic and fail — expected; remove them or replace with real assertions as a follow-up if you can build a mocking harness, OR delete them in favor of the manual local-e2e approach (note in commit body either way).
+    Expected: 200 with `"new_status": "banned"`. No `physical_deleted` or `physical_delete_skipped` fields.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Verify admin DMCA endpoint unchanged.**
 
     ```bash
-    git add src/admin.rs
-    git commit -m "feat(admin): add DELETE action dispatching to perform_physical_delete
-
-    Wires DELETE into /admin/api/moderate's BLOSSOM_ACTION_MAP (new arm:
-    DELETE → BlobStatus::Deleted) and, after the status flip + VCL purge,
-    dispatches to the extracted perform_physical_delete helper when
-    ENABLE_PHYSICAL_DELETE config flag is 'true'. Flag off returns
-    {physical_delete_skipped: true} — first-prod deploy is inert.
-
-    Admin DMCA path (/admin/api/delete) unchanged — always destructive.
-    Shared helper distinguishes callers via audit-log actor field
-    ('admin' vs 'creator_delete').
-
-    Caller: divinevideo/divine-moderation-service#92.
-    "
+    curl -X POST http://localhost:7676/admin/api/delete \
+      -H 'Content-Type: application/json' \
+      -H "Authorization: Bearer <admin_token>" \
+      -d '{"sha256":"<another_hash>","reason":"test"}'
     ```
+    Expected: 200 with `"preserved": true`. Bytes still on MinIO. Unchanged behavior.
+
+- [ ] **Step 9: Commit.** (Matt commits.)
 
 ---
 
 ## Task 4: Local dev config
 
-**Files:**
-- Modify: `config-store-data.json`
+**Files:** Modify `config-store-data.json`
 
-- [ ] **Step 1: Add the flag**
-
-    Open `config-store-data.json` in the repo root. Add `"ENABLE_PHYSICAL_DELETE": "false"` alongside other config keys. Keep it as a string (Fastly config store semantic).
-
-- [ ] **Step 2: Verify local dev picks it up**
-
-    Restart `fastly compute serve`. Confirm via a Task-3-style curl that `physical_delete_skipped: true` is returned.
-
-- [ ] **Step 3: Commit**
-
-    ```bash
-    git add config-store-data.json
-    git commit -m "config: add ENABLE_PHYSICAL_DELETE=false for local dev"
-    ```
+- [ ] **Step 1: Add the flag.** `"ENABLE_PHYSICAL_DELETE": "false"` alongside other config keys.
+- [ ] **Step 2: Commit.** (Matt commits.)
 
 ---
 
-## Task 5: Documentation + PR polish
+## Task 5: Documentation
 
-**Files:**
-- Modify: `README.md` (if the "Configure secrets" section mentions all config keys — add the flag alongside existing `google_allowed_domain`, `gcs_bucket`, etc.).
-- Optionally: `CHANGELOG.md` if the repo maintains one.
+**Files:** Modify `README.md`
 
-- [ ] **Step 1: Document the flag in README**
+- [ ] **Step 1: Document the flag.** In the Configuration or Environment section, add:
 
-    Find the "Configure secrets" or "Configuration" section. Add:
+    `ENABLE_PHYSICAL_DELETE` (config store `blossom_config`): when `"true"`, creator-delete actions via `/admin/api/moderate` physically remove bytes from GCS and purge edge caches. Default `"false"` (status flip only). Flip to `"true"` after end-to-end validation in the creator-delete rollout. Admin DMCA via `/admin/api/delete` is unconditionally soft-delete regardless of this flag.
 
-    ```markdown
-    - `ENABLE_PHYSICAL_DELETE` (config store `blossom_config`): when `"true"`, creator-delete actions via `/admin/api/moderate` physically remove bytes from GCS and purge edge caches. Default `"false"` — status flip only. Flip to `"true"` after end-to-end validation in the creator-delete rollout. Admin DMCA via `/admin/api/delete` is unconditionally destructive regardless of this flag.
-    ```
-
-- [ ] **Step 2: Commit**
-
-    ```bash
-    git add README.md
-    git commit -m "docs(readme): document ENABLE_PHYSICAL_DELETE config flag"
-    ```
+- [ ] **Step 2: Commit.** (Matt commits.)
 
 ---
+
+## Execution order
+
+Task 1 → Task 2 → Task 3 → Task 4 → Task 5
+
+Tasks 1-2 can run in either order. Task 3 depends on both (imports `perform_physical_delete` + uses `moderate_req.reason`). Tasks 4-5 are independent cleanups.
 
 ## Self-Review checklist
 
-After writing the plan, check:
-
-**Spec coverage:**
-- [x] `perform_physical_delete` helper extraction — Task 1
-- [x] `reason` field on `ModerateRequest` — Task 2
-- [x] `DELETE` action dispatch with flag check — Task 3
-- [x] `ENABLE_PHYSICAL_DELETE` config store entry — Task 4
-- [x] Documentation — Task 5
-- [x] Failure handling matrix — covered in Task 3's implementation (eprintln on helper failure, 200 still returned)
-- [x] Observability — existing `[PURGE]` and new `[CREATOR-DELETE]` / `[PHYSICAL-DELETE]` logs
-- [x] Tests — Task 3 with fallback to local e2e if Viceroy mocking is too heavy
-- [x] Dependencies and sequencing — spec section is authoritative
-- [x] Local dev loop — preflight + Task 3 Step 5
-
-**Placeholder scan:** The `todo!()` in Task 3 Step 1 is an acknowledged stub with a fallback — manual local e2e driven by the Step 5 curl commands. This is pragmatic for Rust + Fastly Compute where mocking `fastly::config_store` is non-trivial.
-
-**Type consistency:** `perform_physical_delete(hash: &str, actor: &str, reason: &str, legal_hold: bool) -> Result<()>` — signature consistent across Tasks 1 and 3.
-
----
-
-## Execution handoff
-
-Plan complete and committed to `docs/superpowers/plans/2026-04-16-creator-delete-action-plan.md` on branch `feat/creator-delete-action`. Two execution options:
-
-**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
-
-**2. Inline Execution** — execute in this session using executing-plans, batch execution with checkpoints.
-
-For this PR's scope (5 small tasks, mostly file edits in two files), either approach works. Subagent-driven preserves the per-task review rhythm we've established on the moderation-service side.
+- [x] Spec coverage: `perform_physical_delete` (Task 1), DELETE wiring + flag (Task 3), reason field (Task 2), config (Task 4), docs (Task 5)
+- [x] Existing endpoints untouched: `handle_admin_force_delete` and `execute_vanish` have no changes in any task
+- [x] Build target correct: `wasm32-wasip1` everywhere
+- [x] Test command correct: `cargo check --tests --locked` (not `cargo test`)
+- [x] `write_audit_log` call: action=`"creator_delete"`, actor=`&metadata.owner` (not `actor` in both slots)
+- [x] DELETE is a special-case branch, not an action-map arm (so `soft_delete_blob` runs, not bare `update_blob_status`)
+- [x] `perform_physical_delete` composes `soft_delete_blob` + byte destruction, preserves metadata row
+- [x] Guardrails documented for subagents

--- a/docs/superpowers/plans/2026-04-16-creator-delete-action-plan.md
+++ b/docs/superpowers/plans/2026-04-16-creator-delete-action-plan.md
@@ -1,0 +1,451 @@
+# Blossom `DELETE` Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire a `DELETE` action into Blossom's `/admin/api/moderate` endpoint that dispatches to a shared physical-delete helper extracted from the existing admin DMCA cascade. Gate the destructive step on a new `ENABLE_PHYSICAL_DELETE` config flag (default off) so the first production deploy is inert.
+
+**Architecture:** Extract `perform_physical_delete(hash, actor, reason, legal_hold)` from `handle_admin_force_delete` into a shared helper. Both admin DMCA (unconditional) and creator-delete (flag-gated) call it. Creator-delete ingress stays on the existing `/admin/api/moderate` endpoint so moderation-service's single call pattern is preserved.
+
+**Tech Stack:** Rust on Fastly Compute (WASM), `fastly` crate, `serde_json`. Tests via inline `#[cfg(test)] mod tests` — standard Rust pattern. Local dev via MinIO + `fastly compute serve`.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-creator-delete-action-design.md` on this branch.
+
+---
+
+## File Structure
+
+**Files to modify:**
+- `src/main.rs` — extract `perform_physical_delete` helper (~55 lines moved from `handle_admin_force_delete`), update `handle_admin_force_delete` to call it.
+- `src/admin.rs` — add `reason` field to `ModerateRequest` struct, wire `DELETE` action dispatch with `ENABLE_PHYSICAL_DELETE` flag check.
+- `config-store-data.json` — add `ENABLE_PHYSICAL_DELETE = "false"` for local dev.
+
+**Files to create:**
+- None. Tests live alongside production code in `#[cfg(test)]` modules within the modified files.
+
+---
+
+## Guardrails — do not do these without checkpointing with Matt first
+
+### Scope
+
+- Do not add new dependencies in `Cargo.toml`.
+- Do not refactor any file not listed above.
+- Do not modify `handle_admin_force_delete`'s behavior — only its internals (extract to helper; caller is equivalent).
+- Do not change the auth path on `/admin/api/moderate`. Existing Bearer auth (admin_token OR webhook_secret) remains.
+- Do not modify `BlobStatus` enum. `Deleted` already exists.
+- Do not change any existing tests. Add new tests; don't reshape existing.
+- Do not change the Fastly Purge logic (`purge_vcl_cache`). Reuse it verbatim.
+- Do not add new logging beyond the eprintln lines specified in the spec.
+
+### Safety measures — DO NOT REMOVE OR SIMPLIFY
+
+These are required by the spec:
+
+- `ENABLE_PHYSICAL_DELETE` flag check in the creator-delete DELETE branch. Flag off → status flip only, return `physical_delete_skipped: true`.
+- `actor: "creator_delete"` passed to `perform_physical_delete` (and `"admin"` from the force-delete endpoint). This is the audit-log distinguisher.
+- `legal_hold: false` on the creator-delete ingress (creator re-upload is not blocked).
+- Failure of `perform_physical_delete` is logged but does NOT block the 200 response — the status flip is the load-bearing compliance guarantee.
+- `get_config("ENABLE_PHYSICAL_DELETE")` comparison uses `eq_ignore_ascii_case` on the value OR exact `== Some("true")`; pick ONE and be consistent. The spec uses `as_deref() == Some("true")` — follow it.
+
+### When in doubt
+
+Stop and ask. A checkpoint question is cheaper than reverting a commit.
+
+---
+
+## Per-task review checklist (orchestrator uses this on every subagent output)
+
+- [ ] Tests written before implementation (visible in git history or commit body).
+- [ ] `cargo test` passes all tests (existing + new).
+- [ ] `cargo build --target wasm32-wasi --release` succeeds (or the repo's documented build command).
+- [ ] No new dependencies in `Cargo.toml`.
+- [ ] No files touched outside the task's "Files" list.
+- [ ] Safety measures from Guardrails present and unaltered.
+- [ ] Existing `handle_admin_force_delete` test (if any) still passes after the refactor — behavior equivalence.
+- [ ] Commit message follows existing Blossom convention (check `git log --oneline -10` on main for style; no Claude attribution).
+- [ ] Rust doc comments on new public/pub(crate) functions.
+
+### Red flags to escalate
+
+- Subagent adds a dependency, refactors an unrelated file, or changes `BlobStatus`.
+- `handle_admin_force_delete`'s tests or behavior change beyond the extraction.
+- The DELETE branch returns anything other than 200 on status-flip-only or full-cascade success.
+- The flag check is bypassed, inverted, or gated on the wrong value.
+
+---
+
+## Staging Preflight
+
+- [ ] **Build works at baseline.** `cargo build --target wasm32-wasi --release` on the current branch (before any changes) succeeds. Note the current Fastly CLI version (`fastly version`) — the local dev loop wants ≥14.0.4.
+
+- [ ] **Local dev loop operational.** `docker compose -f docker-compose.local.yml up minio minio-init -d` starts MinIO on :9000. `cp fastly.toml.local fastly.toml` then `fastly compute serve` brings Blossom up on :7676. `curl http://localhost:7676/admin/api/stats -H 'Authorization: Bearer <admin_token>'` returns 200 (admin auth configured for local).
+
+- [ ] **Existing DELETE action confirms baseline.** `curl -X POST http://localhost:7676/admin/api/moderate -H 'Content-Type: application/json' -H 'Authorization: Bearer <admin_token>' -d '{"sha256":"aaaa...","action":"DELETE"}'` returns `400 Unknown action: DELETE`. This is the state this PR changes.
+
+- [ ] **Existing `handle_admin_force_delete` works.** `curl -X POST http://localhost:7676/admin/api/delete -d '{"sha256":"...","reason":"preflight"}'` against a test blob shows the existing cascade. Record the response shape so the refactor in Task 1 can be verified equivalent.
+
+Any preflight failure is a redirect signal.
+
+---
+
+## Task 1: Extract `perform_physical_delete` helper
+
+**Files:**
+- Modify: `src/main.rs`
+
+Refactor `handle_admin_force_delete` (currently ~89 lines, `main.rs:3152-3240`) so its cascade body lives in a new `pub(crate) fn perform_physical_delete(...)` called by the handler. Behavior must be equivalent.
+
+- [ ] **Step 1: Locate the current function**
+
+    ```bash
+    grep -n "^fn handle_admin_force_delete\|^pub fn handle_admin_force_delete" src/main.rs
+    ```
+
+    Confirm the line range (should be roughly 3152-3240). Read it top-to-bottom to understand the flow.
+
+- [ ] **Step 2: Add `perform_physical_delete` above `handle_admin_force_delete`**
+
+    Insert the helper verbatim from the spec (Component 1 code block). Signature:
+
+    ```rust
+    pub(crate) fn perform_physical_delete(
+        hash: &str,
+        actor: &str,
+        reason: &str,
+        legal_hold: bool,
+    ) -> Result<()> { /* body */ }
+    ```
+
+    The body mirrors `handle_admin_force_delete`'s cascade exactly (from "Get metadata before deletion for audit" through "Purge VCL cache"), with `actor` parameterized (was hardcoded `"admin_delete"` / `"admin"`).
+
+- [ ] **Step 3: Update `handle_admin_force_delete` to call the helper**
+
+    Replace the extracted body (between "Get metadata before deletion for audit" and "Purge VCL cache" inclusive) with a single call:
+
+    ```rust
+    perform_physical_delete(&hash, "admin", reason, legal_hold)?;
+    ```
+
+    The surrounding code (hash validation, response construction) stays as-is.
+
+- [ ] **Step 4: Build and verify existing tests pass**
+
+    ```bash
+    cargo build --target wasm32-wasi --release
+    cargo test
+    ```
+
+    Expected: build succeeds, all existing tests pass. The refactor is behavior-equivalent — any test failure here indicates we dropped something in the move.
+
+- [ ] **Step 5: Manual equivalence check against preflight baseline**
+
+    If you captured a response shape from the preflight `handle_admin_force_delete` call, compare the post-refactor response. Should match field-for-field.
+
+- [ ] **Step 6: Commit**
+
+    ```bash
+    git add src/main.rs
+    git commit -m "refactor: extract perform_physical_delete helper from handle_admin_force_delete"
+    ```
+
+---
+
+## Task 2: Add optional `reason` to `ModerateRequest`
+
+**Files:**
+- Modify: `src/admin.rs`
+
+The creator-delete ingress will eventually want to pass a reason for audit purposes. Struct extension is minimal and safe — existing callers that omit `reason` continue to work via `Option<String>`.
+
+- [ ] **Step 1: Update the struct**
+
+    Find `struct ModerateRequest` in `src/admin.rs` (around line 728-732). Change from:
+
+    ```rust
+    #[derive(Deserialize)]
+    struct ModerateRequest {
+        sha256: String,
+        action: String,
+    }
+    ```
+
+    to:
+
+    ```rust
+    #[derive(Deserialize)]
+    struct ModerateRequest {
+        sha256: String,
+        action: String,
+        #[serde(default)]
+        reason: Option<String>,
+    }
+    ```
+
+- [ ] **Step 2: Build**
+
+    ```bash
+    cargo build --target wasm32-wasi --release
+    ```
+    Expected: succeeds. No callers changed; `reason` defaults to `None`.
+
+- [ ] **Step 3: Commit**
+
+    ```bash
+    git add src/admin.rs
+    git commit -m "feat(admin): accept optional reason field in ModerateRequest"
+    ```
+
+---
+
+## Task 3: Wire DELETE action with `ENABLE_PHYSICAL_DELETE` flag check
+
+**Files:**
+- Modify: `src/admin.rs`
+
+Add the new action to `BLOSSOM_ACTION_MAP` (implicit via the match in `handle_admin_moderate_action`) and dispatch to `perform_physical_delete` when the flag is on.
+
+- [ ] **Step 1: Write the failing test first**
+
+    Add to `src/admin.rs` inside the existing `#[cfg(test)] mod tests` block:
+
+    ```rust
+    #[test]
+    fn test_delete_action_with_flag_off_returns_physical_delete_skipped() {
+        // Build a ModerateRequest with action "DELETE"
+        // Mock get_config to return None for ENABLE_PHYSICAL_DELETE
+        // Call handle_admin_moderate_action
+        // Assert: 200 status, body contains physical_delete_skipped: true,
+        //         blob status updated to Deleted.
+        todo!("build minimal viceroy mocks or use real local fastly dev harness");
+    }
+
+    #[test]
+    fn test_delete_action_with_flag_on_invokes_physical_delete() {
+        // Mock get_config to return Some("true") for ENABLE_PHYSICAL_DELETE
+        // Call handle_admin_moderate_action with action "DELETE"
+        // Assert: 200 status, body contains physical_deleted: true
+        // Assert: audit log written with actor="creator_delete"
+        todo!("same mocking as above");
+    }
+    ```
+
+    These are marked `todo!()` to serve as failing-test stubs. If the repo has a mocking harness for `get_config` + storage, expand them. Otherwise, replace `todo!()` with integration tests via local `fastly compute serve` driven by a test script.
+
+    **Fallback if Viceroy/Rust mocking is too heavy:** run the test cases manually via `curl` in the preflight loop and document results in the commit body. Rust mocks for `fastly::config_store` are non-trivial; pragmatic manual verification is acceptable for this narrowly-scoped behavior.
+
+- [ ] **Step 2: Run tests — confirm they're marked todo / fail as expected**
+
+    ```bash
+    cargo test
+    ```
+
+- [ ] **Step 3: Implement the DELETE branch**
+
+    Find `handle_admin_moderate_action` in `src/admin.rs` (around line 734). After the existing `update_blob_status` + `update_stats_on_status_change` + `purge_vcl_cache` calls, AND BEFORE the existing `json_response(StatusCode::OK, &response)` return, insert the DELETE dispatch per the spec Component 2 code block:
+
+    ```rust
+    if moderate_req.action.eq_ignore_ascii_case("DELETE") {
+        let physical_delete_enabled = get_config("ENABLE_PHYSICAL_DELETE")
+            .as_deref()
+            == Some("true");
+
+        if physical_delete_enabled {
+            let reason = moderate_req
+                .reason
+                .as_deref()
+                .unwrap_or("Creator-initiated deletion via kind 5");
+
+            if let Err(e) = crate::perform_physical_delete(
+                &moderate_req.sha256,
+                "creator_delete",
+                reason,
+                false,
+            ) {
+                eprintln!(
+                    "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
+                     Status is still Deleted; bytes may remain. Operator follow-up required.",
+                    moderate_req.sha256, e
+                );
+            }
+
+            let response = serde_json::json!({
+                "success": true,
+                "sha256": moderate_req.sha256,
+                "old_status": format!("{:?}", old_status).to_lowercase(),
+                "new_status": format!("{:?}", new_status).to_lowercase(),
+                "physical_deleted": true
+            });
+            return json_response(StatusCode::OK, &response);
+        } else {
+            let response = serde_json::json!({
+                "success": true,
+                "sha256": moderate_req.sha256,
+                "old_status": format!("{:?}", old_status).to_lowercase(),
+                "new_status": format!("{:?}", new_status).to_lowercase(),
+                "physical_delete_skipped": true
+            });
+            return json_response(StatusCode::OK, &response);
+        }
+    }
+    ```
+
+    The existing action-map match in `handle_admin_moderate_action` handles `DELETE` by mapping to `BlobStatus::Deleted` (once the arm is added). Find the match that sets `new_status` from the action string and add a `"DELETE" | "delete"` arm:
+
+    ```rust
+    let new_status = match moderate_req.action.to_uppercase().as_str() {
+        "BAN" | "BLOCK" => BlobStatus::Banned,
+        "RESTRICT" => BlobStatus::Restricted,
+        "APPROVE" | "ACTIVE" => BlobStatus::Active,
+        "PENDING" => BlobStatus::Pending,
+        "AGE_RESTRICTED" | "AGERESTRICTED" => BlobStatus::AgeRestricted,
+        "DELETE" => BlobStatus::Deleted,  // NEW
+        _ => {
+            return Err(BlossomError::BadRequest(format!(
+                "Unknown action: {}",
+                moderate_req.action
+            )))
+        }
+    };
+    ```
+
+    (The exact existing match arms may vary; confirm against the current file and add `"DELETE" => BlobStatus::Deleted` consistent with the style.)
+
+- [ ] **Step 4: Build**
+
+    ```bash
+    cargo build --target wasm32-wasi --release
+    ```
+    Expected: succeeds.
+
+- [ ] **Step 5: Local e2e validation (manual)**
+
+    Start the local dev stack (per preflight). Then:
+
+    ```bash
+    # Flag off (default): expect physical_delete_skipped=true, blob still in GCS
+    curl -X POST http://localhost:7676/admin/api/moderate \
+      -H 'Content-Type: application/json' \
+      -H "Authorization: Bearer $ADMIN_TOKEN" \
+      -d '{"sha256":"<test_blob_hash>","action":"DELETE"}'
+    # Expect: 200 {..., "physical_delete_skipped": true}
+    # Verify: minio bucket still has the blob (mc ls local/divine-blossom-local)
+    # Verify: Blossom serves 404 on the blob URL (status = Deleted)
+
+    # Flag on: expect physical_deleted=true, blob gone from GCS
+    # Set ENABLE_PHYSICAL_DELETE=true in config-store-data.json (see Task 4)
+    # Restart fastly compute serve
+    curl -X POST http://localhost:7676/admin/api/moderate \
+      -H 'Content-Type: application/json' \
+      -H "Authorization: Bearer $ADMIN_TOKEN" \
+      -d '{"sha256":"<different_test_blob>","action":"DELETE"}'
+    # Expect: 200 {..., "physical_deleted": true}
+    # Verify: minio bucket no longer has the blob
+    ```
+
+    Record both results in the commit body.
+
+- [ ] **Step 6: Run cargo test**
+
+    ```bash
+    cargo test
+    ```
+    Existing tests must still pass. If the `todo!()` tests from Step 1 are still stubs, they'll panic and fail — expected; remove them or replace with real assertions as a follow-up if you can build a mocking harness, OR delete them in favor of the manual local-e2e approach (note in commit body either way).
+
+- [ ] **Step 7: Commit**
+
+    ```bash
+    git add src/admin.rs
+    git commit -m "feat(admin): add DELETE action dispatching to perform_physical_delete
+
+    Wires DELETE into /admin/api/moderate's BLOSSOM_ACTION_MAP (new arm:
+    DELETE → BlobStatus::Deleted) and, after the status flip + VCL purge,
+    dispatches to the extracted perform_physical_delete helper when
+    ENABLE_PHYSICAL_DELETE config flag is 'true'. Flag off returns
+    {physical_delete_skipped: true} — first-prod deploy is inert.
+
+    Admin DMCA path (/admin/api/delete) unchanged — always destructive.
+    Shared helper distinguishes callers via audit-log actor field
+    ('admin' vs 'creator_delete').
+
+    Caller: divinevideo/divine-moderation-service#92.
+    "
+    ```
+
+---
+
+## Task 4: Local dev config
+
+**Files:**
+- Modify: `config-store-data.json`
+
+- [ ] **Step 1: Add the flag**
+
+    Open `config-store-data.json` in the repo root. Add `"ENABLE_PHYSICAL_DELETE": "false"` alongside other config keys. Keep it as a string (Fastly config store semantic).
+
+- [ ] **Step 2: Verify local dev picks it up**
+
+    Restart `fastly compute serve`. Confirm via a Task-3-style curl that `physical_delete_skipped: true` is returned.
+
+- [ ] **Step 3: Commit**
+
+    ```bash
+    git add config-store-data.json
+    git commit -m "config: add ENABLE_PHYSICAL_DELETE=false for local dev"
+    ```
+
+---
+
+## Task 5: Documentation + PR polish
+
+**Files:**
+- Modify: `README.md` (if the "Configure secrets" section mentions all config keys — add the flag alongside existing `google_allowed_domain`, `gcs_bucket`, etc.).
+- Optionally: `CHANGELOG.md` if the repo maintains one.
+
+- [ ] **Step 1: Document the flag in README**
+
+    Find the "Configure secrets" or "Configuration" section. Add:
+
+    ```markdown
+    - `ENABLE_PHYSICAL_DELETE` (config store `blossom_config`): when `"true"`, creator-delete actions via `/admin/api/moderate` physically remove bytes from GCS and purge edge caches. Default `"false"` — status flip only. Flip to `"true"` after end-to-end validation in the creator-delete rollout. Admin DMCA via `/admin/api/delete` is unconditionally destructive regardless of this flag.
+    ```
+
+- [ ] **Step 2: Commit**
+
+    ```bash
+    git add README.md
+    git commit -m "docs(readme): document ENABLE_PHYSICAL_DELETE config flag"
+    ```
+
+---
+
+## Self-Review checklist
+
+After writing the plan, check:
+
+**Spec coverage:**
+- [x] `perform_physical_delete` helper extraction — Task 1
+- [x] `reason` field on `ModerateRequest` — Task 2
+- [x] `DELETE` action dispatch with flag check — Task 3
+- [x] `ENABLE_PHYSICAL_DELETE` config store entry — Task 4
+- [x] Documentation — Task 5
+- [x] Failure handling matrix — covered in Task 3's implementation (eprintln on helper failure, 200 still returned)
+- [x] Observability — existing `[PURGE]` and new `[CREATOR-DELETE]` / `[PHYSICAL-DELETE]` logs
+- [x] Tests — Task 3 with fallback to local e2e if Viceroy mocking is too heavy
+- [x] Dependencies and sequencing — spec section is authoritative
+- [x] Local dev loop — preflight + Task 3 Step 5
+
+**Placeholder scan:** The `todo!()` in Task 3 Step 1 is an acknowledged stub with a fallback — manual local e2e driven by the Step 5 curl commands. This is pragmatic for Rust + Fastly Compute where mocking `fastly::config_store` is non-trivial.
+
+**Type consistency:** `perform_physical_delete(hash: &str, actor: &str, reason: &str, legal_hold: bool) -> Result<()>` — signature consistent across Tasks 1 and 3.
+
+---
+
+## Execution handoff
+
+Plan complete and committed to `docs/superpowers/plans/2026-04-16-creator-delete-action-plan.md` on branch `feat/creator-delete-action`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute in this session using executing-plans, batch execution with checkpoints.
+
+For this PR's scope (5 small tasks, mostly file edits in two files), either approach works. Subagent-driven preserves the per-task review rhythm we've established on the moderation-service side.

--- a/docs/superpowers/specs/2026-04-16-creator-delete-action-design.md
+++ b/docs/superpowers/specs/2026-04-16-creator-delete-action-design.md
@@ -1,0 +1,344 @@
+# Blossom `DELETE` Action for Creator-Initiated Deletes
+
+**Date:** April 16, 2026
+**Author:** Matt Bradley
+**Status:** Draft. Awaiting review.
+
+**Related:**
+- `divine-mobile#3102` (feature issue — "remove media blobs and confirm relay deletion before success")
+- `divine-moderation-service` PR `#92` on branch `spec/per-video-delete-enforcement` (the calling side — creator-delete pipeline)
+- `divine-mobile#3117` (mobile copy PR — sibling, not a dependency)
+- `divine-blossom` PR #33 (merged 2026-04-07 — `Deleted` status serve-path fixes; this work builds on top of it)
+
+## Goal
+
+When `divine-moderation-service` accepts a creator-initiated kind 5 deletion, Blossom must remove the affected media blob from both its live serving path (blob status → `Deleted`) and, when enabled, from Divine-controlled physical storage (GCS bytes gone, Fastly edge cache invalidated). A safety flag (`ENABLE_PHYSICAL_DELETE`, default off) gates the destructive step so the first production deploy is inert and reversible.
+
+## Motivation
+
+The creator-delete pipeline in `divine-moderation-service` sends `POST /admin/api/moderate` with `{sha256, action: "DELETE"}`. Today that request returns `400 Unknown action: DELETE` — the action isn't wired. We need to:
+
+1. Accept the action.
+2. Map it to a physical-removal cascade that matches Liz's compliance scoping on divine-mobile#3102: "remove media blobs" means bytes gone from GCS, not just a status flip.
+3. Gate the cascade on a flag so first-prod deploys don't destroy data before the end-to-end pipeline is verified.
+
+## Current State
+
+Blossom already has most of what we need:
+
+**`handle_admin_force_delete`** (`src/main.rs:3152-3240`) is a working endpoint for admin DMCA / legal-hold force-deletion. It calls:
+- `storage_delete(hash)` — GCS main blob delete (via `Method::DELETE` to gcs_storage backend)
+- `delete_blob_gcs_artifacts(hash)` — thumbnail (`{hash}.jpg`), HLS variants (master.m3u8, stream_720p/480p.m3u8/.ts/.mp4), VTT (`{hash}/vtt/main.vtt`), plus a Cloud Run fire-and-forget for prefix-based catch-all cleanup
+- `cleanup_derived_audio_for_source(hash)` — derived audio cleanup
+- `delete_blob_metadata(hash)` — KV metadata delete
+- `delete_blob_kv_artifacts(hash)` — refs, auth events, subtitle data
+- `remove_from_user_list` / `remove_from_recent_index`
+- `update_stats_on_remove`
+- `write_audit_log` — persisted audit trail
+- `purge_vcl_cache(hash)` — Fastly Purge API call (external `POST https://api.fastly.com/service/{id}/purge/{surrogate_key}` with `fastly_api_token` from secret store; fire-and-forget with logging)
+- Optional `put_tombstone(hash, reason)` (when `legal_hold: true` — prevents future re-upload of the same bytes)
+
+**`handle_admin_moderate_action`** (`src/admin.rs:734-788`) accepts `BAN | BLOCK | RESTRICT | APPROVE | ACTIVE | PENDING | AGE_RESTRICTED` via `BLOSSOM_ACTION_MAP`. Status flip is applied, then `purge_vcl_cache` runs. Auth is Bearer (`admin_token` or `webhook_secret` from `blossom_secrets`, both accepted) or session cookie.
+
+**`BlobStatus::Deleted`** already exists in the blob-status enum. PR #33 (merged) closed route gaps so all serving paths (main, HLS HEAD, subtitle-by-hash) reject `Deleted` blobs with 404.
+
+**Config store access** uses `get_config(key)` against `blossom_config` (`admin.rs:203`). Adding a new flag is standard.
+
+## Gap
+
+Three things are missing:
+
+1. `handle_admin_moderate_action` does not recognize `"DELETE"` — returns 400.
+2. The physical-delete cascade inside `handle_admin_force_delete` is a monolithic 89-line block; not reusable from `handle_admin_moderate_action`.
+3. No `ENABLE_PHYSICAL_DELETE` config flag exists — all force-delete paths are unconditionally destructive (appropriate for admin DMCA, but creator-delete needs a safer first-deploy path).
+
+## Design Principle
+
+**Reuse everything that exists.** The existing force-delete cascade is production-tested for admin DMCA. The creator-delete path should invoke the same cascade, just gated differently. Refactor the cascade into a shared helper so both ingresses call a single source of truth.
+
+Two ingresses, two semantics:
+
+| Ingress | Purpose | Flag behavior |
+|---|---|---|
+| `POST /admin/api/delete` (existing) | Admin DMCA / legal hold | Unconditionally destructive. No flag check. |
+| `POST /admin/api/moderate` with `action: "DELETE"` (new) | Creator-initiated deletion from moderation-service | Gated on `ENABLE_PHYSICAL_DELETE`. Flag off → status flip only. Flag on → full cascade. |
+
+Same helper, different call sites, different semantics. Audit log's `actor` field distinguishes them ("admin" vs "creator_delete").
+
+## Architecture
+
+```
+  moderation-service                              divine-blossom
+  ------------------                              --------------
+  POST /admin/api/moderate                  --->  handle_admin_moderate_action
+  { sha256, action: "DELETE" }
+  Bearer webhook_secret                           [validate_bearer_token]
+                                                  [BLOSSOM_ACTION_MAP: DELETE -> Deleted]
+                                                  [update_blob_status(sha256, Deleted)]
+                                                  [update_stats_on_status_change]
+                                                  [purge_vcl_cache(sha256)]
+                                                           |
+                                                           v
+                                         [flag = get_config("ENABLE_PHYSICAL_DELETE")]
+                                                           |
+                    +--------------------------------------+--------------+
+                    | flag = "true"                                       | flag != "true"
+                    v                                                     v
+           perform_physical_delete(sha256, "creator_delete", reason)    return {
+                    |                                                      success: true,
+                    |  (existing helpers, reused verbatim)                  physical_delete_skipped: true,
+                    |                                                      ...
+                    v                                                    }
+           cleanup_derived_audio_for_source
+           storage_delete (main blob)
+           delete_blob_gcs_artifacts (thumb, HLS, VTT, derived)
+           delete_blob_metadata
+           remove_from_user_list (owner + all refs)
+           delete_blob_kv_artifacts
+           update_stats_on_remove
+           remove_from_recent_index
+           purge_vcl_cache (second pass, post-destruction)
+           write_audit_log(sha256, "creator_delete", ...)
+                    |
+                    v
+           return { success: true, physical_deleted: true, ... }
+```
+
+## Components
+
+### 1. Extract `perform_physical_delete` helper
+
+**File:** `src/main.rs`
+
+Extract the cascade body from `handle_admin_force_delete` (lines 3175-3230 in the current file, the steps between "Get metadata before deletion for audit" and "Purge VCL cache") into a reusable helper:
+
+```rust
+/// Execute full physical deletion of a blob and all derived artifacts.
+/// Caller is responsible for having already verified auth + format + blob existence.
+/// Returns Ok(()) on success; errors are logged internally and best-effort (most
+/// steps are fire-and-forget at the storage/KV layer, matching existing behavior).
+///
+/// actor: attribution tag for the audit log ("admin", "creator_delete", etc.)
+/// reason: free-form reason string for the audit log
+/// legal_hold: when true, writes a tombstone that prevents re-upload of the same bytes
+pub(crate) fn perform_physical_delete(
+    hash: &str,
+    actor: &str,
+    reason: &str,
+    legal_hold: bool,
+) -> Result<()> {
+    // Get metadata before deletion for audit
+    let metadata = get_blob_metadata(hash)?;
+    let meta_json = metadata
+        .as_ref()
+        .and_then(|m| serde_json::to_string(m).ok());
+
+    // Audit log BEFORE deletion
+    write_audit_log(
+        hash,
+        actor, // was "admin_delete" — now parameterized
+        actor,
+        None,
+        meta_json.as_deref(),
+        Some(reason),
+    );
+
+    // GCS: main blob + derived artifacts + derived audio
+    cleanup_derived_audio_for_source(hash);
+    let _ = storage_delete(hash);
+    delete_blob_gcs_artifacts(hash);
+
+    // KV metadata + user list + artifacts
+    let _ = delete_blob_metadata(hash);
+    if let Some(ref meta) = metadata {
+        let _ = remove_from_user_list(&meta.owner, hash);
+    }
+    if let Ok(refs) = get_blob_refs(hash) {
+        for pubkey in &refs {
+            let _ = remove_from_user_list(pubkey, hash);
+        }
+    }
+    delete_blob_kv_artifacts(hash);
+
+    // Stats + recent index
+    if let Some(meta) = metadata {
+        let _ = update_stats_on_remove(&meta);
+    }
+    let _ = remove_from_recent_index(hash);
+
+    // Tombstone (prevents re-upload of these exact bytes)
+    if legal_hold {
+        let _ = put_tombstone(hash, reason);
+    }
+
+    // Fastly VCL cache purge
+    purge_vcl_cache(hash);
+
+    eprintln!(
+        "[PHYSICAL-DELETE] actor={} hash={} legal_hold={}",
+        actor, hash, legal_hold
+    );
+
+    Ok(())
+}
+```
+
+Update `handle_admin_force_delete` to call the helper with `actor: "admin"`, `legal_hold` from the request body, and the request's `reason`. Behavior equivalent — existing tests for force-delete must still pass.
+
+### 2. Wire `DELETE` into `handle_admin_moderate_action`
+
+**File:** `src/admin.rs`
+
+Add `"DELETE"` to the action match in `handle_admin_moderate_action` (around line 754), mapping to `BlobStatus::Deleted`. The status flip runs normally (reuses existing `update_blob_status` + `update_stats_on_status_change` + `purge_vcl_cache` path). Then branch on the flag:
+
+```rust
+// New DELETE action dispatch — after the existing update_blob_status and
+// update_stats_on_status_change calls, BEFORE the json_response return.
+if moderate_req.action.eq_ignore_ascii_case("DELETE") {
+    let physical_delete_enabled = get_config("ENABLE_PHYSICAL_DELETE")
+        .as_deref()
+        == Some("true");
+
+    if physical_delete_enabled {
+        // Reason defaults for creator-initiated deletes. If the caller ever
+        // sends a reason in the body, forward it; else use a stable default.
+        let reason = moderate_req
+            .reason
+            .as_deref()
+            .unwrap_or("Creator-initiated deletion via kind 5");
+
+        // perform_physical_delete is the extracted helper from main.rs.
+        // Failures are logged internally and don't block the response —
+        // the status flip already stopped serving, which is the core
+        // compliance guarantee.
+        if let Err(e) = crate::perform_physical_delete(
+            &moderate_req.sha256,
+            "creator_delete",
+            reason,
+            false, // legal_hold always false for creator-initiated
+        ) {
+            eprintln!(
+                "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
+                 Status is still Deleted; bytes may remain. Operator follow-up required.",
+                moderate_req.sha256, e
+            );
+            // Continue to return success — the status flip is the load-bearing
+            // promise; physical-delete failure is an operator issue.
+        }
+
+        let response = serde_json::json!({
+            "success": true,
+            "sha256": moderate_req.sha256,
+            "old_status": format!("{:?}", old_status).to_lowercase(),
+            "new_status": format!("{:?}", new_status).to_lowercase(),
+            "physical_deleted": true
+        });
+        return json_response(StatusCode::OK, &response);
+    } else {
+        let response = serde_json::json!({
+            "success": true,
+            "sha256": moderate_req.sha256,
+            "old_status": format!("{:?}", old_status).to_lowercase(),
+            "new_status": format!("{:?}", new_status).to_lowercase(),
+            "physical_delete_skipped": true
+        });
+        return json_response(StatusCode::OK, &response);
+    }
+}
+```
+
+### 3. Extend `ModerateRequest` with an optional `reason` field
+
+**File:** `src/admin.rs`
+
+The `ModerateRequest` struct currently has `{sha256, action}`. Add an optional `reason` for the audit log. Moderation-service's current payload doesn't include it, so we use an `Option<String>` with a sensible default when absent.
+
+```rust
+#[derive(Deserialize)]
+struct ModerateRequest {
+    sha256: String,
+    action: String,
+    #[serde(default)]
+    reason: Option<String>,
+}
+```
+
+### 4. Local dev config
+
+**File:** `config-store-data.json`
+
+Add `ENABLE_PHYSICAL_DELETE = "false"` to the local config store data. First-prod deploy flips this to `"true"` only after validation.
+
+### 5. Tests
+
+**File:** new test module in `src/admin.rs` (or a new `src/admin/tests.rs` if one exists)
+
+- Test: `DELETE` action with flag off returns 200 with `physical_delete_skipped: true`, status flip happened, `perform_physical_delete` NOT called
+- Test: `DELETE` action with flag on returns 200 with `physical_deleted: true`, status flip + cascade both ran, audit log has `actor: "creator_delete"`
+- Test: `DELETE` on a non-existent blob returns 404
+- Test: `DELETE` with invalid sha256 format returns 400
+- Test: unknown action still returns 400 (preserves existing behavior)
+
+For the extracted `perform_physical_delete`:
+
+- Test: helper is called from `handle_admin_force_delete` with `actor: "admin"` — existing force-delete behavior preserved
+
+Tests use Fastly Compute's Viceroy runtime with mocked KV / storage / config stores. Follow existing test conventions in the repo (check `src/*.rs` for `#[cfg(test)]` blocks as precedent).
+
+## Failure handling
+
+| Scenario | Response | Notes |
+|---|---|---|
+| `ENABLE_PHYSICAL_DELETE=false`, status flip OK | 200 `{physical_delete_skipped: true}` | Expected first-prod state. |
+| `ENABLE_PHYSICAL_DELETE=true`, full cascade OK | 200 `{physical_deleted: true}` | Happy path. |
+| `ENABLE_PHYSICAL_DELETE=true`, status flip OK, cascade throws | 200 `{physical_deleted: true}` + Sentry log | The cascade helpers are fire-and-forget internally; individual step failures don't propagate. A Rust panic inside `perform_physical_delete` is the one case that logs but doesn't block the response — we preserve the status flip semantics. |
+| Fastly Purge fails mid-cascade | (internal to helper) Logged, doesn't block | Existing `purge_vcl_cache` behavior. |
+| Blob not found | 404 from earlier in `handle_admin_moderate_action` (existing check) | Pre-cascade. |
+| Invalid sha256 | 400 | Existing check. |
+| Auth failure | 401 / 403 | Existing. |
+
+## Observability
+
+- `[CREATOR-DELETE] perform_physical_delete failed for {sha256}: {error}` — ERROR-level eprintln on helper failure. Sentry alert on this string surfaces physical-delete regressions without degrading the creator-visible pipeline.
+- `[PHYSICAL-DELETE] actor=creator_delete hash=... legal_hold=false` — INFO-level on success. Metric source for throughput + audit trail.
+- Existing `[PURGE] VCL purge failed for key={sha256}` already logs on Fastly API failures. Add a Sentry alert on elevated rates.
+- Existing `[ADMIN DELETE]` log becomes per-actor; admin DMCA paths still emit `actor=admin`.
+
+## Security
+
+- **Auth:** unchanged. `validate_admin_auth` accepts `webhook_secret` (used by moderation-service) or `admin_token` (used by admin tools). Creator-delete ingress shares the webhook_secret path with all other moderation-service → Blossom traffic.
+- **Flag scoping:** `ENABLE_PHYSICAL_DELETE` only affects the creator-delete ingress. Admin DMCA via `/admin/api/delete` remains unconditionally destructive — flipping the flag off does not accidentally protect DMCA targets.
+- **Tombstone semantics:** admin DMCA sets `legal_hold: true` when requested (caller's choice). Creator-delete always sets `legal_hold: false` — a creator deleting their own video today can re-upload tomorrow if they choose, and we don't block that at the infrastructure layer.
+- **Reason field:** optional, caller-provided. Written to audit log verbatim. Not rendered to user-visible surfaces. No sanitization needed.
+
+## Dependencies and sequencing
+
+1. **PR #33 already landed on main.** `Deleted` status serving checks are in place.
+2. **This PR** — adds `perform_physical_delete` extraction + DELETE action + flag.
+3. **Deploy sequence for production:**
+   - Step 1: deploy Blossom with `ENABLE_PHYSICAL_DELETE="false"` in `blossom_config` (default). Creator-delete ingress works — status flips to `Deleted`, bytes stay on GCS, Fastly Purge runs (OK — idempotent). Moderation-service still needs its own `CREATOR_DELETE_PIPELINE_ENABLED=false` for its half.
+   - Step 2: deploy moderation-service PR #92. Still inert (its own feature flag).
+   - Step 3: flip moderation-service `CREATOR_DELETE_PIPELINE_ENABLED="true"`. Run validation window (first ~50 creator deletes). Bytes still on GCS.
+   - Step 4: flip Blossom `ENABLE_PHYSICAL_DELETE="true"`. Subsequent creator-deletes physically remove bytes. Legacy `Deleted`-status blobs from the validation window can be cleaned by a one-time sweep script (simple iteration + per-blob `perform_physical_delete` call).
+
+## Staging preflight
+
+Before implementation:
+
+- [ ] Confirm PR #33's merge is reflected on `origin/main` (verified — commit `755b7b8` sits above the relevant PR commits).
+- [ ] Local dev loop: `docker compose -f docker-compose.local.yml up minio minio-init -d`, `cp fastly.toml.local fastly.toml`, `fastly compute serve`. Issue a `POST /admin/api/moderate` with `{sha256: "...", action: "DELETE"}` and confirm the existing 400 "Unknown action" response (establishes pre-change baseline).
+- [ ] Confirm `purge_vcl_cache` emits a log line in local dev (may skip actual Fastly API call if `fastly_api_token` is absent — that's the existing "skipping VCL cache purge" path).
+- [ ] Verify `write_audit_log` persists for local dev (check KV store via `fastly kv-store entry list` or equivalent).
+
+## Non-goals and follow-ups
+
+- **Changes to `/admin/api/delete`'s external contract.** It still accepts `{sha256, reason, legal_hold}` and still unconditionally destroys. Only the internal implementation changes (calls the extracted helper).
+- **Cross-repo audit consolidation.** moderation-service writes its own D1 audit row; Blossom writes its own KV audit log. Reconciling them into a single audit surface is a v2 concern.
+- **Soft-delete grace period for creator deletes.** The spec's moderation-service side already punts creator-initiated un-delete to v2. Blossom mirrors that — no grace window here.
+- **One-time sweep of legacy `Deleted`-status blobs** (status was flipped before the physical-delete flag was on). Matt will script this separately after flag flip; it's a simple iteration.
+- **Fastly Purge retry on failure.** Current behavior is fire-and-forget; failures log but don't retry. Elevating this to a retry loop is a follow-up if purge-failure rate is ever observed non-trivial.
+
+## Open questions
+
+- **Tests for the extracted helper in Viceroy.** Does the existing repo have an integration test harness for Fastly Compute, or is all testing via manual local e2e + prod smoke? If only the latter, we add unit tests for `handle_admin_moderate_action`'s new DELETE branch using the existing mock-friendly pattern (if any); otherwise we rely on local e2e in preflight.
+- **Reason field propagation from moderation-service.** Currently moderation-service's `notifyBlossom` sends `{sha256, action, timestamp}` — no `reason`. This spec treats `reason` as optional on the Blossom side. A follow-up could add a `reason` field from the creator-delete pipeline (e.g., "Creator-initiated delete via kind 5") to enrich the audit log.

--- a/docs/superpowers/specs/2026-04-16-creator-delete-action-design.md
+++ b/docs/superpowers/specs/2026-04-16-creator-delete-action-design.md
@@ -1,6 +1,6 @@
 # Blossom `DELETE` Action for Creator-Initiated Deletes
 
-**Date:** April 16, 2026
+**Date:** April 16, 2026 (revised after code-review scout)
 **Author:** Matt Bradley
 **Status:** Draft. Awaiting review.
 
@@ -12,7 +12,7 @@
 
 ## Goal
 
-When `divine-moderation-service` accepts a creator-initiated kind 5 deletion, Blossom must remove the affected media blob from both its live serving path (blob status → `Deleted`) and, when enabled, from Divine-controlled physical storage (GCS bytes gone, Fastly edge cache invalidated). A safety flag (`ENABLE_PHYSICAL_DELETE`, default off) gates the destructive step so the first production deploy is inert and reversible.
+When `divine-moderation-service` accepts a creator-initiated kind 5 deletion, Blossom must remove the affected media blob from both its live serving path (blob status to `Deleted`) and, when enabled, from Divine-controlled physical storage (GCS bytes gone, Fastly edge cache invalidated). A safety flag (`ENABLE_PHYSICAL_DELETE`, default off) gates the destructive step so the first production deploy is inert and reversible.
 
 ## Motivation
 
@@ -22,48 +22,50 @@ The creator-delete pipeline in `divine-moderation-service` sends `POST /admin/ap
 2. Map it to a physical-removal cascade that matches Liz's compliance scoping on divine-mobile#3102: "remove media blobs" means bytes gone from GCS, not just a status flip.
 3. Gate the cascade on a flag so first-prod deploys don't destroy data before the end-to-end pipeline is verified.
 
-## Current State
+## Current State (verified against `origin/main` on branch `feat/creator-delete-action`)
 
-Blossom already has most of what we need:
+### What Blossom has today
 
-**`handle_admin_force_delete`** (`src/main.rs:3152-3240`) is a working endpoint for admin DMCA / legal-hold force-deletion. It calls:
-- `storage_delete(hash)` — GCS main blob delete (via `Method::DELETE` to gcs_storage backend)
-- `delete_blob_gcs_artifacts(hash)` — thumbnail (`{hash}.jpg`), HLS variants (master.m3u8, stream_720p/480p.m3u8/.ts/.mp4), VTT (`{hash}/vtt/main.vtt`), plus a Cloud Run fire-and-forget for prefix-based catch-all cleanup
-- `cleanup_derived_audio_for_source(hash)` — derived audio cleanup
-- `delete_blob_metadata(hash)` — KV metadata delete
-- `delete_blob_kv_artifacts(hash)` — refs, auth events, subtitle data
-- `remove_from_user_list` / `remove_from_recent_index`
-- `update_stats_on_remove`
-- `write_audit_log` — persisted audit trail
-- `purge_vcl_cache(hash)` — Fastly Purge API call (external `POST https://api.fastly.com/service/{id}/purge/{surrogate_key}` with `fastly_api_token` from secret store; fire-and-forget with logging)
-- Optional `put_tombstone(hash, reason)` (when `legal_hold: true` — prevents future re-upload of the same bytes)
+**`handle_admin_moderate_action`** (`src/admin.rs:848-903`) — the endpoint moderation-service calls. Accepts `BAN|BLOCK`, `RESTRICT`, `AGE_RESTRICT|AGE_RESTRICTED`, `APPROVE|ACTIVE`, `PENDING`. Does a bare `update_blob_status` + `purge_vcl_cache` + `update_stats_on_status_change`. Does NOT call `soft_delete_blob` (no index/user-list cleanup). Does NOT do physical deletion.
 
-**`handle_admin_moderate_action`** (`src/admin.rs:734-788`) accepts `BAN | BLOCK | RESTRICT | APPROVE | ACTIVE | PENDING | AGE_RESTRICTED` via `BLOSSOM_ACTION_MAP`. Status flip is applied, then `purge_vcl_cache` runs. Auth is Bearer (`admin_token` or `webhook_secret` from `blossom_secrets`, both accepted) or session cookie.
+**`handle_admin_force_delete`** (`src/main.rs:3913-3968`) — the admin DMCA endpoint at `/admin/api/delete`. Despite the name, this is **soft-delete by design**: calls `soft_delete_blob(...)` from `delete_policy.rs`. Response includes `"preserved": true`. GCS bytes are NOT removed. This endpoint is NOT modified by this PR.
 
-**`BlobStatus::Deleted`** already exists in the blob-status enum. PR #33 (merged) closed route gaps so all serving paths (main, HLS HEAD, subtitle-by-hash) reject `Deleted` blobs with 404.
+**`soft_delete_blob`** (`src/delete_policy.rs:39-64`) — reusable helper. Status flip to `Deleted`, `update_stats_on_status_change`, `remove_from_user_list` (owner + all refs), `remove_from_recent_index`, optional `put_tombstone`, `purge_vcl_cache`. No physical byte removal.
 
-**Config store access** uses `get_config(key)` against `blossom_config` (`admin.rs:203`). Adding a new flag is standard.
+**`execute_vanish`** (`src/main.rs:3975-4057`) — GDPR right-to-erasure, pubkey-level. Sole-owner branch does inline physical cascade: `cleanup_derived_audio_for_source`, `storage_delete`, `delete_blob_gcs_artifacts`, `delete_blob_metadata`, `delete_blob_kv_artifacts`, `update_stats_on_remove`, `remove_from_recent_index`, `purge_vcl_cache`. This IS physical deletion, but: (a) it's inline, not a reusable helper; (b) it deletes the metadata row entirely (we want to preserve it for audit); (c) it's pubkey-scoped, not per-blob.
 
-## Gap
+**`BlobStatus::Deleted`** exists. PR #33 closed all serve-path gaps (main, HLS HEAD, subtitle-by-hash) so `Deleted` returns 404.
 
-Three things are missing:
+**`purge_vcl_cache`** (`src/main.rs:4722`) — calls Fastly Purge API via `api.fastly.com`. Uses `fastly_api_token` from secret store. Fire-and-forget with logging.
 
-1. `handle_admin_moderate_action` does not recognize `"DELETE"` — returns 400.
-2. The physical-delete cascade inside `handle_admin_force_delete` is a monolithic 89-line block; not reusable from `handle_admin_moderate_action`.
-3. No `ENABLE_PHYSICAL_DELETE` config flag exists — all force-delete paths are unconditionally destructive (appropriate for admin DMCA, but creator-delete needs a safer first-deploy path).
+**`delete_blob_gcs_artifacts`** (`src/main.rs:2968`) — removes thumbnail (`{hash}.jpg`), HLS variants, VTT transcript, plus fire-and-forget Cloud Run for prefix-based catch-all.
+
+**`storage_delete`** (`src/storage.rs`) — `Method::DELETE` to GCS backend.
+
+**Config store** — `get_config(key)` reads from `blossom_config` (Fastly config store). Standard pattern for flags.
+
+**`write_audit_log`** (`src/storage.rs:1172`) — signature: `(sha256, action, actor_pubkey, auth_event_json?, metadata_snapshot?, reason?)`. Writes structured JSON to Cloud Run /audit endpoint, auto-ingested by Cloud Logging.
+
+### What's missing
+
+1. `handle_admin_moderate_action` does not recognize `"DELETE"`.
+2. No reusable per-blob physical-delete helper exists. `execute_vanish` has one inline but its semantics differ (deletes metadata row, pubkey-scoped).
+3. No `ENABLE_PHYSICAL_DELETE` config flag.
 
 ## Design Principle
 
-**Reuse everything that exists.** The existing force-delete cascade is production-tested for admin DMCA. The creator-delete path should invoke the same cascade, just gated differently. Refactor the cascade into a shared helper so both ingresses call a single source of truth.
+**Compose, don't extract.** `soft_delete_blob` is the proven soft-delete helper. Build `perform_physical_delete` as its physical counterpart: calls `soft_delete_blob` first (stops serving, cleans indices), then adds byte destruction. Lives alongside it in `delete_policy.rs`.
 
-Two ingresses, two semantics:
+**Don't touch what works.** `handle_admin_force_delete` stays soft-delete. `execute_vanish` stays inline. Neither is modified by this PR.
 
-| Ingress | Purpose | Flag behavior |
-|---|---|---|
-| `POST /admin/api/delete` (existing) | Admin DMCA / legal hold | Unconditionally destructive. No flag check. |
-| `POST /admin/api/moderate` with `action: "DELETE"` (new) | Creator-initiated deletion from moderation-service | Gated on `ENABLE_PHYSICAL_DELETE`. Flag off → status flip only. Flag on → full cascade. |
+**Two ingresses, two semantics:**
 
-Same helper, different call sites, different semantics. Audit log's `actor` field distinguishes them ("admin" vs "creator_delete").
+| Endpoint | Purpose | Delete semantics | Flag behavior |
+|---|---|---|---|
+| `POST /admin/api/delete` (existing) | Admin DMCA / legal hold | Soft-delete. Bytes preserved. | Not affected by `ENABLE_PHYSICAL_DELETE`. |
+| `POST /admin/api/moderate` with `action: "DELETE"` (new) | Creator-initiated via moderation-service | Soft-delete (flag off) OR soft-delete + physical removal (flag on). | `ENABLE_PHYSICAL_DELETE` gates the byte-destruction step only. |
+
+Admin DMCA is deliberately soft — preserves evidence for legal proceedings. Creator-delete is meant to be permanent when the flag is on.
 
 ## Architecture
 
@@ -72,273 +74,205 @@ Same helper, different call sites, different semantics. Audit log's `actor` fiel
   ------------------                              --------------
   POST /admin/api/moderate                  --->  handle_admin_moderate_action
   { sha256, action: "DELETE" }
-  Bearer webhook_secret                           [validate_bearer_token]
-                                                  [BLOSSOM_ACTION_MAP: DELETE -> Deleted]
-                                                  [update_blob_status(sha256, Deleted)]
-                                                  [update_stats_on_status_change]
-                                                  [purge_vcl_cache(sha256)]
+  Bearer webhook_secret                           [validate_admin_auth]
+                                                  [check: action == "DELETE"?]
                                                            |
-                                                           v
-                                         [flag = get_config("ENABLE_PHYSICAL_DELETE")]
+                                                           v   (special-case branch)
+                                                  [write_audit_log("creator_delete", metadata.owner)]
+                                                  [flag = get_config("ENABLE_PHYSICAL_DELETE")]
                                                            |
                     +--------------------------------------+--------------+
                     | flag = "true"                                       | flag != "true"
                     v                                                     v
-           perform_physical_delete(sha256, "creator_delete", reason)    return {
-                    |                                                      success: true,
-                    |  (existing helpers, reused verbatim)                  physical_delete_skipped: true,
-                    |                                                      ...
-                    v                                                    }
-           cleanup_derived_audio_for_source
-           storage_delete (main blob)
-           delete_blob_gcs_artifacts (thumb, HLS, VTT, derived)
-           delete_blob_metadata
-           remove_from_user_list (owner + all refs)
-           delete_blob_kv_artifacts
-           update_stats_on_remove
-           remove_from_recent_index
-           purge_vcl_cache (second pass, post-destruction)
-           write_audit_log(sha256, "creator_delete", ...)
-                    |
-                    v
-           return { success: true, physical_deleted: true, ... }
+           perform_physical_delete(hash, metadata, reason, false)    soft_delete_blob(hash, metadata, reason, false)
+                    |                                                     |
+                    |  = soft_delete_blob(...)                            | = status flip + indices + VCL purge
+                    |    + cleanup_derived_audio_for_source               |   (bytes preserved)
+                    |    + storage_delete (main blob GCS)                 |
+                    |    + delete_blob_gcs_artifacts (thumb, HLS, VTT)    |
+                    |    + purge_vcl_cache (second pass)                  |
+                    |                                                     |
+                    v                                                     v
+           return { success: true, physical_deleted: true }    return { success: true, physical_delete_skipped: true }
 ```
 
 ## Components
 
-### 1. Extract `perform_physical_delete` helper
+### 1. `perform_physical_delete` helper (`src/delete_policy.rs`)
 
-**File:** `src/main.rs`
-
-Extract the cascade body from `handle_admin_force_delete` (lines 3175-3230 in the current file, the steps between "Get metadata before deletion for audit" and "Purge VCL cache") into a reusable helper:
+New `pub fn` alongside the existing `soft_delete_blob`. Composes soft-delete + byte destruction.
 
 ```rust
-/// Execute full physical deletion of a blob and all derived artifacts.
-/// Caller is responsible for having already verified auth + format + blob existence.
-/// Returns Ok(()) on success; errors are logged internally and best-effort (most
-/// steps are fire-and-forget at the storage/KV layer, matching existing behavior).
-///
-/// actor: attribution tag for the audit log ("admin", "creator_delete", etc.)
-/// reason: free-form reason string for the audit log
-/// legal_hold: when true, writes a tombstone that prevents re-upload of the same bytes
-pub(crate) fn perform_physical_delete(
+/// Physical deletion: soft-delete (stops serving) + GCS byte removal.
+/// Metadata row is preserved (status=Deleted) for audit/support visibility.
+/// Vanish callers that want metadata gone use their own inline cascade.
+pub fn perform_physical_delete(
     hash: &str,
-    actor: &str,
+    metadata: &BlobMetadata,
     reason: &str,
     legal_hold: bool,
 ) -> Result<()> {
-    // Get metadata before deletion for audit
-    let metadata = get_blob_metadata(hash)?;
-    let meta_json = metadata
-        .as_ref()
-        .and_then(|m| serde_json::to_string(m).ok());
+    // Phase 1: stop serving (status flip, index cleanup, optional tombstone, VCL purge)
+    soft_delete_blob(hash, metadata, reason, legal_hold)?;
 
-    // Audit log BEFORE deletion
-    write_audit_log(
-        hash,
-        actor, // was "admin_delete" — now parameterized
-        actor,
-        None,
-        meta_json.as_deref(),
-        Some(reason),
-    );
+    // Phase 2: physical byte + artifact removal from GCS
+    crate::cleanup_derived_audio_for_source(hash);
+    let _ = crate::storage_delete(hash);
+    crate::delete_blob_gcs_artifacts(hash);
 
-    // GCS: main blob + derived artifacts + derived audio
-    cleanup_derived_audio_for_source(hash);
-    let _ = storage_delete(hash);
-    delete_blob_gcs_artifacts(hash);
-
-    // KV metadata + user list + artifacts
-    let _ = delete_blob_metadata(hash);
-    if let Some(ref meta) = metadata {
-        let _ = remove_from_user_list(&meta.owner, hash);
-    }
-    if let Ok(refs) = get_blob_refs(hash) {
-        for pubkey in &refs {
-            let _ = remove_from_user_list(pubkey, hash);
-        }
-    }
-    delete_blob_kv_artifacts(hash);
-
-    // Stats + recent index
-    if let Some(meta) = metadata {
-        let _ = update_stats_on_remove(&meta);
-    }
-    let _ = remove_from_recent_index(hash);
-
-    // Tombstone (prevents re-upload of these exact bytes)
-    if legal_hold {
-        let _ = put_tombstone(hash, reason);
-    }
-
-    // Fastly VCL cache purge
-    purge_vcl_cache(hash);
-
-    eprintln!(
-        "[PHYSICAL-DELETE] actor={} hash={} legal_hold={}",
-        actor, hash, legal_hold
-    );
+    // Phase 3: post-destruction VCL purge (covers the window between
+    // Phase 1's purge and Phase 2's byte removal)
+    crate::purge_vcl_cache(hash);
 
     Ok(())
 }
 ```
 
-Update `handle_admin_force_delete` to call the helper with `actor: "admin"`, `legal_hold` from the request body, and the request's `reason`. Behavior equivalent — existing tests for force-delete must still pass.
+**Why not `delete_blob_metadata`?** Vanish deletes metadata (user is gone, no audit need). Creator-delete preserves it (creator is still active, support may query "what happened to blob X?"). The row stays with `status: Deleted`.
 
-### 2. Wire `DELETE` into `handle_admin_moderate_action`
+**Why not `delete_blob_kv_artifacts`?** Same reasoning — KV artifacts (refs, auth events, subtitle mappings) are preserved alongside the metadata row. If the creator re-uploads, a fresh metadata row + artifacts are created. Stale KV from the deleted blob doesn't interfere.
 
-**File:** `src/admin.rs`
+**Why `legal_hold: false` for creator-delete?** Creator-delete doesn't block future re-upload of the same bytes. Legal hold is a DMCA/legal mechanism. Callers pass `false` explicitly.
 
-Add `"DELETE"` to the action match in `handle_admin_moderate_action` (around line 754), mapping to `BlobStatus::Deleted`. The status flip runs normally (reuses existing `update_blob_status` + `update_stats_on_status_change` + `purge_vcl_cache` path). Then branch on the flag:
+### 2. DELETE special-case branch in `handle_admin_moderate_action` (`src/admin.rs`)
+
+Handle `action: "DELETE"` as a special-case branch BEFORE the existing `match ... => BlobStatus` action map. Why: the existing match does bare `update_blob_status` without index/user-list cleanup; DELETE needs the full `soft_delete_blob` path (or `perform_physical_delete` which calls it).
 
 ```rust
-// New DELETE action dispatch — after the existing update_blob_status and
-// update_stats_on_status_change calls, BEFORE the json_response return.
+// Inside handle_admin_moderate_action, after sha256 validation and metadata fetch,
+// BEFORE the action-map match:
+
 if moderate_req.action.eq_ignore_ascii_case("DELETE") {
+    let reason = moderate_req
+        .reason
+        .as_deref()
+        .unwrap_or("Creator-initiated deletion via kind 5");
+
+    // Audit BEFORE destruction
+    let meta_json = serde_json::to_string(&metadata).ok();
+    crate::write_audit_log(
+        &moderate_req.sha256,
+        "creator_delete",            // action tag
+        &metadata.owner,             // actor = the creator's pubkey
+        None,                        // no auth event for webhook-authed calls
+        meta_json.as_deref(),
+        Some(reason),
+    );
+
     let physical_delete_enabled = get_config("ENABLE_PHYSICAL_DELETE")
         .as_deref()
         == Some("true");
 
     if physical_delete_enabled {
-        // Reason defaults for creator-initiated deletes. If the caller ever
-        // sends a reason in the body, forward it; else use a stable default.
-        let reason = moderate_req
-            .reason
-            .as_deref()
-            .unwrap_or("Creator-initiated deletion via kind 5");
-
-        // perform_physical_delete is the extracted helper from main.rs.
-        // Failures are logged internally and don't block the response —
-        // the status flip already stopped serving, which is the core
-        // compliance guarantee.
-        if let Err(e) = crate::perform_physical_delete(
+        if let Err(e) = perform_physical_delete(
             &moderate_req.sha256,
-            "creator_delete",
+            &metadata,
             reason,
-            false, // legal_hold always false for creator-initiated
+            false, // no legal hold for creator-delete
         ) {
             eprintln!(
                 "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
-                 Status is still Deleted; bytes may remain. Operator follow-up required.",
+                 Status may still be flipped to Deleted; bytes may remain.",
                 moderate_req.sha256, e
             );
-            // Continue to return success — the status flip is the load-bearing
-            // promise; physical-delete failure is an operator issue.
+            // Fallback: ensure at least soft-delete ran (it may have succeeded
+            // inside perform_physical_delete before the byte-removal step failed).
         }
-
-        let response = serde_json::json!({
-            "success": true,
-            "sha256": moderate_req.sha256,
-            "old_status": format!("{:?}", old_status).to_lowercase(),
-            "new_status": format!("{:?}", new_status).to_lowercase(),
-            "physical_deleted": true
-        });
-        return json_response(StatusCode::OK, &response);
     } else {
-        let response = serde_json::json!({
-            "success": true,
-            "sha256": moderate_req.sha256,
-            "old_status": format!("{:?}", old_status).to_lowercase(),
-            "new_status": format!("{:?}", new_status).to_lowercase(),
-            "physical_delete_skipped": true
-        });
-        return json_response(StatusCode::OK, &response);
+        // Flag off: soft-delete only
+        if let Err(e) = soft_delete_blob(
+            &moderate_req.sha256,
+            &metadata,
+            reason,
+            false,
+        ) {
+            eprintln!(
+                "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
+                moderate_req.sha256, e
+            );
+            return Err(e);
+        }
     }
+
+    let response = serde_json::json!({
+        "success": true,
+        "sha256": moderate_req.sha256,
+        "old_status": format!("{:?}", old_status).to_lowercase(),
+        "new_status": "deleted",
+        "physical_deleted": physical_delete_enabled,
+        "physical_delete_skipped": !physical_delete_enabled
+    });
+    return json_response(StatusCode::OK, &response);
 }
+
+// ... existing action-map match follows for BAN, RESTRICT, etc.
 ```
 
-### 3. Extend `ModerateRequest` with an optional `reason` field
+### 3. Optional `reason` field on `ModerateRequest` (`src/admin.rs`)
 
-**File:** `src/admin.rs`
+Add `#[serde(default)] reason: Option<String>` to the struct. Existing callers (which don't send `reason`) continue to work — field defaults to `None`.
 
-The `ModerateRequest` struct currently has `{sha256, action}`. Add an optional `reason` for the audit log. Moderation-service's current payload doesn't include it, so we use an `Option<String>` with a sensible default when absent.
+### 4. `ENABLE_PHYSICAL_DELETE` config entry
 
-```rust
-#[derive(Deserialize)]
-struct ModerateRequest {
-    sha256: String,
-    action: String,
-    #[serde(default)]
-    reason: Option<String>,
-}
-```
-
-### 4. Local dev config
-
-**File:** `config-store-data.json`
-
-Add `ENABLE_PHYSICAL_DELETE = "false"` to the local config store data. First-prod deploy flips this to `"true"` only after validation.
-
-### 5. Tests
-
-**File:** new test module in `src/admin.rs` (or a new `src/admin/tests.rs` if one exists)
-
-- Test: `DELETE` action with flag off returns 200 with `physical_delete_skipped: true`, status flip happened, `perform_physical_delete` NOT called
-- Test: `DELETE` action with flag on returns 200 with `physical_deleted: true`, status flip + cascade both ran, audit log has `actor: "creator_delete"`
-- Test: `DELETE` on a non-existent blob returns 404
-- Test: `DELETE` with invalid sha256 format returns 400
-- Test: unknown action still returns 400 (preserves existing behavior)
-
-For the extracted `perform_physical_delete`:
-
-- Test: helper is called from `handle_admin_force_delete` with `actor: "admin"` — existing force-delete behavior preserved
-
-Tests use Fastly Compute's Viceroy runtime with mocked KV / storage / config stores. Follow existing test conventions in the repo (check `src/*.rs` for `#[cfg(test)]` blocks as precedent).
+Add to `config-store-data.json` (local dev) and document in README. Default `"false"`.
 
 ## Failure handling
 
 | Scenario | Response | Notes |
 |---|---|---|
-| `ENABLE_PHYSICAL_DELETE=false`, status flip OK | 200 `{physical_delete_skipped: true}` | Expected first-prod state. |
-| `ENABLE_PHYSICAL_DELETE=true`, full cascade OK | 200 `{physical_deleted: true}` | Happy path. |
-| `ENABLE_PHYSICAL_DELETE=true`, status flip OK, cascade throws | 200 `{physical_deleted: true}` + Sentry log | The cascade helpers are fire-and-forget internally; individual step failures don't propagate. A Rust panic inside `perform_physical_delete` is the one case that logs but doesn't block the response — we preserve the status flip semantics. |
-| Fastly Purge fails mid-cascade | (internal to helper) Logged, doesn't block | Existing `purge_vcl_cache` behavior. |
-| Blob not found | 404 from earlier in `handle_admin_moderate_action` (existing check) | Pre-cascade. |
+| Flag off, soft-delete OK | 200 `{physical_delete_skipped: true}` | Expected first-prod state. |
+| Flag on, full cascade OK | 200 `{physical_deleted: true}` | Happy path. |
+| Flag on, soft-delete OK, byte destruction fails | 200 `{physical_deleted: true}` + eprintln | Soft-delete has already stopped serving. Byte destruction's internal helpers are fire-and-forget (`let _ = storage_delete(...)`). A Rust panic inside `perform_physical_delete` is caught; status is still Deleted. Operator follow-up for orphaned bytes. |
+| Fastly Purge fails | (internal) Logged by `purge_vcl_cache`, doesn't block | Existing behavior. Edge clears per TTL. |
+| Blob not found | 404 | Existing check in `handle_admin_moderate_action`. |
 | Invalid sha256 | 400 | Existing check. |
 | Auth failure | 401 / 403 | Existing. |
 
 ## Observability
 
-- `[CREATOR-DELETE] perform_physical_delete failed for {sha256}: {error}` — ERROR-level eprintln on helper failure. Sentry alert on this string surfaces physical-delete regressions without degrading the creator-visible pipeline.
-- `[PHYSICAL-DELETE] actor=creator_delete hash=... legal_hold=false` — INFO-level on success. Metric source for throughput + audit trail.
-- Existing `[PURGE] VCL purge failed for key={sha256}` already logs on Fastly API failures. Add a Sentry alert on elevated rates.
-- Existing `[ADMIN DELETE]` log becomes per-actor; admin DMCA paths still emit `actor=admin`.
+- `[CREATOR-DELETE] perform_physical_delete failed for {sha256}: {error}` — ERROR-level eprintln. Sentry alert on this string.
+- Existing `[PURGE] VCL purge failed for key={sha256}` already logs on Fastly API failures.
+- `write_audit_log` entry with `action: "creator_delete"` and `actor_pubkey: <creator's pubkey>` — queryable in Cloud Logging. Distinguishes from admin soft-delete (`action: "admin_delete"`, `actor_pubkey: "admin"`).
 
 ## Security
 
-- **Auth:** unchanged. `validate_admin_auth` accepts `webhook_secret` (used by moderation-service) or `admin_token` (used by admin tools). Creator-delete ingress shares the webhook_secret path with all other moderation-service → Blossom traffic.
-- **Flag scoping:** `ENABLE_PHYSICAL_DELETE` only affects the creator-delete ingress. Admin DMCA via `/admin/api/delete` remains unconditionally destructive — flipping the flag off does not accidentally protect DMCA targets.
-- **Tombstone semantics:** admin DMCA sets `legal_hold: true` when requested (caller's choice). Creator-delete always sets `legal_hold: false` — a creator deleting their own video today can re-upload tomorrow if they choose, and we don't block that at the infrastructure layer.
-- **Reason field:** optional, caller-provided. Written to audit log verbatim. Not rendered to user-visible surfaces. No sanitization needed.
+- **Auth:** unchanged. `validate_admin_auth` accepts `webhook_secret` (used by moderation-service) or `admin_token` (used by admin tools). Creator-delete ingress shares the webhook_secret path with all other moderation-service to Blossom traffic.
+- **Admin DMCA endpoint `/admin/api/delete` is NOT modified.** It stays soft-delete, gated by its own auth, unaffected by `ENABLE_PHYSICAL_DELETE`. This is deliberate — admin DMCA preserves evidence for legal proceedings; creator-delete is meant to be permanent.
+- **`legal_hold: false`** on all creator-delete calls. Tombstone (prevents re-upload) is a legal/DMCA mechanism, not a creator feature. If we later want creators to not be able to re-upload deleted content, that's a product decision for a future PR.
+
+## Testing
+
+Build and verification commands for this Rust + Fastly Compute crate:
+- `cargo build --target wasm32-wasip1 --release` — build for Fastly's WASM target
+- `cargo check --tests --locked` — compile-check tests on host (the edge crate's FFI symbols don't link for `cargo test` on host; CI uses `cargo check` + `cargo clippy`, NOT `cargo test`)
+- Local e2e: `docker compose -f docker-compose.local.yml up minio minio-init -d` then `cp fastly.toml.local fastly.toml` then `fastly compute serve` + curl
+
+Test cases (verified via local e2e + compile-checked unit tests):
+- `perform_physical_delete` compiles and has the right imports (`cargo check --tests`)
+- `/admin/api/moderate` with `action: "DELETE"` and flag off returns 200 + `physical_delete_skipped: true`. Blob serves 404 (status Deleted). MinIO bucket retains bytes.
+- Same with flag on returns 200 + `physical_deleted: true`. MinIO bucket no longer has the bytes. Thumbnail + HLS + VTT also gone.
+- Unknown action still returns 400 (existing behavior preserved).
+- Admin DMCA endpoint (`/admin/api/delete`) behavior unchanged (soft-delete, `preserved: true`).
+- `purge_vcl_cache` log emits on both paths (no functional change to purge).
 
 ## Dependencies and sequencing
 
 1. **PR #33 already landed on main.** `Deleted` status serving checks are in place.
-2. **This PR** — adds `perform_physical_delete` extraction + DELETE action + flag.
+2. **This PR** — adds `perform_physical_delete` + DELETE action + flag.
 3. **Deploy sequence for production:**
-   - Step 1: deploy Blossom with `ENABLE_PHYSICAL_DELETE="false"` in `blossom_config` (default). Creator-delete ingress works — status flips to `Deleted`, bytes stay on GCS, Fastly Purge runs (OK — idempotent). Moderation-service still needs its own `CREATOR_DELETE_PIPELINE_ENABLED=false` for its half.
-   - Step 2: deploy moderation-service PR #92. Still inert (its own feature flag).
-   - Step 3: flip moderation-service `CREATOR_DELETE_PIPELINE_ENABLED="true"`. Run validation window (first ~50 creator deletes). Bytes still on GCS.
-   - Step 4: flip Blossom `ENABLE_PHYSICAL_DELETE="true"`. Subsequent creator-deletes physically remove bytes. Legacy `Deleted`-status blobs from the validation window can be cleaned by a one-time sweep script (simple iteration + per-blob `perform_physical_delete` call).
-
-## Staging preflight
-
-Before implementation:
-
-- [ ] Confirm PR #33's merge is reflected on `origin/main` (verified — commit `755b7b8` sits above the relevant PR commits).
-- [ ] Local dev loop: `docker compose -f docker-compose.local.yml up minio minio-init -d`, `cp fastly.toml.local fastly.toml`, `fastly compute serve`. Issue a `POST /admin/api/moderate` with `{sha256: "...", action: "DELETE"}` and confirm the existing 400 "Unknown action" response (establishes pre-change baseline).
-- [ ] Confirm `purge_vcl_cache` emits a log line in local dev (may skip actual Fastly API call if `fastly_api_token` is absent — that's the existing "skipping VCL cache purge" path).
-- [ ] Verify `write_audit_log` persists for local dev (check KV store via `fastly kv-store entry list` or equivalent).
+   - Step 1: deploy Blossom with `ENABLE_PHYSICAL_DELETE="false"` in `blossom_config` (default). Creator-delete ingress does soft-delete only.
+   - Step 2: deploy moderation-service PR #92 with `CREATOR_DELETE_PIPELINE_ENABLED="false"`.
+   - Step 3: flip moderation-service flag. Validation window. Blossom receives DELETE calls, does soft-delete only (bytes stay).
+   - Step 4: flip Blossom `ENABLE_PHYSICAL_DELETE="true"`. Subsequent creator-deletes physically remove bytes.
+   - Step 5: one-time sweep to physically remove bytes for blobs soft-deleted during the validation window.
 
 ## Non-goals and follow-ups
 
-- **Changes to `/admin/api/delete`'s external contract.** It still accepts `{sha256, reason, legal_hold}` and still unconditionally destroys. Only the internal implementation changes (calls the extracted helper).
-- **Cross-repo audit consolidation.** moderation-service writes its own D1 audit row; Blossom writes its own KV audit log. Reconciling them into a single audit surface is a v2 concern.
-- **Soft-delete grace period for creator deletes.** The spec's moderation-service side already punts creator-initiated un-delete to v2. Blossom mirrors that — no grace window here.
-- **One-time sweep of legacy `Deleted`-status blobs** (status was flipped before the physical-delete flag was on). Matt will script this separately after flag flip; it's a simple iteration.
-- **Fastly Purge retry on failure.** Current behavior is fire-and-forget; failures log but don't retry. Elevating this to a retry loop is a follow-up if purge-failure rate is ever observed non-trivial.
+- **Changes to `handle_admin_force_delete`.** It stays soft-delete by design. If admin DMCA ever needs physical deletion, that's a separate product decision.
+- **Refactoring `execute_vanish`.** Its inline cascade has different semantics (deletes metadata, pubkey-scoped). Unifying with `perform_physical_delete` would change vanish behavior. Separate PR if ever desired.
+- **Cross-repo audit consolidation.** Blossom writes Cloud Logging audit; moderation-service writes D1 audit. Reconciliation is a v2 concern.
+- **One-time sweep for validation-window blobs.** Simple script: iterate `creator_deletions` D1 rows with `status: success`, check Blossom metadata is `Deleted`, call `perform_physical_delete`. Matt scripts this at flag-flip time.
 
 ## Open questions
 
-- **Tests for the extracted helper in Viceroy.** Does the existing repo have an integration test harness for Fastly Compute, or is all testing via manual local e2e + prod smoke? If only the latter, we add unit tests for `handle_admin_moderate_action`'s new DELETE branch using the existing mock-friendly pattern (if any); otherwise we rely on local e2e in preflight.
-- **Reason field propagation from moderation-service.** Currently moderation-service's `notifyBlossom` sends `{sha256, action, timestamp}` — no `reason`. This spec treats `reason` as optional on the Blossom side. A follow-up could add a `reason` field from the creator-delete pipeline (e.g., "Creator-initiated delete via kind 5") to enrich the audit log.
+- **Cloud Run delete-blob trigger.** `delete_blob_gcs_artifacts` fires `trigger_cloud_run_delete_blob` as a secondary cleanup. In local dev against MinIO, this will fail silently (Cloud Run backend not configured in `fastly.toml.local`). That's fine — the primary GCS deletes go through MinIO directly. Worth confirming the fire-and-forget behavior doesn't disrupt the local dev loop.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -836,6 +836,8 @@ pub fn handle_admin_blob_content(req: Request, hash: &str) -> Result<Response> {
 struct ModerateRequest {
     sha256: String,
     action: String,
+    #[serde(default)]
+    reason: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -2,13 +2,15 @@
 // ABOUTME: Provides stats, recent uploads, user lists, OAuth login, and moderation controls
 
 use crate::blossom::{BlobMetadata, BlobStatus, GlobalStats, RecentIndex};
-use crate::delete_policy::{parse_restore_status, restore_soft_deleted_blob};
+use crate::delete_policy::{
+    parse_restore_status, perform_physical_delete, restore_soft_deleted_blob, soft_delete_blob,
+};
 use crate::error::{BlossomError, Result};
 use crate::metadata::{
     get_blob_metadata, get_global_stats, get_recent_index, get_user_blobs, get_user_index,
     replace_global_stats, replace_recent_index, update_blob_status, update_stats_on_status_change,
 };
-use crate::storage::download_blob_with_fallback;
+use crate::storage::{download_blob_with_fallback, write_audit_log};
 use fastly::http::{header, Method, StatusCode};
 use fastly::kv_store::KVStore;
 use fastly::{Request, Response};
@@ -865,6 +867,69 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
     let metadata = get_blob_metadata(&moderate_req.sha256)?
         .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
     let old_status = metadata.status;
+
+    // Creator-delete: special-case because DELETE needs soft_delete_blob's full
+    // index/user-list cleanup, not the bare update_blob_status the action-map
+    // match provides for BAN/RESTRICT/etc.
+    if moderate_req.action.eq_ignore_ascii_case("DELETE") {
+        let reason = moderate_req
+            .reason
+            .as_deref()
+            .unwrap_or("Creator-initiated deletion via kind 5");
+
+        // Audit BEFORE destruction
+        let meta_json = serde_json::to_string(&metadata).ok();
+        write_audit_log(
+            &moderate_req.sha256,
+            "creator_delete",
+            &metadata.owner,
+            None,
+            meta_json.as_deref(),
+            Some(reason),
+        );
+
+        let physical_delete_enabled =
+            get_config("ENABLE_PHYSICAL_DELETE").as_deref() == Some("true");
+
+        if physical_delete_enabled {
+            if let Err(e) = perform_physical_delete(
+                &moderate_req.sha256,
+                &metadata,
+                reason,
+                false, // no legal hold for creator-delete
+            ) {
+                eprintln!(
+                    "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
+                     Status may still be flipped to Deleted; bytes may remain.",
+                    moderate_req.sha256, e
+                );
+            }
+        } else {
+            // Flag off: soft-delete only
+            if let Err(e) = soft_delete_blob(
+                &moderate_req.sha256,
+                &metadata,
+                reason,
+                false,
+            ) {
+                eprintln!(
+                    "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
+                    moderate_req.sha256, e
+                );
+                return Err(e);
+            }
+        }
+
+        let response = serde_json::json!({
+            "success": true,
+            "sha256": moderate_req.sha256,
+            "old_status": format!("{:?}", old_status).to_lowercase(),
+            "new_status": "deleted",
+            "physical_deleted": physical_delete_enabled,
+            "physical_delete_skipped": !physical_delete_enabled
+        });
+        return json_response(StatusCode::OK, &response);
+    }
 
     // Map action to BlobStatus.
     //

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -891,21 +891,26 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
         let physical_delete_enabled =
             get_config("ENABLE_PHYSICAL_DELETE").as_deref() == Some("true");
 
+        let mut physical_deleted = false;
         if physical_delete_enabled {
-            if let Err(e) = perform_physical_delete(
+            match perform_physical_delete(
                 &moderate_req.sha256,
                 &metadata,
                 reason,
-                false, // no legal hold for creator-delete
+                false,
             ) {
-                eprintln!(
-                    "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
-                     Status may still be flipped to Deleted; bytes may remain.",
-                    moderate_req.sha256, e
-                );
+                Ok(()) => {
+                    physical_deleted = true;
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
+                         Status is Deleted (serving stopped); bytes may remain on GCS.",
+                        moderate_req.sha256, e
+                    );
+                }
             }
         } else {
-            // Flag off: soft-delete only
             if let Err(e) = soft_delete_blob(
                 &moderate_req.sha256,
                 &metadata,
@@ -925,7 +930,7 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
             "sha256": moderate_req.sha256,
             "old_status": format!("{:?}", old_status).to_lowercase(),
             "new_status": "deleted",
-            "physical_deleted": physical_delete_enabled,
+            "physical_deleted": physical_deleted,
             "physical_delete_skipped": !physical_delete_enabled
         });
         return json_response(StatusCode::OK, &response);

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -869,9 +869,14 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
     let old_status = metadata.status;
 
     // Creator-delete: thin adapter over handle_creator_delete so /admin/moderate
-    // and /admin/api/moderate produce the same response contract. Audit fires
-    // on every attempted delete, with outcome encoded in the action string so
-    // operators can distinguish full success, partial (soft-only), and failure.
+    // and /admin/api/moderate produce the same response contract.
+    //
+    // Audit strategy: write `creator_delete_attempt` before the helper call and
+    // `creator_delete` after success. A failure path leaves an attempt entry
+    // without a paired success, which operators can query for directly. This
+    // closes the audit gap that would otherwise exist if a soft-delete
+    // succeeded but the physical byte delete failed (soft-delete is durable
+    // even though we propagate the error to the caller).
     if moderate_req.action.eq_ignore_ascii_case("DELETE") {
         let reason = moderate_req
             .reason
@@ -883,38 +888,32 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
 
         let meta_json = serde_json::to_string(&metadata).ok();
 
-        let outcome = match handle_creator_delete(
+        write_audit_log(
+            &moderate_req.sha256,
+            "creator_delete_attempt",
+            &metadata.owner,
+            None,
+            meta_json.as_deref(),
+            Some(reason),
+        );
+
+        let outcome = handle_creator_delete(
             &moderate_req.sha256,
             &metadata,
             reason,
             physical_delete_enabled,
-        ) {
-            Ok(outcome) => outcome,
-            Err(e) => {
-                eprintln!(
-                    "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
-                    moderate_req.sha256, e
-                );
-                write_audit_log(
-                    &moderate_req.sha256,
-                    "creator_delete_failed",
-                    &metadata.owner,
-                    None,
-                    meta_json.as_deref(),
-                    Some(reason),
-                );
-                return Err(e);
-            }
-        };
+        )
+        .map_err(|e| {
+            eprintln!(
+                "[CREATOR-DELETE] handle_creator_delete failed for {}: {}",
+                moderate_req.sha256, e
+            );
+            e
+        })?;
 
-        let audit_action = if outcome.physical_delete_enabled && !outcome.physical_deleted {
-            "creator_delete_partial"
-        } else {
-            "creator_delete"
-        };
         write_audit_log(
             &moderate_req.sha256,
-            audit_action,
+            "creator_delete",
             &metadata.owner,
             None,
             meta_json.as_deref(),
@@ -926,7 +925,6 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
             "sha256": moderate_req.sha256,
             "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
             "new_status": "deleted",
-            "soft_deleted": outcome.soft_deleted,
             "physical_deleted": outcome.physical_deleted,
             "physical_delete_skipped": !outcome.physical_delete_enabled,
         });

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -3,7 +3,7 @@
 
 use crate::blossom::{BlobMetadata, BlobStatus, GlobalStats, RecentIndex};
 use crate::delete_policy::{
-    parse_restore_status, perform_physical_delete, restore_soft_deleted_blob, soft_delete_blob,
+    handle_creator_delete, parse_restore_status, restore_soft_deleted_blob,
 };
 use crate::error::{BlossomError, Result};
 use crate::metadata::{
@@ -286,7 +286,7 @@ fn create_session(provider: &str, identity: &str) -> Result<String> {
 }
 
 /// Get config value from Fastly config store
-fn get_config(key: &str) -> Option<String> {
+pub(crate) fn get_config(key: &str) -> Option<String> {
     fastly::config_store::ConfigStore::open("blossom_config").get(key)
 }
 
@@ -868,16 +868,35 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
         .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
     let old_status = metadata.status;
 
-    // Creator-delete: special-case because DELETE needs soft_delete_blob's full
-    // index/user-list cleanup, not the bare update_blob_status the action-map
-    // match provides for BAN/RESTRICT/etc.
+    // Creator-delete: thin adapter over handle_creator_delete so /admin/moderate
+    // and /admin/api/moderate produce the same response contract.
     if moderate_req.action.eq_ignore_ascii_case("DELETE") {
         let reason = moderate_req
             .reason
             .as_deref()
             .unwrap_or("Creator-initiated deletion via kind 5");
 
-        // Audit BEFORE destruction
+        let physical_delete_enabled =
+            get_config("ENABLE_PHYSICAL_DELETE").as_deref() == Some("true");
+
+        let outcome = match handle_creator_delete(
+            &moderate_req.sha256,
+            &metadata,
+            reason,
+            physical_delete_enabled,
+        ) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                eprintln!(
+                    "[CREATOR-DELETE] handle_creator_delete failed for {}: {}",
+                    moderate_req.sha256, e
+                );
+                return Err(e);
+            }
+        };
+
+        // Audit AFTER the status flip succeeds so the trail does not imply
+        // a delete that did not happen.
         let meta_json = serde_json::to_string(&metadata).ok();
         write_audit_log(
             &moderate_req.sha256,
@@ -888,52 +907,13 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
             Some(reason),
         );
 
-        let physical_delete_enabled =
-            get_config("ENABLE_PHYSICAL_DELETE").as_deref() == Some("true");
-
-        let mut physical_deleted = false;
-        if physical_delete_enabled {
-            match perform_physical_delete(
-                &moderate_req.sha256,
-                &metadata,
-                reason,
-                false,
-            ) {
-                Ok(()) => {
-                    physical_deleted = true;
-                }
-                Err(e) => {
-                    // soft_delete_blob failed inside the helper — blob is NOT deleted.
-                    eprintln!(
-                        "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
-                         Blob status was NOT changed.",
-                        moderate_req.sha256, e
-                    );
-                    return Err(e);
-                }
-            }
-        } else {
-            if let Err(e) = soft_delete_blob(
-                &moderate_req.sha256,
-                &metadata,
-                reason,
-                false,
-            ) {
-                eprintln!(
-                    "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
-                    moderate_req.sha256, e
-                );
-                return Err(e);
-            }
-        }
-
         let response = serde_json::json!({
             "success": true,
             "sha256": moderate_req.sha256,
-            "old_status": format!("{:?}", old_status).to_lowercase(),
+            "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
             "new_status": "deleted",
-            "physical_deleted": physical_deleted,
-            "physical_delete_skipped": !physical_delete_enabled
+            "physical_deleted": outcome.physical_deleted,
+            "physical_delete_skipped": !outcome.physical_delete_enabled,
         });
         return json_response(StatusCode::OK, &response);
     }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -903,11 +903,13 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
                     physical_deleted = true;
                 }
                 Err(e) => {
+                    // soft_delete_blob failed inside the helper — blob is NOT deleted.
                     eprintln!(
                         "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
-                         Status is Deleted (serving stopped); bytes may remain on GCS.",
+                         Blob status was NOT changed.",
                         moderate_req.sha256, e
                     );
+                    return Err(e);
                 }
             }
         } else {

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -869,7 +869,9 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
     let old_status = metadata.status;
 
     // Creator-delete: thin adapter over handle_creator_delete so /admin/moderate
-    // and /admin/api/moderate produce the same response contract.
+    // and /admin/api/moderate produce the same response contract. Audit fires
+    // on every attempted delete, with outcome encoded in the action string so
+    // operators can distinguish full success, partial (soft-only), and failure.
     if moderate_req.action.eq_ignore_ascii_case("DELETE") {
         let reason = moderate_req
             .reason
@@ -878,6 +880,8 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
 
         let physical_delete_enabled =
             get_config("ENABLE_PHYSICAL_DELETE").as_deref() == Some("true");
+
+        let meta_json = serde_json::to_string(&metadata).ok();
 
         let outcome = match handle_creator_delete(
             &moderate_req.sha256,
@@ -888,19 +892,29 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
             Ok(outcome) => outcome,
             Err(e) => {
                 eprintln!(
-                    "[CREATOR-DELETE] handle_creator_delete failed for {}: {}",
+                    "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
                     moderate_req.sha256, e
+                );
+                write_audit_log(
+                    &moderate_req.sha256,
+                    "creator_delete_failed",
+                    &metadata.owner,
+                    None,
+                    meta_json.as_deref(),
+                    Some(reason),
                 );
                 return Err(e);
             }
         };
 
-        // Audit AFTER the status flip succeeds so the trail does not imply
-        // a delete that did not happen.
-        let meta_json = serde_json::to_string(&metadata).ok();
+        let audit_action = if outcome.physical_delete_enabled && !outcome.physical_deleted {
+            "creator_delete_partial"
+        } else {
+            "creator_delete"
+        };
         write_audit_log(
             &moderate_req.sha256,
-            "creator_delete",
+            audit_action,
             &metadata.owner,
             None,
             meta_json.as_deref(),
@@ -912,6 +926,7 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
             "sha256": moderate_req.sha256,
             "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
             "new_status": "deleted",
+            "soft_deleted": outcome.soft_deleted,
             "physical_deleted": outcome.physical_deleted,
             "physical_delete_skipped": !outcome.physical_delete_enabled,
         });

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -63,47 +63,32 @@ pub fn soft_delete_blob(
     Ok(())
 }
 
-/// Physical deletion: soft-delete (stops serving) + GCS byte removal.
-/// Metadata row is preserved (status=Deleted) for audit/support visibility.
-///
-/// Returns Err if the main GCS blob delete fails. Soft-delete may have already
-/// applied in that case (status=Deleted, content stops serving), but bytes may
-/// remain on GCS. Artifact cleanup is best-effort and runs only after the main
-/// blob is confirmed deleted.
-pub fn perform_physical_delete(
-    hash: &str,
-    metadata: &BlobMetadata,
-    reason: &str,
-    legal_hold: bool,
-) -> Result<()> {
-    soft_delete_blob(hash, metadata, reason, legal_hold)?;
-    crate::cleanup_derived_audio_for_source(hash);
-    if let Err(e) = crate::storage::delete_blob(hash) {
-        eprintln!(
-            "[PHYSICAL-DELETE] storage::delete_blob failed for {}: {}. \
-             Bytes may remain on GCS; blob remains in Deleted status.",
-            hash, e
-        );
-        return Err(e);
-    }
-    crate::delete_blob_gcs_artifacts(hash);
-    crate::purge_vcl_cache(hash);
-    Ok(())
-}
-
-/// Outcome of a creator-initiated delete, used to serialize a consistent
-/// response shape across `/admin/moderate` and `/admin/api/moderate`.
+/// Outcome of a creator-initiated delete. Spans the full truth table:
+/// - Both false: nothing happened (`handle_creator_delete` returned `Err`).
+/// - `soft_deleted=true, physical_deleted=false`: content stopped serving,
+///   metadata is in `Deleted` status, but bytes may remain on GCS. This is
+///   either the expected flag-off state, or a partial flag-on outcome where
+///   the GCS byte delete failed.
+/// - Both true: full delete; content stopped serving and main blob bytes
+///   removed. Artifact cleanup is best-effort and may have left stragglers.
 #[derive(Debug, Clone)]
 pub struct CreatorDeleteOutcome {
     pub old_status: BlobStatus,
+    pub soft_deleted: bool,
     pub physical_delete_enabled: bool,
     pub physical_deleted: bool,
 }
 
-/// Shared creator-delete policy. Flips status to Deleted via soft_delete_blob,
-/// and when `physical_delete_enabled` is true also removes GCS bytes via
-/// perform_physical_delete. Returns Err if any step fails so callers never
-/// report success for a delete that did not complete.
+/// Shared creator-delete policy. Callers (`/admin/moderate` and
+/// `/admin/api/moderate`) are thin adapters over this function.
+///
+/// Contract:
+/// - Returns `Err` only when soft-delete itself fails. In that case no state
+///   mutated and both `soft_deleted` and `physical_deleted` would be false.
+/// - Returns `Ok(outcome)` in all other cases, including the partial-success
+///   state where soft-delete applied but the main GCS byte delete failed.
+///   Callers get `soft_deleted=true, physical_deleted=false` so they can
+///   distinguish "retry byte delete only" from "retry the whole operation."
 pub fn handle_creator_delete(
     hash: &str,
     metadata: &BlobMetadata,
@@ -111,15 +96,33 @@ pub fn handle_creator_delete(
     physical_delete_enabled: bool,
 ) -> Result<CreatorDeleteOutcome> {
     let old_status = metadata.status;
+
+    soft_delete_blob(hash, metadata, reason, false)?;
+
     let physical_deleted = if physical_delete_enabled {
-        perform_physical_delete(hash, metadata, reason, false)?;
-        true
+        crate::cleanup_derived_audio_for_source(hash);
+        match crate::storage::delete_blob(hash) {
+            Ok(()) => {
+                crate::delete_blob_gcs_artifacts(hash);
+                crate::purge_vcl_cache(hash);
+                true
+            }
+            Err(e) => {
+                eprintln!(
+                    "[CREATOR-DELETE] storage::delete_blob failed for {}: {}. \
+                     Soft delete applied; bytes may remain on GCS.",
+                    hash, e
+                );
+                false
+            }
+        }
     } else {
-        soft_delete_blob(hash, metadata, reason, false)?;
         false
     };
+
     Ok(CreatorDeleteOutcome {
         old_status,
+        soft_deleted: true,
         physical_delete_enabled,
         physical_deleted,
     })

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -63,6 +63,22 @@ pub fn soft_delete_blob(
     Ok(())
 }
 
+/// Physical deletion: soft-delete (stops serving) + GCS byte removal.
+/// Metadata row is preserved (status=Deleted) for audit/support visibility.
+pub fn perform_physical_delete(
+    hash: &str,
+    metadata: &BlobMetadata,
+    reason: &str,
+    legal_hold: bool,
+) -> Result<()> {
+    soft_delete_blob(hash, metadata, reason, legal_hold)?;
+    crate::cleanup_derived_audio_for_source(hash);
+    let _ = crate::storage::delete_blob(hash);
+    crate::delete_blob_gcs_artifacts(hash);
+    crate::purge_vcl_cache(hash);
+    Ok(())
+}
+
 pub fn restore_soft_deleted_blob(
     hash: &str,
     metadata: &BlobMetadata,

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -73,7 +73,9 @@ pub fn perform_physical_delete(
 ) -> Result<()> {
     soft_delete_blob(hash, metadata, reason, legal_hold)?;
     crate::cleanup_derived_audio_for_source(hash);
-    let _ = crate::storage::delete_blob(hash);
+    if let Err(e) = crate::storage::delete_blob(hash) {
+        eprintln!("[PHYSICAL-DELETE] storage::delete_blob failed for {}: {}. Bytes may remain on GCS.", hash, e);
+    }
     crate::delete_blob_gcs_artifacts(hash);
     crate::purge_vcl_cache(hash);
     Ok(())

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -63,18 +63,18 @@ pub fn soft_delete_blob(
     Ok(())
 }
 
-/// Outcome of a creator-initiated delete. Spans the full truth table:
-/// - Both false: nothing happened (`handle_creator_delete` returned `Err`).
-/// - `soft_deleted=true, physical_deleted=false`: content stopped serving,
-///   metadata is in `Deleted` status, but bytes may remain on GCS. This is
-///   either the expected flag-off state, or a partial flag-on outcome where
-///   the GCS byte delete failed.
-/// - Both true: full delete; content stopped serving and main blob bytes
-///   removed. Artifact cleanup is best-effort and may have left stragglers.
+/// Outcome of a successful creator-initiated delete. Returned only when the
+/// full requested operation completed: soft-delete always, and main GCS byte
+/// removal when `physical_delete_enabled`.
+///
+/// Partial states (soft ok, bytes failed) are not represented here. They
+/// surface as `Err` from `handle_creator_delete` so callers get a loud
+/// failure signal instead of a silent partial success. The validation-window
+/// sweep (blossom#90) is the operational safety net for bytes that remain
+/// after a soft-delete when retries do not converge.
 #[derive(Debug, Clone)]
 pub struct CreatorDeleteOutcome {
     pub old_status: BlobStatus,
-    pub soft_deleted: bool,
     pub physical_delete_enabled: bool,
     pub physical_deleted: bool,
 }
@@ -82,13 +82,15 @@ pub struct CreatorDeleteOutcome {
 /// Shared creator-delete policy. Callers (`/admin/moderate` and
 /// `/admin/api/moderate`) are thin adapters over this function.
 ///
-/// Contract:
-/// - Returns `Err` only when soft-delete itself fails. In that case no state
-///   mutated and both `soft_deleted` and `physical_deleted` would be false.
-/// - Returns `Ok(outcome)` in all other cases, including the partial-success
-///   state where soft-delete applied but the main GCS byte delete failed.
-///   Callers get `soft_deleted=true, physical_deleted=false` so they can
-///   distinguish "retry byte delete only" from "retry the whole operation."
+/// Returns `Err` on any failure, including:
+/// - soft-delete failure (no state mutated)
+/// - main GCS byte delete failure when `physical_delete_enabled` (soft-delete
+///   already applied; content stopped serving; bytes may remain on GCS)
+///
+/// On `Err` from byte-delete failure, the status flip to `Deleted` is already
+/// durable. A retry by the caller converges: `soft_delete_blob` is a no-op on
+/// already-`Deleted` state, and `storage::delete_blob` treats a missing
+/// object as success.
 pub fn handle_creator_delete(
     hash: &str,
     metadata: &BlobMetadata,
@@ -101,28 +103,23 @@ pub fn handle_creator_delete(
 
     let physical_deleted = if physical_delete_enabled {
         crate::cleanup_derived_audio_for_source(hash);
-        match crate::storage::delete_blob(hash) {
-            Ok(()) => {
-                crate::delete_blob_gcs_artifacts(hash);
-                crate::purge_vcl_cache(hash);
-                true
-            }
-            Err(e) => {
-                eprintln!(
-                    "[CREATOR-DELETE] storage::delete_blob failed for {}: {}. \
-                     Soft delete applied; bytes may remain on GCS.",
-                    hash, e
-                );
-                false
-            }
-        }
+        crate::storage::delete_blob(hash).map_err(|e| {
+            eprintln!(
+                "[CREATOR-DELETE] storage::delete_blob failed for {}: {}. \
+                 Soft delete applied; bytes may remain on GCS.",
+                hash, e
+            );
+            e
+        })?;
+        crate::delete_blob_gcs_artifacts(hash);
+        crate::purge_vcl_cache(hash);
+        true
     } else {
         false
     };
 
     Ok(CreatorDeleteOutcome {
         old_status,
-        soft_deleted: true,
         physical_delete_enabled,
         physical_deleted,
     })

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -65,6 +65,11 @@ pub fn soft_delete_blob(
 
 /// Physical deletion: soft-delete (stops serving) + GCS byte removal.
 /// Metadata row is preserved (status=Deleted) for audit/support visibility.
+///
+/// Returns Err if the main GCS blob delete fails. Soft-delete may have already
+/// applied in that case (status=Deleted, content stops serving), but bytes may
+/// remain on GCS. Artifact cleanup is best-effort and runs only after the main
+/// blob is confirmed deleted.
 pub fn perform_physical_delete(
     hash: &str,
     metadata: &BlobMetadata,
@@ -74,11 +79,50 @@ pub fn perform_physical_delete(
     soft_delete_blob(hash, metadata, reason, legal_hold)?;
     crate::cleanup_derived_audio_for_source(hash);
     if let Err(e) = crate::storage::delete_blob(hash) {
-        eprintln!("[PHYSICAL-DELETE] storage::delete_blob failed for {}: {}. Bytes may remain on GCS.", hash, e);
+        eprintln!(
+            "[PHYSICAL-DELETE] storage::delete_blob failed for {}: {}. \
+             Bytes may remain on GCS; blob remains in Deleted status.",
+            hash, e
+        );
+        return Err(e);
     }
     crate::delete_blob_gcs_artifacts(hash);
     crate::purge_vcl_cache(hash);
     Ok(())
+}
+
+/// Outcome of a creator-initiated delete, used to serialize a consistent
+/// response shape across `/admin/moderate` and `/admin/api/moderate`.
+#[derive(Debug, Clone)]
+pub struct CreatorDeleteOutcome {
+    pub old_status: BlobStatus,
+    pub physical_delete_enabled: bool,
+    pub physical_deleted: bool,
+}
+
+/// Shared creator-delete policy. Flips status to Deleted via soft_delete_blob,
+/// and when `physical_delete_enabled` is true also removes GCS bytes via
+/// perform_physical_delete. Returns Err if any step fails so callers never
+/// report success for a delete that did not complete.
+pub fn handle_creator_delete(
+    hash: &str,
+    metadata: &BlobMetadata,
+    reason: &str,
+    physical_delete_enabled: bool,
+) -> Result<CreatorDeleteOutcome> {
+    let old_status = metadata.status;
+    let physical_deleted = if physical_delete_enabled {
+        perform_physical_delete(hash, metadata, reason, false)?;
+        true
+    } else {
+        soft_delete_blob(hash, metadata, reason, false)?;
+        false
+    };
+    Ok(CreatorDeleteOutcome {
+        old_status,
+        physical_delete_enabled,
+        physical_deleted,
+    })
 }
 
 pub fn restore_soft_deleted_blob(

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use crate::blossom::{
     ResumableUploadInitRequest, ResumableUploadInitResponse, SubtitleJob, SubtitleJobCreateRequest,
     SubtitleJobStatus, TranscodeStatus, TranscriptStatus, UploadRequirements,
 };
-use crate::delete_policy::{perform_physical_delete, plan_user_delete, soft_delete_blob, DeletePlan};
+use crate::delete_policy::{handle_creator_delete, plan_user_delete, soft_delete_blob, DeletePlan};
 use crate::error::{BlossomError, Result};
 use crate::media_auth_log::format_media_auth_log;
 use crate::metadata::{
@@ -4743,9 +4743,8 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
         return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
     }
 
-    // Creator-delete: special-case because DELETE needs soft_delete_blob's full
-    // index/user-list cleanup, not the bare update_blob_status the action-map
-    // match below provides for BAN/RESTRICT/etc.
+    // Creator-delete: thin adapter over handle_creator_delete so /admin/moderate
+    // and /admin/api/moderate produce the same response contract.
     if action.eq_ignore_ascii_case("DELETE") {
         let metadata = get_blob_metadata(sha256)?
             .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
@@ -4754,6 +4753,22 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             .as_str()
             .unwrap_or("Creator-initiated deletion via kind 5");
 
+        let physical_delete_enabled =
+            crate::admin::get_config("ENABLE_PHYSICAL_DELETE").as_deref() == Some("true");
+
+        let outcome = match handle_creator_delete(sha256, &metadata, reason, physical_delete_enabled) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                eprintln!(
+                    "[CREATOR-DELETE] handle_creator_delete failed for {}: {}",
+                    sha256, e
+                );
+                return Err(e);
+            }
+        };
+
+        // Audit AFTER the status flip succeeds so the trail does not imply
+        // a delete that did not happen.
         let meta_json = serde_json::to_string(&metadata).ok();
         write_audit_log(
             sha256,
@@ -4764,46 +4779,13 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             Some(reason),
         );
 
-        // Canonical pattern: admin.rs get_config() (private to that module).
-        // Inlined here because get_config is not pub(crate).
-        let physical_delete_enabled = fastly::config_store::ConfigStore::open("blossom_config")
-            .get("ENABLE_PHYSICAL_DELETE")
-            .as_deref()
-            == Some("true");
-
-        let mut physical_deleted = false;
-        if physical_delete_enabled {
-            match perform_physical_delete(sha256, &metadata, reason, false) {
-                Ok(()) => {
-                    physical_deleted = true;
-                }
-                Err(e) => {
-                    // soft_delete_blob failed inside the helper — blob is NOT deleted.
-                    eprintln!(
-                        "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
-                         Blob status was NOT changed.",
-                        sha256, e
-                    );
-                    return Err(e);
-                }
-            }
-        } else {
-            if let Err(e) = soft_delete_blob(sha256, &metadata, reason, false) {
-                eprintln!(
-                    "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
-                    sha256, e
-                );
-                return Err(e);
-            }
-        }
-
         let response = serde_json::json!({
             "success": true,
             "sha256": sha256,
-            "status": "deleted",
-            "physical_deleted": physical_deleted,
-            "physical_delete_skipped": !physical_delete_enabled,
-            "message": "Creator-delete processed"
+            "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
+            "new_status": "deleted",
+            "physical_deleted": outcome.physical_deleted,
+            "physical_delete_skipped": !outcome.physical_delete_enabled,
         });
         let mut resp = json_response(StatusCode::OK, &response);
         add_cors_headers(&mut resp);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4764,17 +4764,27 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             Some(reason),
         );
 
+        // Canonical pattern: admin.rs get_config() (private to that module).
+        // Inlined here because get_config is not pub(crate).
         let physical_delete_enabled = fastly::config_store::ConfigStore::open("blossom_config")
             .get("ENABLE_PHYSICAL_DELETE")
             .as_deref()
             == Some("true");
 
+        let mut physical_deleted = false;
         if physical_delete_enabled {
-            if let Err(e) = perform_physical_delete(sha256, &metadata, reason, false) {
-                eprintln!(
-                    "[CREATOR-DELETE] perform_physical_delete failed for {}: {}",
-                    sha256, e
-                );
+            match perform_physical_delete(sha256, &metadata, reason, false) {
+                Ok(()) => {
+                    physical_deleted = true;
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
+                         Status is Deleted (serving stopped); bytes may remain on GCS.",
+                        sha256, e
+                    );
+                    // physical_deleted stays false — response is honest
+                }
             }
         } else {
             if let Err(e) = soft_delete_blob(sha256, &metadata, reason, false) {
@@ -4790,7 +4800,7 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             "success": true,
             "sha256": sha256,
             "status": "deleted",
-            "physical_deleted": physical_delete_enabled,
+            "physical_deleted": physical_deleted,
             "physical_delete_skipped": !physical_delete_enabled,
             "message": "Creator-delete processed"
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -4778,12 +4778,13 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
                     physical_deleted = true;
                 }
                 Err(e) => {
+                    // soft_delete_blob failed inside the helper — blob is NOT deleted.
                     eprintln!(
                         "[CREATOR-DELETE] perform_physical_delete failed for {}: {}. \
-                         Status is Deleted (serving stopped); bytes may remain on GCS.",
+                         Blob status was NOT changed.",
                         sha256, e
                     );
-                    // physical_deleted stays false — response is honest
+                    return Err(e);
                 }
             }
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4744,7 +4744,9 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
     }
 
     // Creator-delete: thin adapter over handle_creator_delete so /admin/moderate
-    // and /admin/api/moderate produce the same response contract.
+    // and /admin/api/moderate produce the same response contract. Audit fires
+    // on every attempted delete, with outcome encoded in the action string so
+    // operators can distinguish full success, partial (soft-only), and failure.
     if action.eq_ignore_ascii_case("DELETE") {
         let metadata = get_blob_metadata(sha256)?
             .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
@@ -4756,23 +4758,35 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
         let physical_delete_enabled =
             crate::admin::get_config("ENABLE_PHYSICAL_DELETE").as_deref() == Some("true");
 
+        let meta_json = serde_json::to_string(&metadata).ok();
+
         let outcome = match handle_creator_delete(sha256, &metadata, reason, physical_delete_enabled) {
             Ok(outcome) => outcome,
             Err(e) => {
                 eprintln!(
-                    "[CREATOR-DELETE] handle_creator_delete failed for {}: {}",
+                    "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
                     sha256, e
+                );
+                write_audit_log(
+                    sha256,
+                    "creator_delete_failed",
+                    &metadata.owner,
+                    None,
+                    meta_json.as_deref(),
+                    Some(reason),
                 );
                 return Err(e);
             }
         };
 
-        // Audit AFTER the status flip succeeds so the trail does not imply
-        // a delete that did not happen.
-        let meta_json = serde_json::to_string(&metadata).ok();
+        let audit_action = if outcome.physical_delete_enabled && !outcome.physical_deleted {
+            "creator_delete_partial"
+        } else {
+            "creator_delete"
+        };
         write_audit_log(
             sha256,
-            "creator_delete",
+            audit_action,
             &metadata.owner,
             None,
             meta_json.as_deref(),
@@ -4784,6 +4798,7 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             "sha256": sha256,
             "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
             "new_status": "deleted",
+            "soft_deleted": outcome.soft_deleted,
             "physical_deleted": outcome.physical_deleted,
             "physical_delete_skipped": !outcome.physical_delete_enabled,
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use crate::blossom::{
     ResumableUploadInitRequest, ResumableUploadInitResponse, SubtitleJob, SubtitleJobCreateRequest,
     SubtitleJobStatus, TranscodeStatus, TranscriptStatus, UploadRequirements,
 };
-use crate::delete_policy::{plan_user_delete, soft_delete_blob, DeletePlan};
+use crate::delete_policy::{perform_physical_delete, plan_user_delete, soft_delete_blob, DeletePlan};
 use crate::error::{BlossomError, Result};
 use crate::media_auth_log::format_media_auth_log;
 use crate::metadata::{
@@ -4741,6 +4741,62 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
     // Validate sha256 format
     if sha256.len() != 64 || !sha256.chars().all(|c| c.is_ascii_hexdigit()) {
         return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
+    }
+
+    // Creator-delete: special-case because DELETE needs soft_delete_blob's full
+    // index/user-list cleanup, not the bare update_blob_status the action-map
+    // match below provides for BAN/RESTRICT/etc.
+    if action.eq_ignore_ascii_case("DELETE") {
+        let metadata = get_blob_metadata(sha256)?
+            .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
+
+        let reason = payload["reason"]
+            .as_str()
+            .unwrap_or("Creator-initiated deletion via kind 5");
+
+        let meta_json = serde_json::to_string(&metadata).ok();
+        write_audit_log(
+            sha256,
+            "creator_delete",
+            &metadata.owner,
+            None,
+            meta_json.as_deref(),
+            Some(reason),
+        );
+
+        let physical_delete_enabled = fastly::config_store::ConfigStore::open("blossom_config")
+            .get("ENABLE_PHYSICAL_DELETE")
+            .as_deref()
+            == Some("true");
+
+        if physical_delete_enabled {
+            if let Err(e) = perform_physical_delete(sha256, &metadata, reason, false) {
+                eprintln!(
+                    "[CREATOR-DELETE] perform_physical_delete failed for {}: {}",
+                    sha256, e
+                );
+            }
+        } else {
+            if let Err(e) = soft_delete_blob(sha256, &metadata, reason, false) {
+                eprintln!(
+                    "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
+                    sha256, e
+                );
+                return Err(e);
+            }
+        }
+
+        let response = serde_json::json!({
+            "success": true,
+            "sha256": sha256,
+            "status": "deleted",
+            "physical_deleted": physical_delete_enabled,
+            "physical_delete_skipped": !physical_delete_enabled,
+            "message": "Creator-delete processed"
+        });
+        let mut resp = json_response(StatusCode::OK, &response);
+        add_cors_headers(&mut resp);
+        return Ok(resp);
     }
 
     // Map action to BlobStatus.

--- a/src/main.rs
+++ b/src/main.rs
@@ -354,7 +354,7 @@ fn clear_stale_audio_mapping(source_hash: &str, audio_hash: &str) {
     }
 }
 
-fn cleanup_derived_audio_for_source(source_hash: &str) {
+pub(crate) fn cleanup_derived_audio_for_source(source_hash: &str) {
     let mapping = match get_audio_mapping(source_hash) {
         Ok(Some(mapping)) => mapping,
         Ok(None) => return,
@@ -3764,7 +3764,7 @@ fn handle_upload_requirements(req: Request) -> Result<Response> {
 /// Delete all GCS artifacts for a blob (thumbnail, HLS, VTT).
 /// The main blob itself is NOT deleted here (caller handles that).
 /// Best-effort: logs errors but never fails.
-fn delete_blob_gcs_artifacts(hash: &str) {
+pub(crate) fn delete_blob_gcs_artifacts(hash: &str) {
     // Thumbnail
     let _ = storage_delete(&format!("{}.jpg", hash));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4744,9 +4744,14 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
     }
 
     // Creator-delete: thin adapter over handle_creator_delete so /admin/moderate
-    // and /admin/api/moderate produce the same response contract. Audit fires
-    // on every attempted delete, with outcome encoded in the action string so
-    // operators can distinguish full success, partial (soft-only), and failure.
+    // and /admin/api/moderate produce the same response contract.
+    //
+    // Audit strategy: write `creator_delete_attempt` before the helper call and
+    // `creator_delete` after success. A failure path leaves an attempt entry
+    // without a paired success, which operators can query for directly. This
+    // closes the audit gap that would otherwise exist if a soft-delete
+    // succeeded but the physical byte delete failed (soft-delete is durable
+    // even though we propagate the error to the caller).
     if action.eq_ignore_ascii_case("DELETE") {
         let metadata = get_blob_metadata(sha256)?
             .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;
@@ -4760,33 +4765,27 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
 
         let meta_json = serde_json::to_string(&metadata).ok();
 
-        let outcome = match handle_creator_delete(sha256, &metadata, reason, physical_delete_enabled) {
-            Ok(outcome) => outcome,
-            Err(e) => {
-                eprintln!(
-                    "[CREATOR-DELETE] soft_delete_blob failed for {}: {}",
-                    sha256, e
-                );
-                write_audit_log(
-                    sha256,
-                    "creator_delete_failed",
-                    &metadata.owner,
-                    None,
-                    meta_json.as_deref(),
-                    Some(reason),
-                );
-                return Err(e);
-            }
-        };
-
-        let audit_action = if outcome.physical_delete_enabled && !outcome.physical_deleted {
-            "creator_delete_partial"
-        } else {
-            "creator_delete"
-        };
         write_audit_log(
             sha256,
-            audit_action,
+            "creator_delete_attempt",
+            &metadata.owner,
+            None,
+            meta_json.as_deref(),
+            Some(reason),
+        );
+
+        let outcome = handle_creator_delete(sha256, &metadata, reason, physical_delete_enabled)
+            .map_err(|e| {
+                eprintln!(
+                    "[CREATOR-DELETE] handle_creator_delete failed for {}: {}",
+                    sha256, e
+                );
+                e
+            })?;
+
+        write_audit_log(
+            sha256,
+            "creator_delete",
             &metadata.owner,
             None,
             meta_json.as_deref(),
@@ -4798,7 +4797,6 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             "sha256": sha256,
             "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
             "new_status": "deleted",
-            "soft_deleted": outcome.soft_deleted,
             "physical_deleted": outcome.physical_deleted,
             "physical_delete_skipped": !outcome.physical_delete_enabled,
         });


### PR DESCRIPTION
## Summary

Blossom side of per-video delete end-to-end enforcement. Wires a `DELETE` action into the `/admin/moderate` webhook handler with a `perform_physical_delete` helper and an `ENABLE_PHYSICAL_DELETE` safety flag.

**Issue:** divinevideo/divine-mobile#3102
**Rollout comment:** https://github.com/divinevideo/divine-mobile/issues/3102#issuecomment-4264760572
**Rollout plan:** [`support-trust-safety/docs/rollout/2026-04-16-creator-delete-rollout.md`](https://github.com/divinevideo/support-trust-safety/blob/working-draft/docs/rollout/2026-04-16-creator-delete-rollout.md)
**Sibling PR:** divinevideo/divine-moderation-service#92 (caller pipeline)

## What's in this PR

- `perform_physical_delete` helper in `src/delete_policy.rs` composing `soft_delete_blob` (status flip, index cleanup, VCL purge) + GCS byte destruction (derived audio, main blob, thumbnail/HLS/VTT artifacts, second VCL purge)
- DELETE special-case branch in `handle_admin_moderate` webhook handler (`src/main.rs`) with `ENABLE_PHYSICAL_DELETE` flag check
- DELETE branch also in `handle_admin_moderate_action` (`src/admin.rs`) as secondary admin-UI path
- Optional `reason` field on `ModerateRequest` for audit log enrichment
- Two main.rs functions promoted to `pub(crate)`: `cleanup_derived_audio_for_source`, `delete_blob_gcs_artifacts`
- `ENABLE_PHYSICAL_DELETE` in `config-store-data.json` (default false) + README docs

## Key design decisions

- **Composes, doesn't extract.** `perform_physical_delete` calls `soft_delete_blob` first (proven helper), then adds byte destruction. Does NOT extract from `execute_vanish` (different semantics: vanish deletes metadata row, creator-delete preserves it for audit).
- **`handle_admin_force_delete` unchanged.** Admin DMCA stays soft-delete by design. Creator-delete physical removal is a separate code path.
- **Flag gates byte destruction only.** Flag off = soft-delete (status Deleted, bytes preserved). Flag on = soft-delete + GCS removal + Fastly Purge. Both paths write audit logs.
- **Honest response.** `physical_deleted` reflects actual success/failure of `perform_physical_delete`. If soft-delete fails inside the helper, the error propagates (blob was never deleted).
- **Audit before destruction.** `write_audit_log` fires before any destructive call, with `action: "creator_delete"` and `actor: metadata.owner`.

## Test plan

### Build verification (done)
- [x] `cargo build --target wasm32-wasip1 --release` succeeds (15 pre-existing warnings, none from our changes)
- [x] `cargo check --tests --locked` succeeds

### Local e2e (done)
- [x] MinIO + Blossom via `docker compose -f docker-compose.local.yml` + `fastly compute serve`
- [x] Flag off: `POST /admin/moderate` with `action: "DELETE"` returns 200 + `physical_delete_skipped: true`. Blob serves 404 (status Deleted).
- [x] Flag on: same call returns 200 + `physical_deleted: true`. Physical delete cascade executed.
- [x] Webhook auth: `Bearer dev-secret-for-testing` accepted, missing/invalid rejected
- [x] BAN action still works unchanged: `status: "banned", success: true`
- [x] Admin DMCA endpoint (`/admin/api/delete`) still works unchanged: `preserved: true, deleted: true`
- [x] Audit log attempted (Cloud Run backend not available locally, expected fire-and-forget)
- [x] VCL purge skipped locally (no `fastly_api_token`, expected log message)

### Production validation (per rollout plan)
- [ ] Step 1: deploy with flag off, verify DELETE accepted (not "Unknown action")
- [ ] Step 6: flip flag, verify physical byte removal on next creator-delete

### Code review (done)
- [x] Three rounds of self-review including cross-repo integration contract
- [x] All findings addressed: soft-delete failure propagates as error, GCS delete failure logged, response accuracy for physical_deleted, config access pattern documented