### PR TITLE
fix(auth): accept BUD-01 blob GET auth on media routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,12 +233,27 @@ Blossom auth events (`kind 24242`):
 Send as: `Authorization: Nostr <base64_encoded_signed_event>`
 
 Viewer/list requests additionally accept valid NIP-98 HTTP auth (`kind 27235`)
-for the exact request URL and method. This is used to identify the caller's
-pubkey on media routes. `age_restricted` blobs are served to any authenticated
-viewer and return `401 {"error":"age_restricted"}` to anonymous requests.
-`restricted` blobs remain shadow-banned and only serve to the owner or an admin.
-Blossom does not currently read any hosted-session age-verification claim or
-external viewer adult-verification service when serving media.
+for the exact request URL and method. Protected blob/media GET routes also
+accept Blossom GET auth (`kind 24242`) with:
+
+```json
+{
+  "kind": 24242,
+  "tags": [
+    ["t", "get"],
+    ["x", "<sha256>"],
+    ["expiration", "<unix_timestamp>"]
+  ]
+}
+```
+
+If multiple `Authorization` headers are present, viewer auth succeeds when any
+valid NIP-98 or Blossom GET header matches the request. `age_restricted` blobs
+are served to any authenticated viewer and return `401 {"error":"age_restricted"}`
+to anonymous requests. `restricted` blobs remain shadow-banned and only serve
+to the owner or an admin. Blossom does not currently read any hosted-session
+age-verification claim or external viewer adult-verification service when
+serving media.
 
 ## License
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,8 +4,8 @@
 use crate::blossom::{AuthAction, BlossomAuthEvent};
 use crate::error::{BlossomError, Result};
 use crate::viewer_auth::{
-    diagnose_viewer_auth_request, parse_auth_header, validate_blossom_event, ViewerAuthDiagnostics,
-    ViewerAuthState,
+    authenticate_blob_viewer, authenticate_generic_viewer, diagnose_viewer_auth_request,
+    parse_auth_header, public_request_url, validate_blossom_event, ViewerAuthDiagnostics,
 };
 use fastly::http::header::{AUTHORIZATION, HOST};
 use fastly::Request;
