### PR TITLE
fix(transcoder): drop Chirp 3 non-speech garbage (dash spam from music)

### DIFF
--- a/cloud-run-transcoder/scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/scan_and_repair_vtts.py
@@ -268,6 +268,29 @@ def is_loop_hallucination(text: str) -> bool:
             return True
 
 
+def is_non_speech_garbage(text: str) -> bool:
+    """Mirror of `is_non_speech_garbage` in transcription_google_stt_v2.rs.
+
+    Catches Chirp 3's failure mode on music/non-speech audio where the
+    response is mostly dashes or single-character tokens. Fires when the
+    transcript is at least 60 chars AND either:
+      - alphanum chars cover < 35% of total, or
+      - dash-only tokens are > 30% of whitespace-separated tokens.
+    """
+    trimmed = text.strip()
+    if len(trimmed) < 60:
+        return False
+    total = len(trimmed)
+    alpha = sum(1 for c in trimmed if c.isalnum())
+    if alpha / total < 0.35:
+        return True
+    tokens = trimmed.split()
+    if not tokens:
+        return False
+    dash_only = sum(1 for t in tokens if all(c == "-" for c in t))
+    return dash_only / len(tokens) > 0.30
+
+
 def is_repeated_phrase_hallucination(text: str) -> bool:
     """Token-level n-gram dominance guard.
 
@@ -307,6 +330,8 @@ def classify_vtt(body: str, *, check_empty: bool) -> str | None:
     text = vtt_spoken_text(body)
     if check_empty and is_empty_text(text):
         return "empty"
+    if is_non_speech_garbage(text):
+        return "non_speech_garbage"
     if is_loop_hallucination(text):
         return "loop_hallucination"
     if is_repeated_phrase_hallucination(text):

--- a/cloud-run-transcoder/src/transcription_google_stt_v2.rs
+++ b/cloud-run-transcoder/src/transcription_google_stt_v2.rs
@@ -457,6 +457,7 @@ pub(crate) fn is_repeated_phrase_hallucination(text: &str) -> bool {
 pub(crate) enum GoogleDropReason {
     JsonArtifact,
     RepeatedPhrase,
+    NonSpeechGarbage,
 }
 
 pub(crate) fn google_drop_reason(parsed: &ParsedVtt) -> Option<GoogleDropReason> {
@@ -475,7 +476,41 @@ pub(crate) fn google_drop_reason(parsed: &ParsedVtt) -> Option<GoogleDropReason>
     if is_repeated_phrase_hallucination(&parsed.text) {
         return Some(GoogleDropReason::RepeatedPhrase);
     }
+    if is_non_speech_garbage(&parsed.text) {
+        return Some(GoogleDropReason::NonSpeechGarbage);
+    }
     None
+}
+
+/// Drop the transcript when Chirp 3 returns mostly punctuation/dash tokens
+/// or one-character "words" — the failure mode it exhibits when fed
+/// non-speech audio (music, ambient noise, sound effects). Real production
+/// case sha256 d8cae7fd...: cue body had alphanum_ratio=0.005,
+/// dash_token_ratio=0.995, then 20 more cues each one character long.
+///
+/// Triggers when the transcript is at least 60 chars AND any of:
+///   - Less than 35% of characters are alphanumeric
+///   - More than 30% of whitespace-separated tokens are pure dashes
+pub(crate) fn is_non_speech_garbage(text: &str) -> bool {
+    let trimmed = text.trim();
+    if trimmed.chars().count() < 60 {
+        return false;
+    }
+    let total = trimmed.chars().count();
+    let alpha = trimmed.chars().filter(|c| c.is_alphanumeric()).count();
+    let alpha_ratio = alpha as f64 / total as f64;
+    if alpha_ratio < 0.35 {
+        return true;
+    }
+    let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+    if tokens.is_empty() {
+        return false;
+    }
+    let dash_only = tokens
+        .iter()
+        .filter(|t| t.chars().all(|c| c == '-'))
+        .count();
+    (dash_only as f64) / (tokens.len() as f64) > 0.30
 }
 
 /// Whether word-level timestamps, degraded single-cue, or empty output was
@@ -898,6 +933,47 @@ mod tests {
         assert_eq!(
             google_drop_reason(&parsed),
             Some(GoogleDropReason::JsonArtifact)
+        );
+    }
+
+    #[test]
+    fn non_speech_garbage_is_flagged_dash_spam() {
+        // Real production case (sha256 d8cae7fd...) where Chirp 3 fed
+        // music/non-speech audio emitted a token cloud of single dashes.
+        let text = "Ever heard of a sweetie-holic?!-! --- --- --- --- --- --- -- --- -- --- -- - - - --- -- - --- --- - --- - -- - -- --- --- -- - - - -- - - -- -- - -- - - - -- -- - - -- -- --- -- - - - - -- --- -- - - - - - - --- --- ---";
+        assert!(is_non_speech_garbage(text));
+    }
+
+    #[test]
+    fn non_speech_garbage_short_text_is_not_flagged() {
+        // Below the 60-char floor — legitimate punctuation-heavy short
+        // utterances ("Wait... what?!") shouldn't trip the guard.
+        assert!(!is_non_speech_garbage("Wait... what?!"));
+        assert!(!is_non_speech_garbage("--- ok"));
+    }
+
+    #[test]
+    fn non_speech_garbage_normal_text_is_not_flagged() {
+        // Long real-speech transcript (200+ chars, normal punctuation
+        // density) must stay under both thresholds.
+        let text = "Hello and welcome to the show today, where we discuss the latest in technology, business, and culture. Today we have a special guest joining us to talk about their recent project.";
+        assert!(!is_non_speech_garbage(text));
+    }
+
+    #[test]
+    fn google_guard_drops_non_speech_garbage() {
+        let dash_body = "Ever heard of a sweetie-holic?!-! --- --- --- --- --- --- -- --- -- --- -- - - - --- -- - --- --- - --- - -- - -- --- --- -- - - - -- - - -- -- - -- - - - -- -- - - -- -- --- -- - - - - -- --- -- - - - - - - --- --- ---";
+        let parsed = ParsedVtt {
+            content: String::new(),
+            text: dash_body.into(),
+            language: None,
+            duration_ms: 1000,
+            cue_count: 1,
+            confidence: None,
+        };
+        assert_eq!(
+            google_drop_reason(&parsed),
+            Some(GoogleDropReason::NonSpeechGarbage)
         );
     }
 


### PR DESCRIPTION
## Summary

Chirp 3 fed non-speech audio (music, ambient noise) sometimes returns a hallucinated transcript followed by a long tail of single-dash tokens. Real production case sha256 \`d8cae7fd...\` had a 14,755-char transcript that was 99.5% dash tokens / 0.5% alphanumeric, then 20 broken single-character cues with overlapping zero-base timestamps. (Example URL in test fixture comment.)

Adds \`is_non_speech_garbage\` guard, wired as the third check in \`google_drop_reason\`. Fires when transcript ≥ 60 chars AND either alphanum coverage < 35% OR dash-only tokens > 30% of total. Mirrors the same heuristic in the scanner Python so operators can find existing bad VTTs and trigger retranscription.

## Why now

User flagged the pattern in production today: \"i think it's taking music and other sounds and making them into something which we shouldn't be doing.\" Confirmed by inspecting the example VTT: alphanum_ratio=0.005, dash_ratio=0.995, 91% single-character cues, duplicate consecutive cues.

## Caveats

- This fixes the worst-shaped output but doesn't prevent Chirp 3 from being asked to transcribe music in the first place. Long-term, a speech/music classifier upstream would avoid the round trip; for now the guard ensures music-only clips render as empty VTT (correct).
- Other related failure modes are not addressed: model meta-commentary (\"Segment starts at 0.679...\"), brand-name mistranscription (\"Devine\" vs \"Divine\"). Those need separate guards/post-process.

## Test plan

- [x] \`cargo test --bin divine-transcoder\`: 76 passed (was 72 + 4 new)
- [x] Python \`is_non_speech_garbage\` confirmed against the live production VTT and against false-positive controls (\"Wait... what?!\", normal speech)
- [ ] Deploy + run scanner across recent + popular to find existing bad ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)