### PR TITLE
feat(obs): thread request correlation IDs through moderate and creator-delete logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,26 @@ to the owner or an admin. Blossom does not currently read any hosted-session
 age-verification claim or external viewer adult-verification service when
 serving media.
 
+## Request correlation
+
+Admin and moderation endpoints accept an `X-Request-Id` header and include
+its value in related log lines so retries and partial failures can be traced
+across stderr.
+
+- If the caller sends `X-Request-Id`, its first 16 characters are used.
+- If absent, the leading segment of the Cloudflare-provided `cf-ray`
+  header is used (free correlation with Cloudflare edge logs).
+- If neither is present, a short hex ID is generated from the nanosecond
+  clock.
+
+Upstream services integrating with Blossom (e.g. `divine-moderation-service`
+for creator-delete) are encouraged to forward a stable `X-Request-Id`
+across their retry loops so both sides share the same correlation token.
+Log lines are prefixed with `[req=<id>]`; the `[PURGE]` logs emitted by
+the Fastly cache-purge path include the blob `sha256` as their surrogate
+key, which serves as the cross-reference when purging is triggered from
+a moderate/delete request.
+
 ## License
 
 MIT

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -806,7 +806,7 @@ fn set_admin_blob_response_headers(
     resp.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
     resp.set_header(
         "Access-Control-Allow-Headers",
-        "Authorization, Content-Type, Range",
+        "Authorization, Content-Type, Range, X-Request-Id",
     );
 }
 
@@ -851,6 +851,8 @@ struct RestoreRequest {
 
 pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
     validate_admin_auth(&req)?;
+
+    let req_id = crate::req_id::for_request(&req);
 
     let body = req.take_body().into_string();
     let moderate_req: ModerateRequest = serde_json::from_str(&body)
@@ -902,11 +904,12 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
             &metadata,
             reason,
             physical_delete_enabled,
+            &req_id,
         )
         .map_err(|e| {
             eprintln!(
-                "[CREATOR-DELETE] handle_creator_delete failed for {}: {}",
-                moderate_req.sha256, e
+                "[req={}] [CREATOR-DELETE] handle_creator_delete failed for {}: {}",
+                req_id, moderate_req.sha256, e
             );
             e
         })?;
@@ -1509,7 +1512,7 @@ fn json_response<T: serde::Serialize>(status: StatusCode, body: &T) -> Result<Re
     resp.set_header("Access-Control-Allow-Origin", "*");
     resp.set_header(
         "Access-Control-Allow-Headers",
-        "Authorization, Content-Type",
+        "Authorization, Content-Type, X-Request-Id",
     );
     resp.set_body(json);
     Ok(resp)

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -850,9 +850,9 @@ struct RestoreRequest {
 }
 
 pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
-    validate_admin_auth(&req)?;
-
     let req_id = crate::req_id::for_request(&req);
