### PR TITLE
fix: purge Compute edge cache on moderation status change

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -930,7 +930,7 @@ pub fn handle_admin_moderate_action(mut req: Request) -> Result<Response> {
             restore_soft_deleted_blob(&moderate_req.sha256, &metadata, new_status)?;
         } else {
             update_blob_status(&moderate_req.sha256, new_status)?;
-            crate::purge_vcl_cache(&moderate_req.sha256);
+            crate::purge_edge_cache(&moderate_req.sha256);
             let _ = update_stats_on_status_change(old_status, new_status);
         }
     }
@@ -1026,7 +1026,7 @@ pub fn handle_admin_bulk_approve(mut req: Request) -> Result<Response> {
                             if !skip_purge {
                                 let _ =
                                     update_stats_on_status_change(meta.status, BlobStatus::Active);
-                                crate::purge_vcl_cache(hash);
+                                crate::purge_edge_cache(hash);
                             }
                             approved += 1;
                             approved_hashes.push(hash.clone());

--- a/src/delete_policy.rs
+++ b/src/delete_policy.rs
@@ -31,7 +31,7 @@ pub fn soft_delete_blob(
         let _ = put_tombstone(hash, reason);
     }
 
-    crate::purge_vcl_cache(hash);
+    crate::purge_edge_cache(hash);
     Ok(())
 }
 
@@ -51,7 +51,7 @@ impl CreatorDeleteOps for DefaultCreatorDeleteOps {
         crate::delete_blob_gcs_artifacts(hash);
     }
     fn purge_vcl_cache(&self, hash: &str) {
-        crate::purge_vcl_cache(hash);
+        crate::purge_edge_cache(hash);
     }
 }
 
@@ -93,7 +93,7 @@ pub fn restore_soft_deleted_blob(
         }
     }
     let _ = add_to_recent_index(hash);
-    crate::purge_vcl_cache(hash);
+    crate::purge_edge_cache(hash);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,7 +405,7 @@ pub(crate) fn cleanup_derived_audio_for_source(source_hash: &str) {
         let _ = storage_delete(&mapping.audio_sha256);
         let _ = delete_blob_metadata(&mapping.audio_sha256);
         let _ = delete_audio_source_refs(&mapping.audio_sha256);
-        purge_vcl_cache(&mapping.audio_sha256);
+        purge_edge_cache(&mapping.audio_sha256);
     } else {
         let _ = delete_audio_source_refs(&mapping.audio_sha256);
     }
