### PR TITLE
docs: policy for docs/superpowers scaffolding

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Blossom Documentation Map
+
+This directory is the index for repository documentation. Current docs first, historical context second.
+
+## Current
+
+- [README.md](../README.md) — service overview, setup, architecture
+- [CLAUDE.md](../CLAUDE.md) — working notes for AI-assisted development
+- [OAUTH_SETUP.md](../OAUTH_SETUP.md) — OAuth configuration for admin UI
+- [CHANGELOG.md](../CHANGELOG.md) — release history
+- [docs/runbooks/](runbooks/) — operational runbooks
+
+## Historical
+
+- [docs/superpowers/](superpowers/README.md) — per-PR planning and design artifacts, preserved for context
+
+## Source-of-truth rule
+
+When docs and code disagree, trust the code. Historical docs describe intent at a point in time and are not maintained after the linked PR ships.

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,18 @@
+# docs/superpowers — historical planning and design
+
+This directory holds per-PR planning and design artifacts. They are preserved for context, not maintained as current documentation.
+
+## Convention
+
+- `plans/YYYY-MM-DD-<slug>.md` — implementation plans. Typically written before the PR and reflect intent at that point in time.
+- `specs/YYYY-MM-DD-<slug>.md` — design specs. Longer-lived than plans but still point-in-time.
+- No expectation of ongoing maintenance after the linked PR ships.
+- When a doc here and the code disagree, the code wins. Use these as archival context only.
+
+## Why keep them at all
+
+They remain useful for "why did we pick this approach" retrospection, for handoff between contributors, and as context for AI-assisted work. Keeping them in-repo means `git grep` and local tooling find them without GitHub round-trips.
+
+## When to archive differently
+
+If a design doc is durable and meant to evolve with the code (architecture reference rather than PR scaffolding), put it at `docs/` top level instead.


### PR DESCRIPTION
Closes #89.

## Summary

Adopts a lightweight historical-framing policy for `docs/superpowers/`, modeled on the convention already in use in `divine-mobile`. Two small additions:

- `docs/README.md` — current-vs-historical index. Lists repo docs readers should trust today (README, CLAUDE.md, OAUTH_SETUP.md, CHANGELOG.md, runbooks) above the fold; points at `docs/superpowers/` as historical context below.
- `docs/superpowers/README.md` — states the per-PR convention already in practice: `plans/YYYY-MM-DD-<slug>.md` and `specs/YYYY-MM-DD-<slug>.md`, preserved as context not maintained as current documentation, code wins when docs and code disagree. Durable architecture docs belong at `docs/` top level instead.

## Why this shape

Rationale and survey details are in the #89 comment thread: 11 of 13 Divine repos use this directory pattern, only `divine-mobile` has a documented policy, and its status-label requirement has 23% adherence over 30 days. I've deliberately omitted the per-doc status label here rather than adopt a convention we already know drifts.

No retrofit of the 15 existing `docs/superpowers/` files.

## Acceptance criteria from #89

- [x] Document the chosen policy in the repo.
- [x] Apply the policy consistently to future PRs. No enforcement tooling — contributors and AI agents are expected to be good citizens now that the convention is written down.
- [x] Existing `docs/superpowers` content left in place.