@@ -24,29 +24,47 @@ pub fn validate_auth(req: &Request, required_action: AuthAction) -> Result<Bloss
 /// (kind 27235). If an auth header is present but invalid, this returns an
 /// error instead of silently treating the request as anonymous.
 pub fn viewer_pubkey(req: &Request) -> Result<Option<String>> {
-    let diagnostics = diagnose_viewer_auth(req)?;
-
-    match diagnostics.auth_state {
-        ViewerAuthState::Missing => Ok(None),
-        ViewerAuthState::Valid => Ok(diagnostics.viewer_pubkey),
-        ViewerAuthState::InvalidScheme
-        | ViewerAuthState::ParseFailed
-        | ViewerAuthState::RequestUrlInvalid
-        | ViewerAuthState::ValidationFailed => Err(BlossomError::AuthInvalid(
-            diagnostics
-                .auth_error
-                .unwrap_or_else(|| "Invalid viewer authorization".into()),
-        )),
+    let auth_headers = request_auth_headers(req)?;
+    if auth_headers.is_empty() {
+        return Ok(None);
     }
+
+    let request_url = public_request_url(
+        &req.get_url().to_string(),
+        req.get_header(HOST).and_then(|h| h.to_str().ok()),
+    )?;
+    let scope = match blob_hash_from_path(req.get_path()) {
+        Some(hash) => ViewerScope::Blob(hash),
+        None => ViewerScope::Generic,
+    };
+
+    let event = match scope {
+        ViewerScope::Generic => authenticate_generic_viewer(
+            &auth_headers,
+            req.get_method().as_str(),
+            &request_url,
+            unix_now(),
+        )?,
+        ViewerScope::Blob(hash) => authenticate_blob_viewer(
+            &auth_headers,
+            req.get_method().as_str(),
+            &request_url,
+            &hash,
+            unix_now(),
+        )?,
+    };
+
+    Ok(Some(event.pubkey))
 }
 
 pub fn diagnose_viewer_auth(req: &Request) -> Result<ViewerAuthDiagnostics> {
+    let first_auth_header = request_auth_headers(req)?.into_iter().next();
     Ok(diagnose_viewer_auth_request(
         req.get_method().as_str(),
         req.get_path(),
         req.get_header(HOST).and_then(|h| h.to_str().ok()),
         &req.get_url().to_string(),
-        req.get_header(AUTHORIZATION).and_then(|h| h.to_str().ok()),
+        first_auth_header,
         unix_now(),
     ))
 }
@@ -59,6 +77,37 @@ fn parse_request_auth_event(req: &Request) -> Result<BlossomAuthEvent> {
         .map_err(|_| BlossomError::AuthInvalid("Invalid authorization header".into()))?;
 
     parse_auth_header(auth_header)
+}
+
+fn request_auth_headers(req: &Request) -> Result<Vec<&str>> {
+    req.get_header_all_str(AUTHORIZATION)
+        .into_iter()
+        .map(|value| {
+            if value.is_empty() {
+                Err(BlossomError::AuthInvalid(
+                    "Invalid authorization header".into(),
+                ))
+            } else {
+                Ok(value)
+            }
+        })
+        .collect()
+}
+
+enum ViewerScope {
+    Generic,
+    Blob(String),
+}
+
+fn blob_hash_from_path(path: &str) -> Option<String> {
+    let first_segment = path.trim_start_matches('/').split('/').next()?;
+    let candidate = first_segment.split('.').next().unwrap_or(first_segment);
+
+    if candidate.len() == 64 && candidate.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(candidate.to_lowercase())
+    } else {
+        None
+    }
 }
 
 fn unix_now() -> u64 {

--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -420,6 +420,7 @@ pub struct BlossomAuthEvent {
 /// Blossom authorization action types
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthAction {
+    Get,
     Upload,
     Delete,
     List,
@@ -431,6 +432,7 @@ impl BlossomAuthEvent {
         for tag in &self.tags {
             if tag.len() >= 2 && tag[0] == "t" {
                 return match tag[1].as_str() {
+                    "get" => Some(AuthAction::Get),
                     "upload" => Some(AuthAction::Upload),
                     "delete" => Some(AuthAction::Delete),
                     "list" => Some(AuthAction::List),
@@ -1242,11 +1244,17 @@ mod tests {
             pubkey: "a".repeat(64),
             created_at: 0,
             kind: 24242,
-            tags: vec![vec!["t".into(), "upload".into()]],
+            tags: vec![vec!["t".into(), "get".into()]],
             content: String::new(),
             sig: "b".repeat(128),
         };
-        assert_eq!(event.get_action(), Some(AuthAction::Upload));
+        assert_eq!(event.get_action(), Some(AuthAction::Get));
+
+        let upload_event = BlossomAuthEvent {
+            tags: vec![vec!["t".into(), "upload".into()]],
+            ..event.clone()
+        };
+        assert_eq!(upload_event.get_action(), Some(AuthAction::Upload));
 
         let delete_event = BlossomAuthEvent {
             tags: vec![vec!["t".into(), "delete".into()]],

--- a/src/viewer_auth.rs
+++ b/src/viewer_auth.rs
@@ -82,6 +82,25 @@ pub fn validate_blossom_event(
     validate_event_integrity(event)
 }
 
+pub fn validate_blossom_get_event(
+    event: &BlossomAuthEvent,
+    expected_hash: &str,
+    now: u64,
+) -> Result<()> {
+    validate_blossom_event(event, AuthAction::Get, now)?;
+
+    let event_hash = get_tag_value(event, "x")
+        .ok_or_else(|| BlossomError::AuthInvalid("Missing x tag".into()))?;
+    if !event_hash.eq_ignore_ascii_case(expected_hash) {
+        return Err(BlossomError::AuthInvalid(format!(
+            "Hash mismatch: expected {}, got {}",
+            expected_hash, event_hash
+        )));
+    }
+
+    Ok(())
+}
+
 pub fn validate_nip98_event(
     event: &BlossomAuthEvent,
     request_method: &str,
@@ -138,6 +157,46 @@ pub fn validate_viewer_event(
             BLOSSOM_AUTH_KIND, NIP98_AUTH_KIND, kind
         ))),
     }
+}
+
+pub fn validate_blob_viewer_event(
+    event: &BlossomAuthEvent,
+    request_method: &str,
+    request_url: &str,
+    expected_hash: &str,
+    now: u64,
+) -> Result<()> {
+    match event.kind {
+        BLOSSOM_AUTH_KIND => validate_blossom_get_event(event, expected_hash, now),
+        NIP98_AUTH_KIND => validate_nip98_event(event, request_method, request_url, now),
+        kind => Err(BlossomError::AuthInvalid(format!(
+            "Invalid event kind: expected {} or {}, got {}",
+            BLOSSOM_AUTH_KIND, NIP98_AUTH_KIND, kind
+        ))),
+    }
+}
+
+pub fn authenticate_generic_viewer(
+    auth_headers: &[&str],
+    request_method: &str,
+    request_url: &str,
+    now: u64,
+) -> Result<BlossomAuthEvent> {
+    authenticate_viewer(auth_headers, |event| {
+        validate_viewer_event(event, request_method, request_url, now)
+    })
+}
+
+pub fn authenticate_blob_viewer(
+    auth_headers: &[&str],
+    request_method: &str,
+    request_url: &str,
+    expected_hash: &str,
+    now: u64,
+) -> Result<BlossomAuthEvent> {
+    authenticate_viewer(auth_headers, |event| {
+        validate_blob_viewer_event(event, request_method, request_url, expected_hash, now)
+    })
 }
 
 pub fn public_request_url(request_url: &str, host_override: Option<&str>) -> Result<String> {
@@ -245,6 +304,38 @@ fn get_tag_value<'a>(event: &'a BlossomAuthEvent, tag_name: &str) -> Option<&'a 
     })
 }
 
+fn authenticate_viewer<F>(auth_headers: &[&str], validator: F) -> Result<BlossomAuthEvent>
+where
+    F: Fn(&BlossomAuthEvent) -> Result<()>,
+{
+    let mut parsed_events = Vec::new();
+    let mut first_error: Option<BlossomError> = None;
+
+    for auth_header in auth_headers {
+        match parse_auth_header(auth_header) {
+            Ok(event) => parsed_events.push(event),
+            Err(err) if first_error.is_none() => first_error = Some(err),
+            Err(_) => {}
+        }
+    }
+
+    for preferred_kind in [NIP98_AUTH_KIND, BLOSSOM_AUTH_KIND] {
+        for event in parsed_events
+            .iter()
+            .filter(|event| event.kind == preferred_kind)
+        {
+            match validator(event) {
+                Ok(()) => return Ok(event.clone()),
+                Err(err) if first_error.is_none() => first_error = Some(err),
+                Err(_) => {}
+            }
+        }
+    }
+
+    Err(first_error
+        .unwrap_or_else(|| BlossomError::AuthInvalid("Authorization header required".into())))
+}
+
 fn validate_event_integrity(event: &BlossomAuthEvent) -> Result<()> {
     let computed_id = compute_event_id(event)?;
     if computed_id != event.id {
@@ -329,6 +420,250 @@ mod tests {
         );
 
         assert!(validate_viewer_event(&event, "GET", TEST_URL, 1_100).is_ok());
+    }
+
+    #[test]
+    fn blossom_get_auth_is_valid_for_blob_viewer_requests() {
+        let event = signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "get".into()],
+                vec![
+                    "x".into(),
+                    "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e".into(),
+                ],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        );
+
+        assert!(validate_blob_viewer_event(
+            &event,
+            "GET",
+            TEST_URL,
+            "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e",
+            1_100,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn blossom_get_auth_rejects_missing_hash() {
+        let event = signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "get".into()],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        );
+
+        let error = validate_blob_viewer_event(
+            &event,
+            "GET",
+            TEST_URL,
+            "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e",
+            1_100,
+        )
+        .expect_err("missing x tag should fail");
+        assert_eq!(error.message(), "Missing x tag");
+    }
+
+    #[test]
+    fn blossom_get_auth_rejects_hash_mismatch() {
+        let event = signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "get".into()],
+                vec![
+                    "x".into(),
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+                ],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        );
+
+        let error = validate_blob_viewer_event(
+            &event,
+            "GET",
+            TEST_URL,
+            "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e",
+            1_100,
+        )
+        .expect_err("hash mismatch should fail");
+        assert_eq!(
+            error.message(),
+            "Hash mismatch: expected 4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e, got aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+    }
+
+    #[test]
+    fn blossom_get_auth_rejects_wrong_action() {
+        let event = signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "list".into()],
+                vec![
+                    "x".into(),
+                    "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e".into(),
+                ],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        );
+
+        let error = validate_blob_viewer_event(
+            &event,
+            "GET",
+            TEST_URL,
+            "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e",
+            1_100,
+        )
+        .expect_err("wrong action should fail");
+        assert_eq!(error.message(), "Action mismatch: expected Get, got List");
+    }
+
+    #[test]
+    fn blob_viewer_auth_accepts_valid_nip98_only() {
+        let header = encoded_event(signed_event(
+            NIP98_AUTH_KIND,
+            vec![
+                vec!["u".into(), TEST_URL.into()],
+                vec!["method".into(), "GET".into()],
+            ],
+            1_000,
+        ));
+
+        let event = authenticate_blob_viewer(
+            &[header.as_str()],
+            "GET",
+            TEST_URL,
+            "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e",
+            1_000,
+        )
+        .expect("NIP-98 auth should succeed");
+
+        assert_eq!(event.kind, NIP98_AUTH_KIND);
+    }
+
+    #[test]
+    fn blob_viewer_auth_accepts_valid_bud01_only() {
+        let header = encoded_event(signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "get".into()],
+                vec![
+                    "x".into(),
+                    "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e".into(),
+                ],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        ));
+
+        let event = authenticate_blob_viewer(
+            &[header.as_str()],
+            "GET",
+            TEST_URL,
+            "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e",
+            1_100,
+        )
+        .expect("BUD-01 auth should succeed");
+
+        assert_eq!(event.kind, BLOSSOM_AUTH_KIND);
+    }
+
+    #[test]
+    fn blob_viewer_auth_accepts_second_header_when_first_is_invalid() {
+        let bud01 = encoded_event(signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "get".into()],
+                vec![
+                    "x".into(),
+                    "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e".into(),
+                ],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        ));
+
+        let event = authenticate_blob_viewer(
+            &["Nostr definitely-not-base64", bud01.as_str()],
+            "GET",
+            TEST_URL,
+            "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e",
+            1_100,
+        )
+        .expect("later valid header should succeed");
+
+        assert_eq!(event.kind, BLOSSOM_AUTH_KIND);
+    }
+
+    #[test]
+    fn blob_viewer_auth_prefers_valid_nip98_over_invalid_bud01() {
+        let invalid_bud01 = encoded_event(signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "get".into()],
+                vec![
+                    "x".into(),
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+                ],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        ));
+        let nip98 = encoded_event(signed_event(
+            NIP98_AUTH_KIND,
+            vec![
+                vec!["u".into(), TEST_URL.into()],
+                vec!["method".into(), "GET".into()],
+            ],
+            1_000,
+        ));
+
+        let event = authenticate_blob_viewer(
+            &[invalid_bud01.as_str(), nip98.as_str()],
+            "GET",
+            TEST_URL,
+            "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e",
+            1_000,
+        )
+        .expect("valid NIP-98 should win");
+
+        assert_eq!(event.kind, NIP98_AUTH_KIND);
+    }
+
+    #[test]
+    fn blob_viewer_auth_rejects_when_all_headers_fail() {
+        let invalid_bud01 = encoded_event(signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "get".into()],
+                vec![
+                    "x".into(),
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into(),
+                ],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        ));
+
+        let error = authenticate_blob_viewer(
+            &[invalid_bud01.as_str()],
+            "GET",
+            TEST_URL,
+            "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e",
+            1_100,
+        )
+        .expect_err("invalid auth should fail");
+
+        assert_eq!(
+            error.message(),
+            "Hash mismatch: expected 4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e, got aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
     }
 
     #[test]
@@ -575,5 +910,10 @@ mod tests {
             .expect("event id prehash should sign");
         event.sig = hex::encode(signature.to_bytes());
         event
+    }
+
+    fn encoded_event(event: BlossomAuthEvent) -> String {
+        let json = serde_json::to_vec(&event).expect("event should serialize");
+        format!("Nostr {}", BASE64.encode(json))
     }
 }


### PR DESCRIPTION
## Summary
- accept Blossom/BUD-01 kind 24242 t=get auth with matching x=<sha256> on protected blob/media GET routes
- try all Authorization headers for viewer auth and succeed if any valid NIP-98 or BUD-01 header matches
- document the supported viewer auth contract and add regression tests for NIP-98-only, BUD-01-only, mixed headers, and invalid hashes/tags

## Verification
- cargo test --lib
- cargo check --target wasm32-wasi
- live curl checks against media.divine.video after Fastly deploy:
  - SAFE blob without auth -> 200
  - age-restricted blob without auth -> 401
  - age-restricted blob with valid NIP-98 -> 200
  - age-restricted blob with valid BUD-01 -> 200
