### PR TITLE
docs(api): note status-string rendering quirk on creator-delete response

### DIFF
--- a/docs/api/creator-delete-contract.md
+++ b/docs/api/creator-delete-contract.md
@@ -44,12 +44,18 @@ Field semantics:
 |---|---|---|
 | `success` | bool | Always `true` when HTTP 200. |
 | `sha256` | string | Echoes the request blob hash. |
-| `old_status` | string | Lowercase `BlobStatus` the blob was in before this call (`active`, `restricted`, `age_restricted`, `pending`, `banned`, `deleted`). |
+| `old_status` | string | Lowercase `BlobStatus` the blob was in before this call. Current values: `active`, `restricted`, `agerestricted`, `pending`, `banned`, `deleted`. See [note on status rendering](#note-status-string-rendering). |
 | `new_status` | string | Always `"deleted"` on success. |
 | `physical_deleted` | bool | `true` only when the main GCS blob delete succeeded. `false` when the flag is off *or* when physical delete wasn't attempted. |
 | `physical_delete_skipped` | bool | `true` when `ENABLE_PHYSICAL_DELETE` was off; `false` when it was on. |
 
 Callers can rely on these fields without reading Blossom source. Additional fields may be added; clients must ignore unknown fields.
+
+#### Note: status string rendering
+
+The response currently renders `BlobStatus` via `format!("{:?}", status).to_lowercase()`, which bypasses serde's `#[serde(rename = "age_restricted")]` attribute on `BlobStatus::AgeRestricted`. As a result, `old_status` emits `"agerestricted"` (no underscore) on this path, while serde-serialized status strings elsewhere in the API render as `"age_restricted"`.
+
+Tracked as [blossom#95](https://github.com/divinevideo/divine-blossom/issues/95). Until that lands, callers matching on `old_status` should accept `"agerestricted"` for the age-gated variant on creator-delete/moderate/restore responses specifically. Other status variants are unaffected because their `Debug` form lowercases cleanly to the same string serde produces.
 
 ### Mapping between outcomes and response
 


### PR DESCRIPTION
## Summary

- Annotates the `old_status` / `new_status` rendering on creator-delete (and sibling moderate/restore) responses in `docs/api/creator-delete-contract.md`. The current-values list now shows the *observed* string (`agerestricted`, no underscore), with a note explaining why it differs from the serde-canonical `age_restricted` used on GET endpoints.
- Links to #95, which tracks the underlying code fix (switch the four admin response builders from `format!("{:?}", status).to_lowercase()` to a serde-aware renderer).

## Why

Post-merge review of #94 found the doc listed `age_restricted` in the `old_status` possible values, but the response builder in `src/main.rs` and `src/admin.rs` renders via `Debug`, which emits `AgeRestricted` → lowercase → `"agerestricted"`. The `#[serde(rename = "age_restricted")]` attribute only affects serde, which isn't used on this code path.

Either the code or the doc had to change. Opted for the doc annotation (plus #95 to fix the code) so the shipped contract document accurately describes current behavior — callers can rely on `"agerestricted"` today without waiting on the code fix.

## Test plan

- [x] Verified against `origin/main` that all four response builders use `format!("{:?}", status).to_lowercase()`.
- [x] Verified `BlobStatus::AgeRestricted` has `#[serde(rename = "age_restricted")]` in `src/blossom.rs`, so the doc's prior claim was serde-correct but Debug-wrong.
- [x] Tracking issue #95 filed with affected call sites and suggested fix.

Docs-only change — no code impact.