### PR TITLE
fix: return 404 when blob metadata is None for non-admin requests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -490,18 +490,27 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         return Err(BlossomError::NotFound("Blob not found".into()));
     }
 
-    if let Some(ref meta) = metadata {
-        let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "blob")?;
-        match meta.access_for(requester_pk.as_deref(), is_admin) {
-            BlobAccess::Allowed => log_media_outcome("blob", &auth_diagnostics, "allowed"),
-            BlobAccess::NotFound => {
-                log_media_outcome("blob", &auth_diagnostics, "not_found");
+    match metadata {
+        Some(ref meta) => {
+            let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "blob")?;
+            match meta.access_for(requester_pk.as_deref(), is_admin) {
+                BlobAccess::Allowed => log_media_outcome("blob", &auth_diagnostics, "allowed"),
+                BlobAccess::NotFound => {
+                    log_media_outcome("blob", &auth_diagnostics, "not_found");
+                    return Err(BlossomError::NotFound("Blob not found".into()));
+                }
+                BlobAccess::AgeGated => {
+                    log_media_outcome("blob", &auth_diagnostics, "age_gated");
+                    return Err(BlossomError::AuthRequired("age_restricted".into()));
+                }
+            }
+        }
+        None => {
+            if !is_admin {
+                eprintln!("[ACCESS] hash={} metadata=None denied (no metadata, non-admin)", hash);
                 return Err(BlossomError::NotFound("Blob not found".into()));
             }
-            BlobAccess::AgeGated => {
-                log_media_outcome("blob", &auth_diagnostics, "age_gated");
-                return Err(BlossomError::AuthRequired("age_restricted".into()));
-            }
+            eprintln!("[ACCESS] hash={} metadata=None allowed (admin bypass)", hash);
         }
     }
 
@@ -1066,16 +1075,15 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
 
     // HEAD has no req/admin context. Banned/Restricted collapse to 404; AgeRestricted
     // surfaces as 401 so the client knows to age-gate.
-    let metadata = get_blob_metadata(&hash_lower)?;
-    if let Some(ref meta) = metadata {
-        match meta.access_for(None, false) {
-            BlobAccess::Allowed => {}
-            BlobAccess::NotFound => {
-                return Err(BlossomError::NotFound("Content not found".into()));
-            }
-            BlobAccess::AgeGated => {
-                return Err(BlossomError::AuthRequired("age_restricted".into()));
-            }
+    let metadata = get_blob_metadata(&hash_lower)?
+        .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
+    match metadata.access_for(None, false) {
+        BlobAccess::Allowed => {}
+        BlobAccess::NotFound => {
+            return Err(BlossomError::NotFound("Content not found".into()));
+        }
+        BlobAccess::AgeGated => {
+            return Err(BlossomError::AuthRequired("age_restricted".into()));
         }
     }
 
@@ -1099,14 +1107,11 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
             Ok(resp)
         }
         Err(BlossomError::NotFound(_)) if filename == "master.m3u8" => {
-            let meta = metadata
-                .as_ref()
-                .ok_or_else(|| BlossomError::NotFound("Content not found".into()))?;
             match decide_transcode_fetch_action(
-                meta.transcode_status,
-                meta.transcode_retry_after,
-                meta.transcode_attempt_count,
-                meta.transcode_terminal,
+                metadata.transcode_status,
+                metadata.transcode_retry_after,
+                metadata.transcode_attempt_count,
+                metadata.transcode_terminal,
                 unix_timestamp_secs(),
             ) {
                 TranscodeFetchAction::Accepted {
@@ -1123,7 +1128,7 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
                 }
                 TranscodeFetchAction::Terminal => Ok(derivative_failure_head_response(
                     &hash_lower,
-                    meta.transcode_error_code.as_deref(),
+                    metadata.transcode_error_code.as_deref(),
                     content_type,
                 )),
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,25 +422,32 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
 
         // Check parent video's moderation status - thumbnails inherit video access rules
         let mut is_restricted = false;
-        if let Ok(Some(meta)) = get_blob_metadata(video_hash) {
-            let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "thumbnail")?;
-            match meta.access_for(requester_pk.as_deref(), is_admin) {
-                BlobAccess::Allowed => {
-                    log_media_outcome("thumbnail", &auth_diagnostics, "allowed");
-                    // Authenticated access to restricted/age-restricted thumbnails
-                    // must stay private in cache below.
-                    if meta.status.requires_private_cache() {
-                        is_restricted = true;
+        match get_blob_metadata(video_hash)? {
+            Some(meta) => {
+                let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "thumbnail")?;
+                match meta.access_for(requester_pk.as_deref(), is_admin) {
+                    BlobAccess::Allowed => {
+                        log_media_outcome("thumbnail", &auth_diagnostics, "allowed");
+                        if meta.status.requires_private_cache() {
+                            is_restricted = true;
+                        }
+                    }
+                    BlobAccess::NotFound => {
+                        log_media_outcome("thumbnail", &auth_diagnostics, "not_found");
+                        return Err(BlossomError::NotFound("Blob not found".into()));
+                    }
+                    BlobAccess::AgeGated => {
+                        log_media_outcome("thumbnail", &auth_diagnostics, "age_gated");
+                        return Err(BlossomError::AuthRequired("age_restricted".into()));
                     }
                 }
-                BlobAccess::NotFound => {
-                    log_media_outcome("thumbnail", &auth_diagnostics, "not_found");
+            }
+            None => {
+                if !is_admin {
+                    eprintln!("[ACCESS] thumbnail hash={} metadata=None denied (non-admin)", video_hash);
                     return Err(BlossomError::NotFound("Blob not found".into()));
                 }
-                BlobAccess::AgeGated => {
-                    log_media_outcome("thumbnail", &auth_diagnostics, "age_gated");
-                    return Err(BlossomError::AuthRequired("age_restricted".into()));
-                }
+                eprintln!("[ACCESS] thumbnail hash={} metadata=None allowed (admin bypass)", video_hash);
             }
         }
 
@@ -609,6 +616,24 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
 fn handle_head_blob(path: &str) -> Result<Response> {
     // Check if this is a thumbnail request ({hash}.jpg)
     if let Some(thumbnail_key) = parse_thumbnail_path(path) {
+        let thumb_hash = thumbnail_key.trim_end_matches(".jpg");
+
+        // HEAD has no auth context — apply non-owner access rules.
+        match get_blob_metadata(thumb_hash)? {
+            Some(meta) => match meta.access_for(None, false) {
+                BlobAccess::Allowed => {}
+                BlobAccess::NotFound => {
+                    return Err(BlossomError::NotFound("Blob not found".into()));
+                }
+                BlobAccess::AgeGated => {
+                    return Err(BlossomError::AuthRequired("age_restricted".into()));
+                }
+            },
+            None => {
+                return Err(BlossomError::NotFound("Blob not found".into()));
+            }
+        }
+
         let resp = download_thumbnail(&thumbnail_key)?;
         let content_length = resp
             .get_header_str("x-goog-stored-content-length")
@@ -618,7 +643,6 @@ fn handle_head_blob(path: &str) -> Result<Response> {
         let mut head_resp = Response::from_status(StatusCode::OK);
         head_resp.set_header("Content-Type", "image/jpeg");
         head_resp.set_header("Content-Length", &content_length);
-        let thumb_hash = thumbnail_key.trim_end_matches(".jpg");
         add_cache_headers(&mut head_resp, thumb_hash);
         head_resp.set_header("Accept-Ranges", "bytes");
         add_cors_headers(&mut head_resp);
@@ -2004,20 +2028,29 @@ fn handle_get_subtitle_by_hash(req: Request, path: &str) -> Result<Response> {
     // Don't leak subtitle info for moderated content. Use the blob's access_for so
     // age-restricted videos surface as 401 (age gate) instead of 404.
     let is_admin = admin::validate_bearer_token(&req).is_ok();
-    if let Some(meta) = get_blob_metadata(&hash)? {
-        let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "subtitle_by_hash")?;
-        match meta.access_for(requester_pk.as_deref(), is_admin) {
-            BlobAccess::Allowed => {
-                log_media_outcome("subtitle_by_hash", &auth_diagnostics, "allowed")
+    match get_blob_metadata(&hash)? {
+        Some(meta) => {
+            let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "subtitle_by_hash")?;
+            match meta.access_for(requester_pk.as_deref(), is_admin) {
+                BlobAccess::Allowed => {
+                    log_media_outcome("subtitle_by_hash", &auth_diagnostics, "allowed")
+                }
+                BlobAccess::NotFound => {
+                    log_media_outcome("subtitle_by_hash", &auth_diagnostics, "not_found");
+                    return Err(BlossomError::NotFound("Video hash not found".into()));
+                }
+                BlobAccess::AgeGated => {
+                    log_media_outcome("subtitle_by_hash", &auth_diagnostics, "age_gated");
+                    return Err(BlossomError::AuthRequired("age_restricted".into()));
+                }
             }
-            BlobAccess::NotFound => {
-                log_media_outcome("subtitle_by_hash", &auth_diagnostics, "not_found");
+        }
+        None => {
+            if !is_admin {
+                eprintln!("[ACCESS] subtitle hash={} metadata=None denied (non-admin)", hash);
                 return Err(BlossomError::NotFound("Video hash not found".into()));
             }
-            BlobAccess::AgeGated => {
-                log_media_outcome("subtitle_by_hash", &auth_diagnostics, "age_gated");
-                return Err(BlossomError::AuthRequired("age_restricted".into()));
-            }
+            eprintln!("[ACCESS] subtitle hash={} metadata=None allowed (admin bypass)", hash);
         }
     }
 


### PR DESCRIPTION
Refs #109

## Summary

Fixes the metadata-None access-control bypass in the following blob-serving paths:

- `handle_get_blob` main blob path: `None` metadata now returns 404 for non-admin requests and allows admin preview of orphaned blobs.
- `handle_head_hls_content`: `None` metadata now returns 404 instead of falling through to HEAD existence checks.
- `handle_get_blob` thumbnail subpath: `if let Ok(Some(...))` now uses explicit metadata handling so `None` returns 404 for non-admin requests and KV errors propagate as 5xx.
- `handle_get_subtitle_by_hash`: `None` metadata no longer falls through to subtitle job lookup.
- `handle_head_blob` thumbnail path: now applies metadata-based access control before returning 200 plus `Content-Length`.

The remaining same-class path, `handle_get_hls_content`, is fixed separately in #111.

## Root cause

When KV metadata is missing (for example after `vanish` deletes metadata but GCS bytes survive), the original `if let Some(...)` / `if let Ok(Some(...))` patterns skipped access control entirely and fell through to storage-backed responses.

Several of those sites were also swallowing KV errors as “no metadata, allow” rather than failing closed.

## Scope

This PR fixes the metadata-None bypass everywhere listed above.

`handle_get_hls_content` is intentionally left to #111 to avoid duplicate commits. The full issue #109 remediation is the combination of #110 and #111.

## Test plan

- `cargo check --tests` passes (CI equivalent for Fastly Compute crate)
- `cargo clippy --all-targets --all-features` clean
- CI green
- [ ] Deploy to staging and verify:
  - blob with no metadata returns 404 for non-admin requests
  - admin bearer token still bypasses for orphaned blob preview
  - thumbnail GET/HEAD for deleted metadata returns 404 for non-admin requests
  - subtitle-by-hash no longer returns job data when metadata is missing
