### PR TITLE
fix: return 404 in handle_get_hls_content when blob metadata is None for non-admin requests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -890,23 +890,44 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
     let is_admin = admin::validate_bearer_token(&req).is_ok();
     let mut is_restricted = false;
 
-    if let Ok(Some(ref meta)) = get_blob_metadata(&hash) {
-        let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "hls_content")?;
-        match meta.access_for(requester_pk.as_deref(), is_admin) {
-            BlobAccess::Allowed => {
-                log_media_outcome("hls_content", &auth_diagnostics, "allowed");
-                if meta.status.requires_private_cache() {
-                    is_restricted = true;
+    // Propagate KV errors instead of swallowing them as "no metadata, allow":
+    // a transient KV failure must fail closed so we don't leak HLS variants
+    // for moderated/vanished blobs.
+    match get_blob_metadata(&hash)? {
+        Some(ref meta) => {
+            let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "hls_content")?;
+            match meta.access_for(requester_pk.as_deref(), is_admin) {
+                BlobAccess::Allowed => {
+                    log_media_outcome("hls_content", &auth_diagnostics, "allowed");
+                    if meta.status.requires_private_cache() {
+                        is_restricted = true;
+                    }
+                }
+                BlobAccess::NotFound => {
+                    log_media_outcome("hls_content", &auth_diagnostics, "not_found");
+                    return Err(BlossomError::NotFound("Blob not found".into()));
+                }
+                BlobAccess::AgeGated => {
+                    log_media_outcome("hls_content", &auth_diagnostics, "age_gated");
+                    return Err(BlossomError::AuthRequired("age_restricted".into()));
                 }
             }
-            BlobAccess::NotFound => {
-                log_media_outcome("hls_content", &auth_diagnostics, "not_found");
-                return Err(BlossomError::NotFound("Blob not found".into()));
+        }
+        None => {
+            // Metadata may be missing because vanish/soft-delete removed it while
+            // GCS bytes survive. Mirror handle_get_blob: 404 for non-admin, log
+            // and allow admin so the moderation proxy can preview orphaned bytes.
+            if !is_admin {
+                eprintln!(
+                    "[ACCESS] hash={} metadata=None denied (no metadata, non-admin, hls_content)",
+                    hash
+                );
+                return Err(BlossomError::NotFound("Content not found".into()));
             }
-            BlobAccess::AgeGated => {
-                log_media_outcome("hls_content", &auth_diagnostics, "age_gated");
-                return Err(BlossomError::AuthRequired("age_restricted".into()));
-            }
+            eprintln!(
+                "[ACCESS] hash={} metadata=None allowed (admin bypass, hls_content)",
+                hash
+            );
         }
     }
 


### PR DESCRIPTION
Follow-up to #110 (which closes #109). The audit in #110 missed the same
metadata-None access-control bypass in `handle_get_hls_content` — the GET
sibling of `handle_head_hls_content`.

## Summary

- `handle_get_hls_content` (`src/main.rs:893` pre-patch): `if let Ok(Some(ref meta)) = get_blob_metadata(&hash) { … access_for(…) … }` silently fell through to `download_hls_content(&gcs_path, None)` on both `Ok(None)` and `Err(_)`, serving HLS variant playlists and `.ts` segments from GCS regardless of moderation/vanish state.
- Strictly worse than the original bug: `if let Ok(Some(...))` also swallowed transient KV errors as "no metadata, allow" rather than failing closed.
- Replaced with `match get_blob_metadata(&hash)? { … }`:
  - `?` propagates KV errors so we fail closed on transient failures.
  - `None` arm mirrors the new policy in `handle_get_blob` from #110: 404 for non-admin, log + allow for admin so the moderation proxy can still preview orphaned bytes.
- The inner `Err(NotFound) if filename == "master.m3u8"` fallback (lines ~951–1020) was already correct (`if let Some(ref meta) … else { Err(NotFound) }`) and is unchanged.

## Motivation

`vanish()` (`src/main.rs:execute_vanish`) deletes `blob_metadata` synchronously, but `delete_blob_gcs_artifacts` is best-effort with a fire-and-forget Cloud Run cleanup. Any HLS file that survives the local `storage_delete` calls — failures, races, or paths the deterministic list doesn't enumerate — remains addressable. Without metadata, `handle_get_hls_content`'s `if let Ok(Some)` skipped access control entirely and served those bytes.

Reachability is the same vanish-style scenario described in #109; the GET path leaks the actual video content (segments + variant playlists), so this is at least as severe as the `handle_get_blob` case fixed in #110.

#110 had this in its description:
> All other blob-serving endpoints audited and confirmed safe (already use `ok_or_else` or explicit else-return-404).

That is true for `handle_head_blob`, `handle_get_hls_master`, `handle_head_hls_master`, `serve_transcript_by_hash`, `handle_head_transcript_by_hash`, and `handle_get_quality_variant`, but **not** for the primary path of `handle_get_hls_content`. This PR closes that remaining gap.

## Changes

- `src/main.rs` `handle_get_hls_content`: `if let Ok(Some(...))` → `match get_blob_metadata(&hash)?`, with explicit `None` arm matching `handle_get_blob`'s admin-bypass policy from #110.
- No behavioral change for the happy path (metadata present, access allowed): same access_for switch, same `is_restricted` propagation.

## Linked issues

- Refs #109 (does not close it on its own; #110 still does the primary fix)
- Follow-up to #110

## Test plan

- [x] `cargo check --tests --locked` passes
- [x] `cargo clippy --locked --all-targets --all-features` clean (only pre-existing warnings unrelated to this change)
- [ ] Deploy to staging after #110, verify:
  - HLS variant request (`GET /<hash>/hls/stream_720p.ts`) for a hash with deleted metadata returns 404 for unauthenticated/non-admin requesters.
  - Same request with the admin Bearer token still serves the GCS bytes (orphan-preview path) and emits `[ACCESS] hash=… metadata=None allowed (admin bypass, hls_content)`.
  - HLS variant request for an active blob (metadata present) is unaffected.

## No visual change

This is an edge-server access-control fix; no UI/API contract changes for blobs that have metadata. Only post-vanish/post-soft-delete blobs see new 404s where they previously leaked.