+
+    validate_admin_auth(&req)?;
 
     let body = req.take_body().into_string();
     let moderate_req: ModerateRequest = serde_json::from_str(&body)

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -82,6 +82,10 @@ pub struct CreatorDeleteOutcome {
 /// Shared creator-delete policy. Callers (`/admin/moderate` and
 /// `/admin/api/moderate`) are thin adapters over this function.
 ///
+/// `req_id` is a correlation ID extracted or generated at the HTTP entry
+/// point; it is included in every log line so retries and partial failures
+/// can be traced across stderr. See `crate::req_id` for the contract.
+///
 /// Returns `Err` on any failure, including:
 /// - soft-delete failure (no state mutated)
 /// - main GCS byte delete failure when `physical_delete_enabled` (soft-delete
@@ -96,6 +100,7 @@ pub fn handle_creator_delete(
     metadata: &BlobMetadata,
     reason: &str,
     physical_delete_enabled: bool,
+    req_id: &str,
 ) -> Result<CreatorDeleteOutcome> {
     let old_status = metadata.status;
 
@@ -105,9 +110,9 @@ pub fn handle_creator_delete(
         crate::cleanup_derived_audio_for_source(hash);
         crate::storage::delete_blob(hash).map_err(|e| {
             eprintln!(
-                "[CREATOR-DELETE] storage::delete_blob failed for {}: {}. \
+                "[req={}] [CREATOR-DELETE] storage::delete_blob failed for {}: {}. \
                  Soft delete applied; bytes may remain on GCS.",
-                hash, e
+                req_id, hash, e
             );
             e
         })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod delete_policy;
 mod error;
 mod media_auth_log;
 mod metadata;
+mod req_id;
 mod storage;
 mod viewer_auth;
 
@@ -4684,6 +4685,8 @@ fn handle_admin_backfill_vtt(req: Request) -> Result<Response> {
 /// POST /admin/moderate - Webhook from divine-moderation-service
 /// Receives moderation decisions and updates blob status
 fn handle_admin_moderate(mut req: Request) -> Result<Response> {
+    let req_id = crate::req_id::for_request(&req);
+
     // Try to get webhook secret from secret store (optional)
     let expected_secret: Option<String> =
         fastly::secret_store::SecretStore::open("blossom_secrets")
@@ -4703,18 +4706,24 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             Some(ref header) if header.starts_with("Bearer ") => {
                 let provided = header.strip_prefix("Bearer ").unwrap_or("");
                 if provided != expected.trim() {
-                    eprintln!("[ADMIN] Invalid webhook secret");
+                    eprintln!("[req={}] [ADMIN] Invalid webhook secret", req_id);
                     return Err(BlossomError::Forbidden("Invalid webhook secret".into()));
                 }
             }
             _ => {
-                eprintln!("[ADMIN] Missing or invalid Authorization header");
+                eprintln!(
+                    "[req={}] [ADMIN] Missing or invalid Authorization header",
+                    req_id
+                );
                 return Err(BlossomError::AuthRequired("Webhook secret required".into()));
             }
         }
     } else {
         // Fail closed: reject requests if webhook_secret is not configured
-        eprintln!("[ADMIN] webhook_secret not configured, rejecting request");
+        eprintln!(
+            "[req={}] [ADMIN] webhook_secret not configured, rejecting request",
+            req_id
+        );
         return Err(BlossomError::Forbidden(
             "Webhook secret not configured".into(),
         ));
@@ -4734,8 +4743,8 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
         .ok_or_else(|| BlossomError::BadRequest("Missing 'action' field".into()))?;
 
     eprintln!(
-        "[ADMIN] Moderation webhook: sha256={}, action={}",
-        sha256, action
+        "[req={}] [ADMIN] Moderation webhook: sha256={}, action={}",
+        req_id, sha256, action
     );
 
     // Validate sha256 format
@@ -4774,14 +4783,20 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             Some(reason),
         );
 
-        let outcome = handle_creator_delete(sha256, &metadata, reason, physical_delete_enabled)
-            .map_err(|e| {
-                eprintln!(
-                    "[CREATOR-DELETE] handle_creator_delete failed for {}: {}",
-                    sha256, e
-                );
-                e
-            })?;
+        let outcome = handle_creator_delete(
+            sha256,
+            &metadata,
+            reason,
+            physical_delete_enabled,
+            &req_id,
+        )
+        .map_err(|e| {
+            eprintln!(
+                "[req={}] [CREATOR-DELETE] handle_creator_delete failed for {}: {}",
+                req_id, sha256, e
+            );
+            e
+        })?;
 
         write_audit_log(
             sha256,
@@ -5590,7 +5605,7 @@ fn add_cors_headers(resp: &mut Response) {
     );
     resp.set_header(
         "Access-Control-Allow-Headers",
-        "Authorization, Content-Type, X-Sha256",
+        "Authorization, Content-Type, X-Sha256, X-Request-Id",
     );
     resp.set_header("Access-Control-Expose-Headers", upload_exposed_headers());
 }

--- a/src/req_id.rs
+++ b/src/req_id.rs
@@ -1,0 +1,76 @@
+// ABOUTME: Request correlation ID helper for moderation and delete log traces
+// ABOUTME: Threaded through handlers so retries and partial failures are greppable across stderr
+
+use fastly::Request;
+
+/// Header upstream callers (e.g. moderation-service) can send to pin a
+/// correlation ID across their retry loops.
+pub(crate) const REQUEST_ID_HEADER: &str = "x-request-id";
+
+/// Cloudflare adds this to every request. Useful as a fallback because it
+/// lets an operator cross-reference Blossom stderr with CF edge logs.
+const CF_RAY_HEADER: &str = "cf-ray";
+
+/// Max characters kept from any external ID. Keeps log lines readable.
+const MAX_LEN: usize = 16;
+
+/// Extract or generate a request correlation ID.
+///
+/// Priority:
+/// 1. `x-request-id` if the caller provided one (preferred; lets upstream
+///    retry loops pin the same ID across attempts).
+/// 2. Leading segment of `cf-ray` (Cloudflare-provided; free correlation
+///    with CF edge logs).
+/// 3. Generated short hex ID derived from the current nanosecond clock.
+pub(crate) fn for_request(req: &Request) -> String {
+    if let Some(v) = req.get_header_str(REQUEST_ID_HEADER) {
+        let trimmed = v.trim();
+        if !trimmed.is_empty() {
+            return truncate(trimmed);
+        }
+    }
+    if let Some(v) = req.get_header_str(CF_RAY_HEADER) {
+        if let Some(left) = v.split('-').next() {
+            let trimmed = left.trim();
+            if !trimmed.is_empty() {
+                return truncate(trimmed);
+            }
+        }
+    }
+    generate()
+}
+
+fn truncate(s: &str) -> String {
+    s.chars().take(MAX_LEN).collect()
+}
+
+fn generate() -> String {
+    let ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    format!("{:012x}", ns & 0x0000_FFFF_FFFF_FFFF)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_limits_length() {
+        let long = "a".repeat(32);
+        assert_eq!(truncate(&long).len(), MAX_LEN);
+    }
+
+    #[test]
+    fn truncate_preserves_short() {
+        assert_eq!(truncate("abc123"), "abc123");
+    }
+
+    #[test]
+    fn generate_returns_hex_of_expected_length() {
+        let id = generate();
+        assert_eq!(id.len(), 12);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}

--- a/src/req_id.rs
+++ b/src/req_id.rs
@@ -24,24 +24,31 @@ const MAX_LEN: usize = 16;
 /// 3. Generated short hex ID derived from the current nanosecond clock.
 pub(crate) fn for_request(req: &Request) -> String {
     if let Some(v) = req.get_header_str(REQUEST_ID_HEADER) {
-        let trimmed = v.trim();
-        if !trimmed.is_empty() {
-            return truncate(trimmed);
+        let sanitized = sanitize(v);
+        if !sanitized.is_empty() {
+            return sanitized;
         }
     }
     if let Some(v) = req.get_header_str(CF_RAY_HEADER) {
         if let Some(left) = v.split('-').next() {
-            let trimmed = left.trim();
-            if !trimmed.is_empty() {
-                return truncate(trimmed);
+            let sanitized = sanitize(left);
+            if !sanitized.is_empty() {
+                return sanitized;
             }
         }
     }
     generate()
 }
 
-fn truncate(s: &str) -> String {
-    s.chars().take(MAX_LEN).collect()
+/// Restrict correlation IDs to a safe log charset. Header values are
+/// attacker-controllable; without filtering, an `X-Request-Id` containing
+/// newlines or ANSI escapes would be echoed verbatim into stderr and could
+/// forge log lines or corrupt terminal output for operators tailing logs.
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .take(MAX_LEN)
+        .collect()
 }
 
 fn generate() -> String {
@@ -57,14 +64,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn truncate_limits_length() {
+    fn sanitize_limits_length() {
         let long = "a".repeat(32);
-        assert_eq!(truncate(&long).len(), MAX_LEN);
+        assert_eq!(sanitize(&long).len(), MAX_LEN);
     }
 
     #[test]
-    fn truncate_preserves_short() {
-        assert_eq!(truncate("abc123"), "abc123");
+    fn sanitize_preserves_short_alnum() {
+        assert_eq!(sanitize("abc123-_"), "abc123-_");
+    }
+
+    #[test]
+    fn sanitize_strips_log_injection_chars() {
+        assert_eq!(sanitize("abc\n[ADMIN] fake"), "abcADMINfake");
+        assert_eq!(sanitize("\x1b[31mred\x1b[0m"), "31mred0m");
+        assert_eq!(sanitize("a b\tc\rd"), "abcd");
+    }
+
+    #[test]
+    fn sanitize_empty_when_all_filtered() {
+        assert_eq!(sanitize("\n\r\t "), "");
+        assert_eq!(sanitize(""), "");
     }
 
     #[test]


### PR DESCRIPTION
Closes #86.

Stacked on #85 (`feat/creator-delete-action`) — do not merge until #85 lands so the diff stays clean.

## Summary

Adds request correlation IDs to the moderate and creator-delete log paths so retries and partial failures across `/admin/moderate` and `/admin/api/moderate` can be traced in a single grep.

## What changed

- New `src/req_id.rs` helper. Priority: `X-Request-Id` header > leading segment of `cf-ray` > generated 12-hex-char ID from nanosecond clock.
- `handle_creator_delete` gains a `req_id: &str` argument; its internal byte-delete failure log now includes the ID.
- `handle_admin_moderate` (main.rs) and `handle_admin_moderate_action` (admin.rs) extract the ID at entry and prefix their `[ADMIN]` / `[CREATOR-DELETE]` log lines with `[req=<id>]`.
- `X-Request-Id` added to the CORS allowed-headers list in all three CORS sites.
- README section documenting the header contract and fallback behavior.

## Scope decisions

- **`purge_vcl_cache` signature unchanged.** 11 call sites, several in background / non-request paths. Its `[PURGE]` logs already include the sha256 as the surrogate key, which correlates back to request-context logs via that shared value when purging is triggered from a moderate/delete path. Threading `req_id` everywhere wasn't worth the ripple for this pass. Follow-up material if operators want tighter purge tracing.
- **Audit entries unchanged.** Adding a req_id column would require schema work; the spec's "audit log entries where appropriate" was optional. The paired `creator_delete_attempt` / `creator_delete` entries from #85 already let operators reconstruct a trace via sha256 + timestamp.

## Acceptance criteria

- [x] Prefer incoming `X-Request-Id` header.
- [x] Generate a short stable-per-request ID when absent.
- [x] Include the ID in `eprintln!` lines for delete and failure paths (`[CREATOR-DELETE]`, `[ADMIN]`).
- [x] Document the header name expected from upstream callers (README).

`cargo check --tests --locked --target wasm32-wasip1` passes with no new warnings.