### PR TITLE
fix(transcoder): unwrap JSON envelopes from LLM transcript responses

### DIFF
--- a/cloud-run-transcoder/scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/scan_and_repair_vtts.py
@@ -33,6 +33,20 @@ JSON_CORRUPTION_MARKERS = (
     '"finish_reason"',
 )
 
+# Distinct STT-response key names. >=2 of these together signal a leaked
+# JSON envelope (Gemini sometimes emits one instead of plain transcript).
+JSON_ENVELOPE_KEYS = (
+    '"language"',
+    '"segments"',
+    '"transcript"',
+    '"start":',
+    '"end":',
+    '"text":',
+    '"words":',
+    '"alternatives":',
+    '"results":',
+)
+
 # Mirrors cloud-run-transcoder/src/main.rs `is_loop_hallucination` and
 # `is_repeated_phrase_hallucination`. Keep parameters in lockstep so the
 # scanner flags exactly what the deployed service would reject.
@@ -242,6 +256,16 @@ def has_json_artifact(body: str) -> bool:
     return any(marker in body for marker in JSON_CORRUPTION_MARKERS)
 
 
+def has_json_envelope_leak(text: str) -> bool:
+    """True if the text contains >=2 distinct STT-response JSON keys.
+
+    Catches Gemini's "I returned an envelope instead of plain text" mode.
+    Conservative: a transcript that legitimately mentions one technical
+    term won't fire (needs at least two co-occurring quoted keys).
+    """
+    return sum(1 for k in JSON_ENVELOPE_KEYS if k in text) >= 2
+
+
 def is_loop_hallucination(text: str) -> bool:
     """Sentence-level autoregressive loop guard.
 
@@ -305,6 +329,8 @@ def classify_vtt(body: str, *, check_empty: bool) -> str | None:
     if has_json_artifact(body):
         return "json_artifact"
     text = vtt_spoken_text(body)
+    if has_json_envelope_leak(text):
+        return "json_envelope_leak"
     if check_empty and is_empty_text(text):
         return "empty"
     if is_loop_hallucination(text):

--- a/cloud-run-transcoder/src/transcription_google_stt_v2.rs
+++ b/cloud-run-transcoder/src/transcription_google_stt_v2.rs
@@ -164,12 +164,164 @@ pub(crate) fn group_words_into_cues(words: &[SttWord]) -> Vec<Cue> {
     cues
 }
 
+/// Try to extract spoken text when the model returned a JSON envelope
+/// instead of plain text (e.g. Gemini emitting
+/// `{"language":"en","segments":[{"start":0.4,"text":"Hey guys..."}]}`).
+///
+/// Returns `Some(extracted_text)` if the input was JSON-shaped AND yielded
+/// useful text. Returns `None` for plain text (caller uses original) or
+/// when extraction yields nothing.
+///
+/// Handles three shapes:
+/// 1. Clean JSON via serde — walks `text`, `transcript`, `segments[].text`,
+///    or `results[].alternatives[0].transcript` fields.
+/// 2. Truncated/malformed JSON via byte-walking: scans for `"text":"..."`
+///    occurrences and joins them, accepting a missing closing quote at the
+///    end of the input (the most common truncation pattern).
+pub(crate) fn unwrap_json_envelope(text: &str) -> Option<String> {
+    let trimmed = text.trim();
+    if !trimmed.starts_with('{') && !trimmed.starts_with('[') {
+        return None;
+    }
+
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        if let Some(out) = extract_text_from_json_value(&value) {
+            let cleaned = out.trim().to_string();
+            if !cleaned.is_empty() {
+                return Some(cleaned);
+            }
+        }
+    }
+
+    // Truncated or malformed — best-effort regex-equivalent scan.
+    let parts = scan_text_fields(trimmed);
+    if parts.is_empty() {
+        return None;
+    }
+    let joined = parts.join(" ").trim().to_string();
+    if joined.is_empty() {
+        None
+    } else {
+        Some(joined)
+    }
+}
+
+fn extract_text_from_json_value(v: &serde_json::Value) -> Option<String> {
+    // Top-level transcript / text (Whisper verbose, OpenAI, generic).
+    for key in &["transcript", "text"] {
+        if let Some(s) = v.get(key).and_then(|x| x.as_str()) {
+            return Some(s.to_string());
+        }
+    }
+    // Gemini-style: { segments: [{ text: "..." }, ...] }
+    if let Some(segments) = v.get("segments").and_then(|x| x.as_array()) {
+        let parts: Vec<String> = segments
+            .iter()
+            .filter_map(|s| s.get("text").and_then(|t| t.as_str()).map(str::to_string))
+            .collect();
+        if !parts.is_empty() {
+            return Some(parts.join(" "));
+        }
+    }
+    // Google STT V2: { results: [{ alternatives: [{ transcript: "..." }] }] }
+    if let Some(results) = v.get("results").and_then(|x| x.as_array()) {
+        let parts: Vec<String> = results
+            .iter()
+            .filter_map(|r| {
+                r.get("alternatives")
+                    .and_then(|a| a.as_array())
+                    .and_then(|arr| arr.first())
+                    .and_then(|alt| alt.get("transcript"))
+                    .and_then(|t| t.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        if !parts.is_empty() {
+            return Some(parts.join(" "));
+        }
+    }
+    None
+}
+
+/// Permissive byte-walker: scans for `"text"` keys followed by `:` and a
+/// quoted string value. Used when serde_json fails (truncated input).
+/// Accepts a missing closing quote at the very end of input as the value
+/// running to end-of-input.
+fn scan_text_fields(input: &str) -> Vec<String> {
+    let bytes = input.as_bytes();
+    let needle = b"\"text\"";
+    let mut out: Vec<String> = Vec::new();
+    let mut i = 0usize;
+    while i + needle.len() <= bytes.len() {
+        if &bytes[i..i + needle.len()] != needle {
+            i += 1;
+            continue;
+        }
+        let mut j = i + needle.len();
+        // Skip whitespace then expect ':'.
+        while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n') {
+            j += 1;
+        }
+        if j >= bytes.len() || bytes[j] != b':' {
+            i += 1;
+            continue;
+        }
+        j += 1;
+        while j < bytes.len() && (bytes[j] == b' ' || bytes[j] == b'\t' || bytes[j] == b'\n') {
+            j += 1;
+        }
+        if j >= bytes.len() || bytes[j] != b'"' {
+            i += 1;
+            continue;
+        }
+        j += 1;
+        let value_start = j;
+        // Walk until unescaped `"` or end of input.
+        let mut value_end_excl = bytes.len();
+        while j < bytes.len() {
+            match bytes[j] {
+                b'\\' if j + 1 < bytes.len() => j += 2,
+                b'"' => {
+                    value_end_excl = j;
+                    break;
+                }
+                _ => j += 1,
+            }
+        }
+        // Slice safely on UTF-8 boundary by snapping to a known char start.
+        let raw = std::str::from_utf8(&bytes[value_start..value_end_excl]).unwrap_or("");
+        let unescaped = raw
+            .replace("\\\"", "\"")
+            .replace("\\n", "\n")
+            .replace("\\t", "\t")
+            .replace("\\\\", "\\");
+        let cleaned = unescaped.trim().to_string();
+        if !cleaned.is_empty() {
+            out.push(cleaned);
+        }
+        i = value_end_excl + 1;
+    }
+    out
+}
+
 pub(crate) fn transcript_only_to_parsed_vtt(
     transcript: &str,
     language: Option<String>,
     audio_duration_ms: u64,
 ) -> ParsedVtt {
-    let trimmed = transcript.trim();
+    // First, try to unwrap a JSON envelope. Some providers (notably
+    // Gemini) sometimes emit `{"language":"en","segments":[{"text":"..."}]}`
+    // instead of plain text. When that happens we want to preserve the
+    // real transcript inside the envelope rather than render the JSON
+    // syntax to viewers.
+    let unwrapped: String;
+    let trimmed: &str = match unwrap_json_envelope(transcript) {
+        Some(extracted) => {
+            unwrapped = extracted;
+            unwrapped.as_str()
+        }
+        None => transcript.trim(),
+    };
     if trimmed.is_empty() {
         return ParsedVtt {
             content: "WEBVTT\n\n".to_string(),
@@ -531,6 +683,60 @@ pub(crate) fn parse_response_to_parsed_vtt(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unwrap_envelope_handles_clean_gemini_segments() {
+        let json = r#"{"language":"en","segments":[{"start":0.4,"text":"Hey guys"},{"start":1.2,"text":"my name's Tristan"}]}"#;
+        assert_eq!(
+            unwrap_json_envelope(json).as_deref(),
+            Some("Hey guys my name's Tristan")
+        );
+    }
+
+    #[test]
+    fn unwrap_envelope_handles_top_level_text() {
+        let json = r#"{"text":"Hello world","language":"en"}"#;
+        assert_eq!(unwrap_json_envelope(json).as_deref(), Some("Hello world"));
+    }
+
+    #[test]
+    fn unwrap_envelope_handles_truncated_envelope() {
+        // Real production case sha256 26e4bece...: Gemini emitted a
+        // structurally-broken envelope (no closing quote/brackets) with
+        // the actual transcript inside the first text field.
+        let bad = "{ \"language\": \"en\", \"segments\": [ { \"start\": 0.403, \"text\": \"Hey guys, my name's Tristan. I'm just trying to use this platform to make y'all laugh and be happy. Thank you all.  Here is the JSON requested:";
+        let extracted = unwrap_json_envelope(bad)
+            .expect("scan_text_fields should recover the transcript from truncated JSON");
+        assert!(
+            extracted.starts_with("Hey guys, my name's Tristan."),
+            "extracted = {extracted:?}"
+        );
+        assert!(
+            extracted.contains("happy. Thank you all."),
+            "extracted = {extracted:?}"
+        );
+    }
+
+    #[test]
+    fn unwrap_envelope_returns_none_for_plain_text() {
+        assert_eq!(unwrap_json_envelope("Hello world this is a normal sentence"), None);
+    }
+
+    #[test]
+    fn unwrap_envelope_returns_none_for_empty_json() {
+        // Pure JSON with no extractable text — caller should fall back.
+        assert_eq!(unwrap_json_envelope("{}"), None);
+        assert_eq!(unwrap_json_envelope("[]"), None);
+    }
+
+    #[test]
+    fn transcript_only_unwraps_envelope_in_pipeline() {
+        let bad = r#"{"language":"en","segments":[{"text":"Hello there"}]}"#;
+        let parsed = transcript_only_to_parsed_vtt(bad, Some("en".into()), 5_000);
+        assert_eq!(parsed.text, "Hello there");
+        assert!(parsed.content.contains("Hello there"));
+        assert!(!parsed.content.contains("\"language\""));
+    }
 
     #[test]
     fn limits_are_sane() {


### PR DESCRIPTION
## Summary

Some providers (notably Gemini) sometimes return a JSON envelope instead of plain transcript text. Real production case sha256 \`26e4bece...\` rendered \`{ \"language\": \"en\", \"segments\": [ { \"start\": 0.403, \"text\": \"Hey guys, my name's Tristan...\" }\` etc. directly into the VTT cue body — unreadable subtitles even though the actual speech was transcribed correctly.

Better than dropping the whole transcript: **parse the envelope and extract the real transcript inside**. Adds \`unwrap_json_envelope\` with two stages:

1. \`serde_json\` parse, walking known STT response shapes (top-level \`text\`/\`transcript\`, \`segments[].text\`, \`results[].alternatives[0].transcript\`).
2. Permissive byte-walker fallback for truncated/malformed JSON that scans for \`\"text\":\"...\"\` patterns and accepts a missing closing quote at end-of-input (the production failure mode).

Wired into \`transcript_only_to_parsed_vtt\` so Gemini-style providers benefit transparently. Plain text passes through unchanged.

## Why parse instead of drop

User direction: *\"we need to be able to handle a json response and not expect that the LLM will always give us plain text.\"* Dropping would lose the actual transcribed speech — \"Hey guys, my name's Tristan...\" was correct, only the wrapper was bad.

## Scanner side

Adds \`has_json_envelope_leak\` to \`scan_and_repair_vtts.py\` so operators can find existing bad VTTs and trigger retranscription. Threshold: 2+ quoted STT-response keys co-occurring (conservative, won't fire on legitimate speech mentioning a single technical term).

## Test plan

- [x] \`cargo test --bin divine-transcoder\`: 78 passed (was 72 + 6 new)
- [x] Production fixture (truncated envelope) extracts \"Hey guys, my name's Tristan. ...\"
- [x] Clean Gemini-style envelope extracts segment text correctly
- [x] Plain text input passes through unchanged
- [x] Empty JSON \`{}\` returns None (caller falls back to original input)
- [x] Python detector flags the production sha as \`json_envelope_leak\` and does NOT flag a normal transcript or one that mentions a single JSON term
- [ ] Deploy + run scanner across recent + popular to retranscribe existing bad VTTs

## Caveats

- The byte-walker only extracts \`\"text\":\"...\"\` matches — won't catch envelope shapes that store the transcript under a different key (e.g. \`\"transcript\":\"...\"\` in a malformed envelope). Clean serde_json parse handles those when JSON is well-formed; could extend the walker if production data shows the need.
- Stacks cleanly with PRs #115, #116, #117, #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)