### PR TITLE
test(moderation): add shared validation and action-mapping unit tests

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -3,8 +3,8 @@
 
 use crate::blossom::{BlobMetadata, BlobStatus, GlobalStats, RecentIndex};
 use crate::delete_policy::{
-    build_creator_delete_response, handle_creator_delete, parse_restore_status,
-    restore_soft_deleted_blob,
+    build_creator_delete_response, handle_creator_delete, map_moderate_action,
+    parse_restore_status, restore_soft_deleted_blob, validate_sha256_format,
 };
 use crate::error::{BlossomError, Result};
 use crate::metadata::{
@@ -859,12 +859,7 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
     let moderate_req: ModerateRequest = serde_json::from_str(&body)
         .map_err(|e| BlossomError::BadRequest(format!("Invalid JSON: {}", e)))?;
 
-    // Validate sha256 format
-    if moderate_req.sha256.len() != 64
-        || !moderate_req.sha256.chars().all(|c| c.is_ascii_hexdigit())
-    {
-        return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
-    }
+    validate_sha256_format(&moderate_req.sha256)?;
 
     // Get current metadata to track status change
     let metadata = get_blob_metadata(&moderate_req.sha256)?
@@ -928,23 +923,7 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
         return json_response(StatusCode::OK, &response);
     }
 