@@ -4048,7 +4048,7 @@ fn execute_vanish(pubkey: &str) -> (u32, u32, u32) {
             delete_blob_kv_artifacts(hash);
             let _ = update_stats_on_remove(&metadata);
             let _ = remove_from_recent_index(hash);
-            purge_vcl_cache(hash);
+            purge_edge_cache(hash);
             fully_deleted += 1;
         } else if is_owner {
             // Transfer ownership to next ref
@@ -4838,7 +4838,7 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
 
             // Purge VCL cache so the new status takes effect immediately.
             // Banned/restricted content will 404 on next request; approved content will 200.
-            purge_vcl_cache(sha256);
+            purge_edge_cache(sha256);
 
             let response = serde_json::json!({
                 "success": true,
@@ -4967,7 +4967,7 @@ fn handle_transcode_status(mut req: Request) -> Result<Response> {
                 parsed.status,
                 TranscodeStatus::Complete | TranscodeStatus::Failed
             ) {
-                purge_vcl_cache(sha256);
+                purge_edge_cache(sha256);
             }
 
             let response = serde_json::json!({
@@ -5124,7 +5124,7 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
                 TranscriptStatus::Complete | TranscriptStatus::Failed
             ) {
                 purge_transcript_content_cache(sha256);
-                purge_vcl_cache(sha256);
+                purge_edge_cache(sha256);
             }
 
             let response = serde_json::json!({
@@ -5505,6 +5505,14 @@ fn error_response(error: &BlossomError) -> Response {
     resp.set_body(body.to_string());
     add_cors_headers(&mut resp);
 
+    // Cap how long CDN caches 404s from access-controlled blobs.
+    // Without this, moderation status changes (e.g. Restricted -> Active)
+    // stay invisible at the edge until Fastly's default TTL expires.
+    if error.status_code() == StatusCode::NOT_FOUND {
+        resp.set_header("Cache-Control", "no-store");
+        resp.set_header("Surrogate-Control", "max-age=60");
+    }
+
     resp
 }
 
@@ -5534,10 +5542,10 @@ fn add_no_cache_headers(resp: &mut Response) {
     resp.set_header("Surrogate-Control", "no-store");
 }
 
-/// Purge content from the VCL caching layer by Surrogate-Key.
-/// Calls POST /service/{service_id}/purge/{key} on api.fastly.com.
-/// Best-effort: logs errors but never fails the calling request.
-pub(crate) fn purge_vcl_cache(surrogate_key: &str) {
+/// Purge content from both the VCL website cache and the Compute media cache
+/// by Surrogate-Key. Calls POST /service/{id}/purge/{key} on api.fastly.com
+/// for each service. Best-effort: logs errors but never fails the calling request.
+pub(crate) fn purge_edge_cache(surrogate_key: &str) {
     let api_token = match fastly::secret_store::SecretStore::open("blossom_secrets")
         .ok()
         .and_then(|store| store.get("fastly_api_token"))
@@ -5545,41 +5553,45 @@ pub(crate) fn purge_vcl_cache(surrogate_key: &str) {
     {
         Some(token) if !token.is_empty() => token,
         _ => {
-            eprintln!("[PURGE] fastly_api_token not configured, skipping VCL cache purge");
+            eprintln!("[PURGE] fastly_api_token not configured, skipping cache purge");
             return;
         }
     };
 
-    // VCL service ID for the caching layer (Divine.Video's website)
-    let vcl_service_id = "ML7R82HKfmTaqTpHExIDVN";
-    let url = format!(
-        "https://api.fastly.com/service/{}/purge/{}",
-        vcl_service_id, surrogate_key
-    );
+    let services: &[(&str, &str)] = &[
+        ("ML7R82HKfmTaqTpHExIDVN", "VCL"),     // divine.video website
+        ("pOvEEWykEbpnylqst1KTrR", "Compute"),  // media.divine.video (Blossom)
+    ];
 
-    let mut purge_req = Request::new(Method::POST, &url);
-    purge_req.set_header("Host", "api.fastly.com");
-    purge_req.set_header("Fastly-Key", &api_token);
-    purge_req.set_header("Accept", "application/json");
+    for &(service_id, label) in services {
+        let url = format!(
+            "https://api.fastly.com/service/{}/purge/{}",
+            service_id, surrogate_key
+        );
 
-    match purge_req.send("fastly_api") {
-        Ok(resp) => {
-            let status = resp.get_status();
-            if status.is_success() {
-                eprintln!("[PURGE] VCL cache purged for key={}", surrogate_key);
-            } else {
+        let mut purge_req = Request::new(Method::POST, &url);
+        purge_req.set_header("Host", "api.fastly.com");
+        purge_req.set_header("Fastly-Key", &api_token);
+        purge_req.set_header("Accept", "application/json");
+
+        match purge_req.send("fastly_api") {
+            Ok(resp) => {
+                let status = resp.get_status();
+                if status.is_success() {
+                    eprintln!("[PURGE] {} cache purged for key={}", label, surrogate_key);
+                } else {
+                    eprintln!(
+                        "[PURGE] {} purge failed for key={}: HTTP {}",
+                        label, surrogate_key, status.as_u16()
+                    );
+                }
+            }
+            Err(e) => {
                 eprintln!(
-                    "[PURGE] VCL purge failed for key={}: HTTP {}",
-                    surrogate_key,
-                    status.as_u16()
+                    "[PURGE] {} purge request failed for key={}: {}",
+                    label, surrogate_key, e
                 );
             }
-        }
-        Err(e) => {
-            eprintln!(
-                "[PURGE] VCL purge request failed for key={}: {}",
-                surrogate_key, e
-            );
         }
     }
 }
@@ -6072,5 +6084,29 @@ mod tests {
         let resp = error_response(&BlossomError::NotFound("Upload session not found".into()));
 
         assert_eq!(resp.get_status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn error_response_404_has_short_cdn_ttl() {
+        let resp = error_response(&BlossomError::NotFound("Blob not found".into()));
+
+        assert_eq!(resp.get_status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            resp.get_header_str("Cache-Control"),
+            Some("no-store"),
+        );
+        assert_eq!(
+            resp.get_header_str("Surrogate-Control"),
+            Some("max-age=60"),
+        );
+    }
+
+    #[test]
+    fn error_response_non_404_has_no_cdn_cache_headers() {
+        let resp = error_response(&BlossomError::BadRequest("bad input".into()));
+
+        assert_eq!(resp.get_status(), StatusCode::BAD_REQUEST);
+        assert_eq!(resp.get_header_str("Cache-Control"), None);
+        assert_eq!(resp.get_header_str("Surrogate-Control"), None);
     }
 }


### PR DESCRIPTION
## Summary

- 404 responses now set `Surrogate-Control: max-age=60` so stale edge-cached `NotFound` responses self-evict within a brief window after moderation changes
- `purge_edge_cache()` (renamed from `purge_vcl_cache()`) now purges both the VCL website cache and the Compute media cache via the Fastly API
- Two new tests cover `error_response()` cache header behavior at compile-check time

## Motivation

When a blob's moderation status changes (e.g. Restricted to Active via `/admin/moderate`), the Fastly Compute cache at `media.divine.video` can continue serving the stale response:

- **Restricted to Active**: cached 404s persist (approved content stays invisible)
- **Active to Restricted**: cached 200s persist (quarantined content remains publicly accessible)

Root cause: `error_response()` set no cache headers on 404s, and `purge_vcl_cache()` only purged the divine.video website VCL service (`ML7R82HKfmTaqTpHExIDVN`), not the Compute service (`pOvEEWykEbpnylqst1KTrR`) where Blossom actually runs.

The 60s `Surrogate-Control` TTL on 404s handles the restricted-to-active direction (cached 404s self-evict). The Compute service surrogate-key purge handles the active-to-restricted direction (cached 200s, which carry surrogate keys, are invalidated immediately).

This 404 TTL cap applies to all `BlossomError::NotFound` responses, not only moderation-denied blobs. That's an intentional tradeoff: slightly shorter edge caching for genuine 404s is preferable to leaving moderation-state changes stale at the edge.

## Related Issue

- Closes #107

## Validation

- [x] `cargo check --tests --locked`
- [x] `cargo clippy --locked --all-targets --all-features`
- [x] CI `test` job passed on this branch
- [x] The new `error_response_*` tests in the Fastly Compute binary crate are compile-checked today; they do not execute natively outside the edge runtime. This matches the existing limitation on binary-crate tests in this repo.

## Manual Test Plan / Notes

Verified the original failure mode end-to-end before this fix:
1. Blob was quarantined by Hive AI (false positive), then marked SAFE via moderation admin UI
2. Blossom KV updated to Active (confirmed via edgecompute origin returning 200)
3. `media.divine.video` continued serving cached 404 (`age` growing, origin confirmed serving 200)
4. Fastly API surrogate-key purge against Compute service returned OK but did not clear cached 404 (no surrogate key on 404 response)
5. HTTP `PURGE` against `media.divine.video/{sha256}` cleared the cache immediately

After this fix:
- Cached 404s expire within 60s via `Surrogate-Control: max-age=60` (no purge needed)
- Cached 200s are purged via the new Compute service API call in `purge_edge_cache()`
- 401/AuthRequired behavior is unchanged; this PR only adjusts the 404 path

## Visuals / API Examples

- [x] No visual change

New response headers on 404:
```
Cache-Control: no-store
Surrogate-Control: max-age=60
```

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved
