### PR TITLE
test(delete): unit coverage for creator-delete response contract

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -3,7 +3,8 @@
 
 use crate::blossom::{BlobMetadata, BlobStatus, GlobalStats, RecentIndex};
 use crate::delete_policy::{
-    handle_creator_delete, parse_restore_status, restore_soft_deleted_blob,
+    build_creator_delete_response, handle_creator_delete, parse_restore_status,
+    restore_soft_deleted_blob,
 };
 use crate::error::{BlossomError, Result};
 use crate::metadata::{
@@ -923,14 +924,7 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
             Some(reason),
         );
 
-        let response = serde_json::json!({
-            "success": true,
-            "sha256": moderate_req.sha256,
-            "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
-            "new_status": "deleted",
-            "physical_deleted": outcome.physical_deleted,
-            "physical_delete_skipped": !outcome.physical_delete_enabled,
-        });
+        let response = build_creator_delete_response(&moderate_req.sha256, &outcome);
         return json_response(StatusCode::OK, &response);
     }
 

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -249,4 +249,21 @@ mod tests {
         assert_eq!(body["physical_deleted"], serde_json::json!(false));
         assert_eq!(body["physical_delete_skipped"], serde_json::json!(true));
     }
+
+    #[test]
+    fn response_builder_active_blob_flag_on_physical_success() {
+        let outcome = CreatorDeleteOutcome {
+            old_status: BlobStatus::Active,
+            physical_delete_enabled: true,
+            physical_deleted: true,
+        };
+        let body = build_creator_delete_response(
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            &outcome,
+        );
+        assert_eq!(body["physical_deleted"], serde_json::json!(true));
+        assert_eq!(body["physical_delete_skipped"], serde_json::json!(false));
+        assert_eq!(body["old_status"], serde_json::json!("active"));
+        assert_eq!(body["new_status"], serde_json::json!("deleted"));
+    }
 }

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -320,29 +320,4 @@ mod tests {
         }
     }
 
-    #[test]
-    fn outcome_truth_table_matches_contract() {
-        // Pins the two reachable success outcomes the contract doc describes.
-        // Used as a readable enumeration of what downstream callers can expect.
-        let flag_off = CreatorDeleteOutcome {
-            old_status: BlobStatus::Active,
-            physical_delete_enabled: false,
-            physical_deleted: false,
-        };
-        assert!(!flag_off.physical_delete_enabled);
-        assert!(!flag_off.physical_deleted);
-
-        let flag_on_success = CreatorDeleteOutcome {
-            old_status: BlobStatus::Active,
-            physical_delete_enabled: true,
-            physical_deleted: true,
-        };
-        assert!(flag_on_success.physical_delete_enabled);
-        assert!(flag_on_success.physical_deleted);
-
-        // The (physical_delete_enabled=true, physical_deleted=false)
-        // combination is unreachable via handle_creator_delete's Ok path —
-        // byte-delete failure returns Err. No test case for it because it
-        // cannot be produced by the helper.
-    }
 }

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -286,4 +286,37 @@ mod tests {
         assert_eq!(body["physical_deleted"], serde_json::json!(true));
         assert_eq!(body["physical_delete_skipped"], serde_json::json!(false));
     }
+
+    #[test]
+    fn response_builder_old_status_covers_every_blob_status_variant() {
+        // Pins the current Debug-to-lowercase rendering. When #95 switches
+        // to serde-aware rendering, AgeRestricted's expected string flips to
+        // "age_restricted" and this test needs updating to match.
+        let cases: &[(BlobStatus, &str)] = &[
+            (BlobStatus::Active, "active"),
+            (BlobStatus::Restricted, "restricted"),
+            (BlobStatus::Pending, "pending"),
+            (BlobStatus::Banned, "banned"),
+            (BlobStatus::Deleted, "deleted"),
+            (BlobStatus::AgeRestricted, "agerestricted"),
+        ];
+        for (status, expected) in cases {
+            let outcome = CreatorDeleteOutcome {
+                old_status: *status,
+                physical_delete_enabled: false,
+                physical_deleted: false,
+            };
+            let body = build_creator_delete_response(
+                "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+                &outcome,
+            );
+            assert_eq!(
+                body["old_status"],
+                serde_json::json!(expected),
+                "BlobStatus::{:?} should render as {:?}",
+                status,
+                expected
+            );
+        }
+    }
 }

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -130,6 +130,30 @@ pub fn handle_creator_delete(
     })
 }
 