-    // Map action to BlobStatus.
-    //
-    // AGE_RESTRICT lands on BlobStatus::AgeRestricted, which serves 401 (age gate)
-    // to non-owners. RESTRICT continues to mean the existing 404 shadow-ban.
-    let new_status = match moderate_req.action.to_uppercase().as_str() {
-        "BAN" | "BLOCK" => BlobStatus::Banned,
-        "RESTRICT" => BlobStatus::Restricted,
-        "AGE_RESTRICT" | "AGE_RESTRICTED" => BlobStatus::AgeRestricted,
-        "APPROVE" | "ACTIVE" => BlobStatus::Active,
-        "PENDING" => BlobStatus::Pending,
-        _ => {
-            return Err(BlossomError::BadRequest(format!(
-                "Unknown action: {}",
-                moderate_req.action
-            )))
-        }
-    };
+    let new_status = map_moderate_action(&moderate_req.action)?;
 
     if old_status != new_status {
         if old_status == BlobStatus::Deleted {
@@ -974,10 +953,7 @@ pub fn handle_admin_restore_action(mut req: Request) -> Result<Response> {
     let restore_req: RestoreRequest = serde_json::from_str(&body)
         .map_err(|e| BlossomError::BadRequest(format!("Invalid JSON: {}", e)))?;
 
-    if restore_req.sha256.len() != 64 || !restore_req.sha256.chars().all(|c| c.is_ascii_hexdigit())
-    {
-        return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
-    }
+    validate_sha256_format(&restore_req.sha256)?;
 
     let metadata = get_blob_metadata(&restore_req.sha256)?
         .ok_or_else(|| BlossomError::NotFound("Blob not found".into()))?;

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -3,7 +3,7 @@
 
 use crate::blossom::{BlobMetadata, BlobStatus, GlobalStats, RecentIndex};
 use crate::delete_policy::{
-    build_creator_delete_response, handle_creator_delete, map_moderate_action,
+    build_creator_delete_response, handle_creator_delete, map_admin_api_action,
     parse_restore_status, restore_soft_deleted_blob, validate_sha256_format,
 };
 use crate::error::{BlossomError, Result};
@@ -923,7 +923,7 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
         return json_response(StatusCode::OK, &response);
     }
 
-    let new_status = map_moderate_action(&moderate_req.action)?;
+    let new_status = map_admin_api_action(&moderate_req.action)?;
 
     if old_status != new_status {
         if old_status == BlobStatus::Deleted {

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -12,6 +12,37 @@ pub enum DeletePlan {
     UnlinkOnly,
 }
 
+/// Validates that a SHA-256 string is exactly 64 hex characters.
+/// Used by both `/admin/moderate` and `/admin/api/moderate` before any
+/// metadata lookup.
+pub fn validate_sha256_format(sha256: &str) -> Result<()> {
+    if sha256.len() != 64 || !sha256.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
+    }
+    Ok(())
+}
+
+/// Maps an action string from a moderation request to a `BlobStatus`.
+/// Returns `Err(BadRequest)` for unknown actions. The DELETE action is
+/// handled separately by callers before reaching this function.
+///
+/// Both `/admin/moderate` and `/admin/api/moderate` accept slightly
+/// different action aliases. This function covers the union so both
+/// endpoints can share validation.
+pub fn map_moderate_action(action: &str) -> Result<BlobStatus> {
+    match action.to_uppercase().as_str() {
+        "BAN" | "BLOCK" | "PERMANENT_BAN" => Ok(BlobStatus::Banned),
+        "RESTRICT" | "QUARANTINE" => Ok(BlobStatus::Restricted),
+        "AGE_RESTRICT" | "AGE_RESTRICTED" => Ok(BlobStatus::AgeRestricted),
+        "APPROVE" | "ACTIVE" | "SAFE" => Ok(BlobStatus::Active),
+        "PENDING" => Ok(BlobStatus::Pending),
+        _ => Err(BlossomError::BadRequest(format!(
+            "Unknown action: {}",
+            action
+        ))),
+    }
+}
+
 pub fn plan_user_delete(is_owner: bool) -> DeletePlan {
     if is_owner {
         DeletePlan::SoftDelete
@@ -528,6 +559,152 @@ mod tests {
         assert_eq!(body["physical_deleted"], serde_json::json!(true));
         assert_eq!(body["physical_delete_skipped"], serde_json::json!(false));
     }
+
+    // ── validate_sha256_format ────────────────────────────────────────
+
+    #[test]
+    fn sha256_valid_lowercase_hex_passes() {
+        validate_sha256_format(&"a".repeat(64)).unwrap();
+    }
+
+    #[test]
+    fn sha256_valid_uppercase_hex_passes() {
+        validate_sha256_format(&"A".repeat(64)).unwrap();
+    }
+
+    #[test]
+    fn sha256_valid_mixed_case_passes() {
+        validate_sha256_format("aAbBcCdDeEfF0011223344556677889900112233445566778899aAbBcCdDeEfF").unwrap();
+    }
+
+    #[test]
+    fn sha256_too_short_returns_bad_request() {
+        let result = validate_sha256_format(&"a".repeat(63));
+        assert!(matches!(result, Err(BlossomError::BadRequest(_))));
+    }
+
+    #[test]
+    fn sha256_too_long_returns_bad_request() {
+        let result = validate_sha256_format(&"a".repeat(65));
+        assert!(matches!(result, Err(BlossomError::BadRequest(_))));
+    }
+
+    #[test]
+    fn sha256_empty_returns_bad_request() {
+        let result = validate_sha256_format("");
+        assert!(matches!(result, Err(BlossomError::BadRequest(_))));
+    }
+
+    #[test]
+    fn sha256_non_hex_chars_return_bad_request() {
+        let mut bad = "a".repeat(62);
+        bad.push_str("zz");
+        let result = validate_sha256_format(&bad);
+        assert!(matches!(result, Err(BlossomError::BadRequest(_))));
+    }
+
+    #[test]
+    fn sha256_with_spaces_returns_bad_request() {
+        let result = validate_sha256_format(&format!("{} {}", "a".repeat(32), "b".repeat(31)));
+        assert!(matches!(result, Err(BlossomError::BadRequest(_))));
+    }
+
+    // ── map_moderate_action ─────────────────────────────────────────
+
+    #[test]
+    fn action_ban_aliases_all_map_to_banned() {
+        for action in &["BAN", "BLOCK", "PERMANENT_BAN", "ban", "Block", "permanent_ban"] {
+            assert_eq!(
+                map_moderate_action(action).unwrap(),
+                BlobStatus::Banned,
+                "{action} should map to Banned"
+            );
+        }
+    }
+
+    #[test]
+    fn action_restrict_aliases_map_to_restricted() {
+        for action in &["RESTRICT", "QUARANTINE", "restrict", "Quarantine"] {
+            assert_eq!(
+                map_moderate_action(action).unwrap(),
+                BlobStatus::Restricted,
+                "{action} should map to Restricted"
+            );
+        }
+    }
+
+    #[test]
+    fn action_age_restrict_aliases_map_to_age_restricted() {
+        for action in &["AGE_RESTRICT", "AGE_RESTRICTED", "age_restrict", "Age_Restricted"] {
+            assert_eq!(
+                map_moderate_action(action).unwrap(),
+                BlobStatus::AgeRestricted,
+                "{action} should map to AgeRestricted"
+            );
+        }
+    }
+
+    #[test]
+    fn action_approve_aliases_map_to_active() {
+        for action in &["APPROVE", "ACTIVE", "SAFE", "approve", "Active", "safe"] {
+            assert_eq!(
+                map_moderate_action(action).unwrap(),
+                BlobStatus::Active,
+                "{action} should map to Active"
+            );
+        }
+    }
+
+    #[test]
+    fn action_pending_maps_to_pending() {
+        assert_eq!(map_moderate_action("PENDING").unwrap(), BlobStatus::Pending);
+        assert_eq!(map_moderate_action("pending").unwrap(), BlobStatus::Pending);
+    }
+
+    #[test]
+    fn action_unknown_returns_bad_request_with_action_name() {
+        let result = map_moderate_action("OBLITERATE");
+        match result {
+            Err(BlossomError::BadRequest(msg)) => assert!(
+                msg.contains("OBLITERATE"),
+                "error should include the unknown action name, got: {msg}"
+            ),
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn action_empty_string_returns_bad_request() {
+        assert!(matches!(
+            map_moderate_action(""),
+            Err(BlossomError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn action_delete_is_not_handled_by_map_moderate_action() {
+        // DELETE is handled by callers before reaching map_moderate_action.
+        // If someone passes it here, it's an unknown action.
+        assert!(matches!(
+            map_moderate_action("DELETE"),
+            Err(BlossomError::BadRequest(_))
+        ));
+    }
+
+    // ── Coverage gaps documented (require Viceroy integration tests) ─
+    //
+    // The following #87 checklist items cannot be tested as pure functions
+    // because they depend on Fastly KV metadata lookups inside the HTTP
+    // handler:
+    //
+    //   4. Missing blob returns 404 — requires metadata::get_metadata()
+    //      to return None, which only happens inside the handler path that
+    //      reads from Fastly KV (needs Viceroy).
+    //
+    // The response contract divergence between /admin/moderate and
+    // /admin/api/moderate for non-DELETE actions is documented in
+    // docs/api/creator-delete-contract.md. DELETE responses are unified
+    // through build_creator_delete_response (tested above).
 
     #[test]
     fn response_builder_old_status_covers_every_blob_status_variant() {

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -22,22 +22,35 @@ pub fn validate_sha256_format(sha256: &str) -> Result<()> {
     Ok(())
 }
 
-/// Maps an action string from a moderation request to a `BlobStatus`.
-/// Returns `Err(BadRequest)` for unknown actions. The DELETE action is
-/// handled separately by callers before reaching this function.
-///
-/// Both `/admin/moderate` and `/admin/api/moderate` accept slightly
-/// different action aliases. This function covers the union so both
-/// endpoints can share validation.
-pub fn map_moderate_action(action: &str) -> Result<BlobStatus> {
+/// Maps an action string from `/admin/api/moderate` to a `BlobStatus`.
+/// Accepts: BAN, BLOCK, RESTRICT, AGE_RESTRICT, AGE_RESTRICTED, APPROVE,
+/// ACTIVE, PENDING. DELETE is handled by callers before reaching this.
+pub fn map_admin_api_action(action: &str) -> Result<BlobStatus> {
     match action.to_uppercase().as_str() {
-        "BAN" | "BLOCK" | "PERMANENT_BAN" => Ok(BlobStatus::Banned),
-        "RESTRICT" | "QUARANTINE" => Ok(BlobStatus::Restricted),
+        "BAN" | "BLOCK" => Ok(BlobStatus::Banned),
+        "RESTRICT" => Ok(BlobStatus::Restricted),
         "AGE_RESTRICT" | "AGE_RESTRICTED" => Ok(BlobStatus::AgeRestricted),
-        "APPROVE" | "ACTIVE" | "SAFE" => Ok(BlobStatus::Active),
+        "APPROVE" | "ACTIVE" => Ok(BlobStatus::Active),
         "PENDING" => Ok(BlobStatus::Pending),
         _ => Err(BlossomError::BadRequest(format!(
             "Unknown action: {}",
+            action
+        ))),
+    }
+}
+
+/// Maps an action string from `/admin/moderate` (webhook) to a `BlobStatus`.
+/// Accepts: BLOCK, BAN, PERMANENT_BAN, AGE_RESTRICTED, AGE_RESTRICT,
+/// RESTRICT, QUARANTINE, APPROVE, SAFE. DELETE is handled by callers
+/// before reaching this.
+pub fn map_webhook_moderate_action(action: &str) -> Result<BlobStatus> {
+    match action.to_uppercase().as_str() {
+        "BLOCK" | "BAN" | "PERMANENT_BAN" => Ok(BlobStatus::Banned),
+        "AGE_RESTRICTED" | "AGE_RESTRICT" => Ok(BlobStatus::AgeRestricted),
+        "RESTRICT" | "QUARANTINE" => Ok(BlobStatus::Restricted),
+        "APPROVE" | "SAFE" => Ok(BlobStatus::Active),
+        _ => Err(BlossomError::BadRequest(format!(
+            "Unknown action: {}. Expected BLOCK, RESTRICT, QUARANTINE, AGE_RESTRICTED, or APPROVE",
             action
         ))),
     }
@@ -400,8 +413,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result =
-            handle_creator_delete_with_ops(HASH, &metadata, "user", true, REQ_ID, &ops);
+        let result = handle_creator_delete_with_ops(HASH, &metadata, "user", true, REQ_ID, &ops);
 
         assert!(
             matches!(result, Err(BlossomError::StorageError(ref m)) if m.contains("simulated GCS 500")),
@@ -574,7 +586,8 @@ mod tests {
 
     #[test]
     fn sha256_valid_mixed_case_passes() {
-        validate_sha256_format("aAbBcCdDeEfF0011223344556677889900112233445566778899aAbBcCdDeEfF").unwrap();
+        validate_sha256_format("aAbBcCdDeEfF0011223344556677889900112233445566778899aAbBcCdDeEfF")
+            .unwrap();
     }
 
     #[test]
@@ -609,13 +622,13 @@ mod tests {
         assert!(matches!(result, Err(BlossomError::BadRequest(_))));
     }
 
-    // ── map_moderate_action ─────────────────────────────────────────
+    // ── map_admin_api_action (/admin/api/moderate) ──────────────────
 
     #[test]
-    fn action_ban_aliases_all_map_to_banned() {
-        for action in &["BAN", "BLOCK", "PERMANENT_BAN", "ban", "Block", "permanent_ban"] {
+    fn admin_api_ban_aliases_map_to_banned() {
+        for action in &["BAN", "BLOCK", "ban", "Block"] {
             assert_eq!(
-                map_moderate_action(action).unwrap(),
+                map_admin_api_action(action).unwrap(),
                 BlobStatus::Banned,
                 "{action} should map to Banned"
             );
@@ -623,21 +636,46 @@ mod tests {
     }
 
     #[test]
-    fn action_restrict_aliases_map_to_restricted() {
-        for action in &["RESTRICT", "QUARANTINE", "restrict", "Quarantine"] {
-            assert_eq!(
-                map_moderate_action(action).unwrap(),
-                BlobStatus::Restricted,
-                "{action} should map to Restricted"
-            );
-        }
+    fn admin_api_restrict_maps_to_restricted() {
+        assert_eq!(
+            map_admin_api_action("RESTRICT").unwrap(),
+            BlobStatus::Restricted
+        );
+        assert_eq!(
+            map_admin_api_action("restrict").unwrap(),
+            BlobStatus::Restricted
+        );
     }
 
     #[test]
-    fn action_age_restrict_aliases_map_to_age_restricted() {
-        for action in &["AGE_RESTRICT", "AGE_RESTRICTED", "age_restrict", "Age_Restricted"] {
+    fn admin_api_does_not_accept_quarantine() {
+        assert!(matches!(
+            map_admin_api_action("QUARANTINE"),
+            Err(BlossomError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn admin_api_does_not_accept_permanent_ban() {
+        assert!(matches!(
+            map_admin_api_action("PERMANENT_BAN"),
+            Err(BlossomError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn admin_api_does_not_accept_safe() {
+        assert!(matches!(
+            map_admin_api_action("SAFE"),
+            Err(BlossomError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn admin_api_age_restrict_aliases_map_to_age_restricted() {
+        for action in &["AGE_RESTRICT", "AGE_RESTRICTED", "age_restrict"] {
             assert_eq!(
-                map_moderate_action(action).unwrap(),
+                map_admin_api_action(action).unwrap(),
                 BlobStatus::AgeRestricted,
                 "{action} should map to AgeRestricted"
             );
@@ -645,10 +683,10 @@ mod tests {
     }
 
     #[test]
-    fn action_approve_aliases_map_to_active() {
-        for action in &["APPROVE", "ACTIVE", "SAFE", "approve", "Active", "safe"] {
+    fn admin_api_approve_aliases_map_to_active() {
+        for action in &["APPROVE", "ACTIVE", "approve", "Active"] {
             assert_eq!(
-                map_moderate_action(action).unwrap(),
+                map_admin_api_action(action).unwrap(),
                 BlobStatus::Active,
                 "{action} should map to Active"
             );
@@ -656,14 +694,20 @@ mod tests {
     }
 
     #[test]
-    fn action_pending_maps_to_pending() {
-        assert_eq!(map_moderate_action("PENDING").unwrap(), BlobStatus::Pending);
-        assert_eq!(map_moderate_action("pending").unwrap(), BlobStatus::Pending);
+    fn admin_api_pending_maps_to_pending() {
+        assert_eq!(
+            map_admin_api_action("PENDING").unwrap(),
+            BlobStatus::Pending
+        );
+        assert_eq!(
+            map_admin_api_action("pending").unwrap(),
+            BlobStatus::Pending
+        );
     }
 
     #[test]
-    fn action_unknown_returns_bad_request_with_action_name() {
-        let result = map_moderate_action("OBLITERATE");
+    fn admin_api_unknown_returns_bad_request() {
+        let result = map_admin_api_action("OBLITERATE");
         match result {
             Err(BlossomError::BadRequest(msg)) => assert!(
                 msg.contains("OBLITERATE"),
@@ -674,19 +718,111 @@ mod tests {
     }
 
     #[test]
-    fn action_empty_string_returns_bad_request() {
+    fn admin_api_delete_is_not_handled() {
         assert!(matches!(
-            map_moderate_action(""),
+            map_admin_api_action("DELETE"),
+            Err(BlossomError::BadRequest(_))
+        ));
+    }
+
+    // ── map_webhook_moderate_action (/admin/moderate) ─────────────────
+
+    #[test]
+    fn webhook_ban_aliases_map_to_banned() {
+        for action in &["BLOCK", "BAN", "PERMANENT_BAN", "block", "permanent_ban"] {
+            assert_eq!(
+                map_webhook_moderate_action(action).unwrap(),
+                BlobStatus::Banned,
+                "{action} should map to Banned"
+            );
+        }
+    }
+
+    #[test]
+    fn webhook_restrict_aliases_map_to_restricted() {
+        for action in &["RESTRICT", "QUARANTINE", "restrict", "Quarantine"] {
+            assert_eq!(
+                map_webhook_moderate_action(action).unwrap(),
+                BlobStatus::Restricted,
+                "{action} should map to Restricted"
+            );
+        }
+    }
+
+    #[test]
+    fn webhook_age_restrict_aliases_map_to_age_restricted() {
+        for action in &["AGE_RESTRICTED", "AGE_RESTRICT", "age_restricted"] {
+            assert_eq!(
+                map_webhook_moderate_action(action).unwrap(),
+                BlobStatus::AgeRestricted,
+                "{action} should map to AgeRestricted"
+            );
+        }
+    }
+
+    #[test]
+    fn webhook_approve_aliases_map_to_active() {
+        for action in &["APPROVE", "SAFE", "approve", "safe"] {
+            assert_eq!(
+                map_webhook_moderate_action(action).unwrap(),
+                BlobStatus::Active,
+                "{action} should map to Active"
+            );
+        }
+    }
+
+    #[test]
+    fn webhook_does_not_accept_active() {
+        assert!(matches!(
+            map_webhook_moderate_action("ACTIVE"),
             Err(BlossomError::BadRequest(_))
         ));
     }
 
     #[test]
-    fn action_delete_is_not_handled_by_map_moderate_action() {
-        // DELETE is handled by callers before reaching map_moderate_action.
-        // If someone passes it here, it's an unknown action.
+    fn webhook_does_not_accept_pending() {
         assert!(matches!(
-            map_moderate_action("DELETE"),
+            map_webhook_moderate_action("PENDING"),
+            Err(BlossomError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn webhook_unknown_returns_specific_error_message() {
+        let result = map_webhook_moderate_action("OBLITERATE");
+        match result {
+            Err(BlossomError::BadRequest(msg)) => {
+                assert!(
+                    msg.contains("OBLITERATE"),
+                    "error should include the unknown action name, got: {msg}"
+                );
+                assert!(
+                    msg.contains(
+                        "Expected BLOCK, RESTRICT, QUARANTINE, AGE_RESTRICTED, or APPROVE"
+                    ),
+                    "webhook error should list expected actions, got: {msg}"
+                );
+            }
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn webhook_delete_is_not_handled() {
+        assert!(matches!(
+            map_webhook_moderate_action("DELETE"),
+            Err(BlossomError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn admin_api_and_webhook_empty_string_returns_bad_request() {
+        assert!(matches!(
+            map_admin_api_action(""),
+            Err(BlossomError::BadRequest(_))
+        ));
+        assert!(matches!(
+            map_webhook_moderate_action(""),
             Err(BlossomError::BadRequest(_))
         ));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ use crate::blossom::{
     SubtitleJobStatus, TranscodeStatus, TranscriptStatus, UploadRequirements,
 };
 use crate::delete_policy::{
-    build_creator_delete_response, handle_creator_delete, map_moderate_action, plan_user_delete,
-    soft_delete_blob, validate_sha256_format, DeletePlan,
+    build_creator_delete_response, handle_creator_delete, map_webhook_moderate_action,
+    plan_user_delete, soft_delete_blob, validate_sha256_format, DeletePlan,
 };
 use crate::error::{BlossomError, Result};
 use crate::media_auth_log::format_media_auth_log;
@@ -4783,20 +4783,15 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
             Some(reason),
         );
 
-        let outcome = handle_creator_delete(
-            sha256,
-            &metadata,
-            reason,
-            physical_delete_enabled,
-            &req_id,
-        )
-        .map_err(|e| {
-            eprintln!(
-                "[req={}] [CREATOR-DELETE] handle_creator_delete failed for {}: {}",
-                req_id, sha256, e
-            );
-            e
-        })?;
+        let outcome =
+            handle_creator_delete(sha256, &metadata, reason, physical_delete_enabled, &req_id)
+                .map_err(|e| {
+                    eprintln!(
+                        "[req={}] [CREATOR-DELETE] handle_creator_delete failed for {}: {}",
+                        req_id, sha256, e
+                    );
+                    e
+                })?;
 
         write_audit_log(
             sha256,
@@ -4813,7 +4808,7 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
         return Ok(resp);
     }
 
-    let new_status = map_moderate_action(action)?;
+    let new_status = map_webhook_moderate_action(action)?;
 
     // Update blob status
     match update_blob_status(sha256, new_status) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ use crate::blossom::{
     SubtitleJobStatus, TranscodeStatus, TranscriptStatus, UploadRequirements,
 };
 use crate::delete_policy::{
-    build_creator_delete_response, handle_creator_delete, plan_user_delete, soft_delete_blob,
-    DeletePlan,
+    build_creator_delete_response, handle_creator_delete, map_moderate_action, plan_user_delete,
+    soft_delete_blob, validate_sha256_format, DeletePlan,
 };
 use crate::error::{BlossomError, Result};
 use crate::media_auth_log::format_media_auth_log;
@@ -4750,10 +4750,7 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
         req_id, sha256, action
     );
 
-    // Validate sha256 format
-    if sha256.len() != 64 || !sha256.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
-    }
+    validate_sha256_format(sha256)?;
 
     // Creator-delete: thin adapter over handle_creator_delete so /admin/moderate
     // and /admin/api/moderate produce the same response contract.
@@ -4816,23 +4813,7 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
         return Ok(resp);
     }
 
-    // Map action to BlobStatus.
-    //
-    // AGE_RESTRICTED is intentionally split out from RESTRICT/QUARANTINE: it lands on
-    // BlobStatus::AgeRestricted, which serves as a 401 age gate to anonymous viewers
-    // instead of the 404 shadow-ban that RESTRICT/QUARANTINE produce.
-    let new_status = match action.to_uppercase().as_str() {
-        "BLOCK" | "BAN" | "PERMANENT_BAN" => BlobStatus::Banned,
-        "AGE_RESTRICTED" | "AGE_RESTRICT" => BlobStatus::AgeRestricted,
-        "RESTRICT" | "QUARANTINE" => BlobStatus::Restricted,
-        "APPROVE" | "SAFE" => BlobStatus::Active,
-        _ => {
-            return Err(BlossomError::BadRequest(format!(
-                "Unknown action: {}. Expected BLOCK, RESTRICT, QUARANTINE, AGE_RESTRICTED, or APPROVE",
-                action
-            )));
-        }
-    };
+    let new_status = map_moderate_action(action)?;
 
     // Update blob status
     match update_blob_status(sha256, new_status) {
@@ -4928,10 +4909,7 @@ fn handle_transcode_status(mut req: Request) -> Result<Response> {
         parsed.terminal
     );
 
-    // Validate sha256 format
-    if sha256.len() != 64 || !sha256.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
-    }
+    validate_sha256_format(sha256)?;
 
     // Update transcode status (and optionally file size and dimensions if provided)
     use crate::metadata::update_transcode_status_with_metadata;
@@ -5056,10 +5034,7 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
         sha256, parsed.status, parsed.job_id
     );
 
-    // Validate sha256 format
-    if sha256.len() != 64 || !sha256.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(BlossomError::BadRequest("Invalid sha256 format".into()));
-    }
+    validate_sha256_format(sha256)?;
 
     use crate::metadata::update_transcript_status;
     match update_transcript_status(


### PR DESCRIPTION
## Summary

- Extract `validate_sha256_format()` from the two moderation handlers into a shared pure helper in `delete_policy.rs`
- Extract endpoint-specific action mappers into shared pure helpers in `delete_policy.rs`:
  - `map_admin_api_action()` preserves the existing `/admin/api/moderate` alias set and error behavior
  - `map_webhook_moderate_action()` preserves the existing `/admin/moderate` alias set and error behavior
- Add unit tests covering SHA-256 validation, accepted aliases, rejected aliases, and unknown-action behavior for both ingress paths
- Document remaining coverage gaps: missing-blob 404 still needs an integration/Viceroy path, and runnable native execution of these tests is tracked separately

**Note:** These tests are compile-verified via `cargo check --tests --target wasm32-wasip1` but do not execute natively yet because of the Fastly FFI link constraint. Issue #104 tracks the `blossom-core` extraction needed to run them under normal `cargo test`.

**Stack:** #105 depends on this PR. Retarget #105 to `main` before merging this.

## Test plan

- [x] `cargo check --target wasm32-wasip1` passes (no errors, pre-existing warnings only)
- [x] `cargo check --tests --target wasm32-wasip1` passes
- [x] Unit tests pin the existing per-endpoint alias sets and unknown-action behavior for both moderation handlers
- [x] Rebased on current `main` after #99 landed so the crate-private test seam remains intact

Refs #87