### PR TITLE
Fixing serialize admin BlobStatus using canonical API names

### DIFF
--- a/docs/api/creator-delete-contract.md
+++ b/docs/api/creator-delete-contract.md
@@ -44,18 +44,12 @@ Field semantics:
 |---|---|---|
 | `success` | bool | Always `true` when HTTP 200. |
 | `sha256` | string | Echoes the request blob hash. |
-| `old_status` | string | Lowercase `BlobStatus` the blob was in before this call. Current values: `active`, `restricted`, `agerestricted`, `pending`, `banned`, `deleted`. See [note on status rendering](#note-status-string-rendering). |
+| `old_status` | string | Lowercase `BlobStatus` the blob was in before this call. Current values: `active`, `restricted`, `age_restricted`, `pending`, `banned`, `deleted`. |
 | `new_status` | string | Always `"deleted"` on success. |
 | `physical_deleted` | bool | `true` only when the main GCS blob delete succeeded. `false` when the flag is off *or* when physical delete wasn't attempted. |
 | `physical_delete_skipped` | bool | `true` when `ENABLE_PHYSICAL_DELETE` was off; `false` when it was on. |
 
 Callers can rely on these fields without reading Blossom source. Additional fields may be added; clients must ignore unknown fields.
-
-#### Note: status string rendering
-
-The response currently renders `BlobStatus` via `format!("{:?}", status).to_lowercase()`, which bypasses serde's `#[serde(rename = "age_restricted")]` attribute on `BlobStatus::AgeRestricted`. As a result, `old_status` emits `"agerestricted"` (no underscore) on this path, while serde-serialized status strings elsewhere in the API render as `"age_restricted"`.
-
-Tracked as [blossom#95](https://github.com/divinevideo/divine-blossom/issues/95). Until that lands, callers matching on `old_status` should accept `"agerestricted"` for the age-gated variant on creator-delete/moderate/restore responses specifically. Other status variants are unaffected because their `Debug` form lowercases cleanly to the same string serde produces.
 
 ### Mapping between outcomes and response
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -959,8 +959,8 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
     let response = serde_json::json!({
         "success": true,
         "sha256": moderate_req.sha256,
-        "old_status": format!("{:?}", old_status).to_lowercase(),
-        "new_status": format!("{:?}", new_status).to_lowercase()
+        "old_status": old_status.as_api_str(),
+        "new_status": new_status.as_api_str()
     });
 
     json_response(StatusCode::OK, &response)
@@ -994,8 +994,8 @@ pub fn handle_admin_restore_action(mut req: Request) -> Result<Response> {
         "success": true,
         "restored": true,
         "sha256": restore_req.sha256,
-        "old_status": format!("{:?}", old_status).to_lowercase(),
-        "new_status": format!("{:?}", new_status).to_lowercase()
+        "old_status": old_status.as_api_str(),
+        "new_status": new_status.as_api_str()
     });
 
     json_response(StatusCode::OK, &response)

--- a/src/blossom.rs
+++ b/src/blossom.rs
@@ -124,6 +124,17 @@ pub enum BlobStatus {
 }
 
 impl BlobStatus {
+    pub fn as_api_str(self) -> &'static str {
+        match self {
+            BlobStatus::Active => "active",
+            BlobStatus::Restricted => "restricted",
+            BlobStatus::Pending => "pending",
+            BlobStatus::Banned => "banned",
+            BlobStatus::Deleted => "deleted",
+            BlobStatus::AgeRestricted => "age_restricted",
+        }
+    }
+
     pub fn blocks_public_access(self) -> bool {
         matches!(self, BlobStatus::Banned | BlobStatus::Deleted)
     }
@@ -999,6 +1010,22 @@ mod tests {
     fn blob_status_deserializes_age_restricted() {
         let parsed: BlobStatus = serde_json::from_str("\"age_restricted\"").unwrap();
         assert_eq!(parsed, BlobStatus::AgeRestricted);
+    }
+
+    #[test]
+    fn blob_status_api_string_covers_every_variant() {
+        let cases = [
+            (BlobStatus::Active, "active"),
+            (BlobStatus::Restricted, "restricted"),
+            (BlobStatus::Pending, "pending"),
+            (BlobStatus::Banned, "banned"),
+            (BlobStatus::Deleted, "deleted"),
+            (BlobStatus::AgeRestricted, "age_restricted"),
+        ];
+
+        for (status, expected) in cases {
+            assert_eq!(status.as_api_str(), expected);
+        }
     }
 
     #[test]

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -133,13 +133,6 @@ pub fn handle_creator_delete(
 /// Build the JSON response body for a successful creator-delete. Both the
 /// `/admin/moderate` and `/admin/api/moderate` handlers delegate to this so
 /// their response contracts stay identical.
-///
-/// The `old_status` field is rendered via `format!("{:?}", ...).to_lowercase()`
-/// which produces `"agerestricted"` for `BlobStatus::AgeRestricted` rather than
-/// the serde-canonical `"age_restricted"`. This mismatch is documented in
-/// `docs/api/creator-delete-contract.md` and tracked for fix in
-/// divinevideo/divine-blossom#95. Tests in this module pin the current
-/// behavior; they will need updating when #95 lands.
 pub fn build_creator_delete_response(
     sha256: &str,
     outcome: &CreatorDeleteOutcome,
@@ -147,7 +140,7 @@ pub fn build_creator_delete_response(
     serde_json::json!({
         "success": true,
         "sha256": sha256,
-        "old_status": format!("{:?}", outcome.old_status).to_lowercase(),
+        "old_status": outcome.old_status.as_api_str(),
         "new_status": "deleted",
         "physical_deleted": outcome.physical_deleted,
         "physical_delete_skipped": !outcome.physical_delete_enabled,
@@ -289,16 +282,13 @@ mod tests {
 
     #[test]
     fn response_builder_old_status_covers_every_blob_status_variant() {
-        // Pins the current Debug-to-lowercase rendering. When #95 switches
-        // to serde-aware rendering, AgeRestricted's expected string flips to
-        // "age_restricted" and this test needs updating to match.
         let cases: &[(BlobStatus, &str)] = &[
             (BlobStatus::Active, "active"),
             (BlobStatus::Restricted, "restricted"),
             (BlobStatus::Pending, "pending"),
             (BlobStatus::Banned, "banned"),
             (BlobStatus::Deleted, "deleted"),
-            (BlobStatus::AgeRestricted, "agerestricted"),
+            (BlobStatus::AgeRestricted, "age_restricted"),
         ];
         for (status, expected) in cases {
             let outcome = CreatorDeleteOutcome {
@@ -319,5 +309,4 @@ mod tests {
             );
         }
     }
-
 }


### PR DESCRIPTION
Should close #95 