+/// Build the JSON response body for a successful creator-delete. Both the
+/// `/admin/moderate` and `/admin/api/moderate` handlers delegate to this so
+/// their response contracts stay identical.
+///
+/// The `old_status` field is rendered via `format!("{:?}", ...).to_lowercase()`
+/// which produces `"agerestricted"` for `BlobStatus::AgeRestricted` rather than
+/// the serde-canonical `"age_restricted"`. This mismatch is documented in
+/// `docs/api/creator-delete-contract.md` and tracked for fix in
+/// divinevideo/divine-blossom#95. Tests in this module pin the current
+/// behavior; they will need updating when #95 lands.
+pub fn build_creator_delete_response(
+    sha256: &str,
+    outcome: &CreatorDeleteOutcome,
+) -> serde_json::Value {
+    serde_json::json!({
+        "success": true,
+        "sha256": sha256,
+        "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
+        "new_status": "deleted",
+        "physical_deleted": outcome.physical_deleted,
+        "physical_delete_skipped": !outcome.physical_delete_enabled,
+    })
+}
+
 pub fn restore_soft_deleted_blob(
     hash: &str,
     metadata: &BlobMetadata,
@@ -202,5 +226,27 @@ mod tests {
             parse_restore_status(Some("age_restrict")).unwrap(),
             BlobStatus::AgeRestricted
         );
+    }
+
+    #[test]
+    fn response_builder_active_blob_flag_off() {
+        let outcome = CreatorDeleteOutcome {
+            old_status: BlobStatus::Active,
+            physical_delete_enabled: false,
+            physical_deleted: false,
+        };
+        let body = build_creator_delete_response(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            &outcome,
+        );
+        assert_eq!(body["success"], serde_json::json!(true));
+        assert_eq!(
+            body["sha256"],
+            serde_json::json!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
+        assert_eq!(body["old_status"], serde_json::json!("active"));
+        assert_eq!(body["new_status"], serde_json::json!("deleted"));
+        assert_eq!(body["physical_deleted"], serde_json::json!(false));
+        assert_eq!(body["physical_delete_skipped"], serde_json::json!(true));
     }
 }

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -319,4 +319,30 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn outcome_truth_table_matches_contract() {
+        // Pins the two reachable success outcomes the contract doc describes.
+        // Used as a readable enumeration of what downstream callers can expect.
+        let flag_off = CreatorDeleteOutcome {
+            old_status: BlobStatus::Active,
+            physical_delete_enabled: false,
+            physical_deleted: false,
+        };
+        assert!(!flag_off.physical_delete_enabled);
+        assert!(!flag_off.physical_deleted);
+
+        let flag_on_success = CreatorDeleteOutcome {
+            old_status: BlobStatus::Active,
+            physical_delete_enabled: true,
+            physical_deleted: true,
+        };
+        assert!(flag_on_success.physical_delete_enabled);
+        assert!(flag_on_success.physical_deleted);
+
+        // The (physical_delete_enabled=true, physical_deleted=false)
+        // combination is unreachable via handle_creator_delete's Ok path —
+        // byte-delete failure returns Err. No test case for it because it
+        // cannot be produced by the helper.
+    }
 }

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -266,4 +266,24 @@ mod tests {
         assert_eq!(body["old_status"], serde_json::json!("active"));
         assert_eq!(body["new_status"], serde_json::json!("deleted"));
     }
