### PR TITLE
chore: add repo contribution guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Report a bug or regression
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors for external partners, customers, brands, campaign names, and other sensitive identities unless a maintainer has approved naming them publicly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the problem.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the request flow, service interaction, or deploy condition needed to reproduce the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include relevant service, environment, logs, or payloads. Redact secrets and sensitive external names.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Propose a new feature or improvement
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use generic descriptors for external partners, customers, brands, campaign names, and other sensitive identities unless a maintainer has approved naming them publicly.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the feature or improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: Explain why this work is needed.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Approach
+      description: Describe the intended behavior or implementation direction.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Include relevant service interactions, API examples, or rollout notes. Redact secrets and sensitive external names.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+-
+
+## Motivation
+
+-
+
+## Related Issue
+
+- Closes #
+
+## Validation
+
+- [ ] `cargo check --tests --locked`
+- [ ] `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked`
+- [ ] `cargo clippy --locked --all-targets --all-features`
+- [ ] relevant service-local checks for touched Cloud Run or Python code
+- [ ] I could not run some validation locally, and I explained why below
+
+## Manual Test Plan / Notes
+
+-
+
+## Visuals / API Examples
+
+- [ ] No visual change
+- [ ] Screenshots, sample payloads, or logs attached if needed
+
+## Public Artifact Review
+
+- [ ] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved

--- a/.github/workflows/semantic_pr.yml
+++ b/.github/workflows/semantic_pr.yml
@@ -1,0 +1,12 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/semantic_pull_request.yml@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Fastly Compute edge service code lives under `src/`.
+- Cloud Run services live under `cloud-run-upload/` and `cloud-run-transcoder/`.
+- Blob processing and moderation webhook code lives under `cloud-functions/process-blob/`.
+- Operational docs and rollout notes live in `README.md`, `OAUTH_SETUP.md`, and `docs/`.
+- Deployment and environment config lives in `fastly.toml*`, `Dockerfile.local`, and service-specific config files. Verify current config before changing domains, buckets, or service bindings.
+
+## Build, Test, and Validation Commands
+- `cargo check --tests --locked`: check the Fastly edge crate.
+- `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked`: upload service tests.
+- `cargo clippy --locked --all-targets --all-features`: lint gate used in CI.
+- Use the relevant service-local test or validation command when touching `cloud-run-transcoder/` or `cloud-functions/process-blob/`.
+- For deploy work, prefer local verification before any publish or deploy step.
+
+## Coding Style & Naming Conventions
+- Keep edge, upload, transcoder, and process-blob changes scoped. Do not mix unrelated services or deployment refactors in one PR.
+- Follow the existing Rust, Python, and Fastly/GCP patterns already established in the repo.
+- Verify domains, bucket names, and service identifiers against config files before introducing or changing URLs. Do not hardcode environment-specific values in application code.
+
+## Security & Operational Notes
+- Never commit secrets, API tokens, private keys, service credentials, or screenshots/logs containing sensitive values.
+- Public issues, PRs, branch names, screenshots, and descriptions must not mention corporate partners, customers, brands, campaign names, or other sensitive external identities unless a maintainer explicitly approves it. Use generic descriptors instead.
+- Respect the existing deployment rule: use `fastly compute publish` for Fastly deploys, not separate build and deploy commands.
+
+## Pull Request Guardrails
+- PR titles must use Conventional Commit format: `type(scope): summary` or `type: summary`.
+- Set the correct PR title when opening the PR. Do not rely on fixing it later.
+- If a PR title is edited after opening, verify that the semantic PR title check reruns successfully.
+- Keep PRs tightly scoped. Do not include unrelated formatting churn, dependency noise, or drive-by refactors.
+- Temporary or transitional code must include `TODO(#issue):` with a tracking issue.
+- UI, API, or externally visible behavior changes should include screenshots, sample payloads, or an explicit note that there is no visual change.
+- PR descriptions must include a summary, motivation, linked issue, and manual validation plan.
+- Before requesting review, run the relevant checks for the files you changed, or note what you could not run.


### PR DESCRIPTION
## Summary
- add repo-local contributor and agent guardrails in AGENTS.md
- add semantic PR title enforcement plus PR and issue templates
- reinforce redaction of sensitive external names in public repo artifacts

## Motivation
- make repo-local contribution expectations explicit for humans and AI agents
- align this repo with the org standard without duplicating existing deployment-specific docs

## Validation
- not run; docs and GitHub metadata changes only