+
+    #[test]
+    fn response_builder_already_deleted_blob_idempotent_retry() {
+        // Scenario: caller retries DELETE on a blob that was already soft-deleted.
+        // handle_creator_delete returned Ok with old_status=Deleted (no change).
+        // physical_deleted reflects the retry's byte-delete outcome.
+        let outcome = CreatorDeleteOutcome {
+            old_status: BlobStatus::Deleted,
+            physical_delete_enabled: true,
+            physical_deleted: true,
+        };
+        let body = build_creator_delete_response(
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            &outcome,
+        );
+        assert_eq!(body["old_status"], serde_json::json!("deleted"));
+        assert_eq!(body["new_status"], serde_json::json!("deleted"));
+        assert_eq!(body["physical_deleted"], serde_json::json!(true));
+        assert_eq!(body["physical_delete_skipped"], serde_json::json!(false));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,10 @@ use crate::blossom::{
     ResumableUploadInitRequest, ResumableUploadInitResponse, SubtitleJob, SubtitleJobCreateRequest,
     SubtitleJobStatus, TranscodeStatus, TranscriptStatus, UploadRequirements,
 };
-use crate::delete_policy::{handle_creator_delete, plan_user_delete, soft_delete_blob, DeletePlan};
+use crate::delete_policy::{
+    build_creator_delete_response, handle_creator_delete, plan_user_delete, soft_delete_blob,
+    DeletePlan,
+};
 use crate::error::{BlossomError, Result};
 use crate::media_auth_log::format_media_auth_log;
 use crate::metadata::{
@@ -4807,14 +4810,7 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             Some(reason),
         );
 
-        let response = serde_json::json!({
-            "success": true,
-            "sha256": sha256,
-            "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
-            "new_status": "deleted",
-            "physical_deleted": outcome.physical_deleted,
-            "physical_delete_skipped": !outcome.physical_delete_enabled,
-        });
+        let response = build_creator_delete_response(sha256, &outcome);
         let mut resp = json_response(StatusCode::OK, &response);
         add_cors_headers(&mut resp);
         return Ok(resp);


### PR DESCRIPTION
Refs #87.

## Summary

Adds unit coverage for the creator-delete response contract and extracts a shared `build_creator_delete_response(sha256, outcome)` helper so `/admin/moderate` and `/admin/api/moderate` produce the same response via one code path.

## Coverage

Per Liz's note on #87 ("prioritize unit coverage around the extracted creator-delete policy helper plus a lightweight response-shape fixture"), this PR stays at the unit level and does not spin up Viceroy for full handler tests.

- Response-shape test for flag-off active blob (base case).
- Response-shape test for flag-on active blob with successful byte-delete.
- Response-shape test for idempotent retry on an already-`Deleted` blob.
- Parameterized test pinning `old_status` rendering for every `BlobStatus` variant (`active`, `restricted`, `pending`, `banned`, `deleted`, `agerestricted`).

Handler-level pre-validation paths (`Invalid sha256 → 400`, `missing blob → 404`, `unknown action unchanged`) return before the helper is reached. They're exercised by the rollout plan's Step 1 smoke test and ship without new unit coverage per Liz's Viceroy-cost note.

## Refactor

Both handlers now call `build_creator_delete_response` instead of inlining `serde_json::json!({...})`. Response shape guaranteed identical via a single source. `main.rs` preserves its pre-existing `add_cors_headers` call; `admin.rs` remains CORS-free as before.

## Out of scope

- #95 (serde-aware `BlobStatus` rendering) — the variant test pins current behavior (`"agerestricted"`, no underscore) with an inline comment. When #95 lands, that one assertion flips to `\"age_restricted\"`.

## Review pass

Ran the code-reviewer agent on the diff before opening. Two findings:
- **CORS asymmetry between handlers** (flagged as concern) — verified against origin/main that `main.rs`'s `add_cors_headers` call was pre-existing; the refactor preserved it. No behavior change.
- **Tautological assertions in a truth-table test** — dropped the test per feedback. The readable-enumeration intent it served is already covered by the distinct `response_builder_*` tests.

## Verification

`cargo check --tests --locked --target wasm32-wasip1` passes with no new warnings.
