### PR TITLE
fix(transcoder): use per-request language hint for Chirp 3 and Gemini

### DIFF
--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -2507,12 +2507,32 @@ async fn fetch_gcp_access_token() -> std::result::Result<String, ProviderFailure
     }
 }
 
+/// Build the Gemini transcription prompt, optionally biased to a specific
+/// language. Empty/auto/und sentinels fall through to the generic prompt
+/// so the model is free to detect the language itself.
+fn build_gemini_prompt(language: Option<&str>) -> String {
+    let base = "Transcribe this audio. Return every spoken segment with start and end timestamps in seconds and the text. If there is no speech, return an empty segments array.";
+    match language {
+        Some(lang)
+            if !lang.trim().is_empty()
+                && !lang.eq_ignore_ascii_case("auto")
+                && !lang.eq_ignore_ascii_case("und") =>
+        {
+            format!(
+                "Transcribe this audio in {}. Return every spoken segment with start and end timestamps in seconds and the text. If there is no speech, return an empty segments array.",
+                lang.trim()
+            )
+        }
+        _ => base.to_string(),
+    }
+}
+
 /// Transcribe audio using Gemini via Vertex AI generateContent.
 /// Returns raw JSON text with segments and timestamps.
 async fn transcribe_via_gemini(
     config: &Config,
     audio_path: &Path,
-    _language: Option<&str>,
+    language: Option<&str>,
 ) -> std::result::Result<String, ProviderFailure> {
     let audio_bytes = tokio::fs::read(audio_path).await.map_err(|e| {
         parse_provider_status(None, None, &format!("Failed to read audio: {}", e), false)
@@ -2526,11 +2546,13 @@ async fn transcribe_via_gemini(
         config.gcp_region, config.gcp_project_id, config.gcp_region, config.transcription_model,
     );
 
+    let prompt = build_gemini_prompt(language);
+
     let body = serde_json::json!({
         "contents": [{
             "role": "user",
             "parts": [
-                {"text": "Transcribe this audio. Return every spoken segment with start and end timestamps in seconds and the text. If there is no speech, return an empty segments array."},
+                {"text": prompt},
                 {"inlineData": {"mimeType": "audio/wav", "data": audio_b64}}
             ]
         }],
@@ -3503,6 +3525,28 @@ mod tests {
             .expect("plain text should still work");
         assert!(parsed.content.starts_with("WEBVTT"));
         assert_eq!(parsed.text, "This is spoken text from the video");
+    }
+
+    // ---- gemini prompt tests ----
+
+    #[test]
+    fn gemini_prompt_uses_language_when_provided() {
+        let prompt = super::build_gemini_prompt(Some("Spanish"));
+        assert!(prompt.contains("in Spanish"));
+        let prompt_es = super::build_gemini_prompt(Some("es-ES"));
+        assert!(prompt_es.contains("in es-ES"));
+    }
+
+    #[test]
+    fn gemini_prompt_omits_language_for_sentinels() {
+        let generic = super::build_gemini_prompt(None);
+        for sentinel in &["", "  ", "auto", "AUTO", "und"] {
+            let prompt = super::build_gemini_prompt(Some(*sentinel));
+            assert_eq!(
+                prompt, generic,
+                "sentinel `{sentinel}` should produce generic prompt"
+            );
+        }
     }
 
     // ---- loop-hallucination guard tests ----

--- a/cloud-run-transcoder/src/transcription_google_stt_v2.rs
+++ b/cloud-run-transcoder/src/transcription_google_stt_v2.rs
@@ -48,12 +48,27 @@ pub(crate) fn recognize_url(config: &Config) -> String {
     )
 }
 
-pub(crate) fn build_recognize_request(config: &Config, audio_bytes: &[u8]) -> String {
+pub(crate) fn build_recognize_request(
+    config: &Config,
+    audio_bytes: &[u8],
+    language: Option<&str>,
+) -> String {
     let audio_b64 = base64::engine::general_purpose::STANDARD.encode(audio_bytes);
+    // Per-request language wins over the env-default. Empty / "auto" / "und"
+    // fall through to the configured codes (multi-language detection).
+    let language_codes: Vec<String> = match language {
+        Some(lang) if !lang.trim().is_empty()
+            && !lang.eq_ignore_ascii_case("auto")
+            && !lang.eq_ignore_ascii_case("und") =>
+        {
+            vec![lang.trim().to_string()]
+        }
+        _ => config.google_stt_language_codes.clone(),
+    };
     let body = serde_json::json!({
         "config": {
             "model": config.google_stt_model,
-            "languageCodes": config.google_stt_language_codes,
+            "languageCodes": language_codes,
             "features": {
                 "enableAutomaticPunctuation": config.google_stt_enable_automatic_punctuation,
                 "enableWordTimeOffsets": config.google_stt_enable_word_time_offsets,
@@ -313,7 +328,7 @@ pub(crate) fn parse_stt_v2_response(
 pub(crate) async fn transcribe(
     config: &Config,
     audio_path: &Path,
-    _language: Option<&str>,
+    language: Option<&str>,
 ) -> std::result::Result<String, ProviderFailure> {
     let audio_bytes = tokio::fs::read(audio_path).await.map_err(|e| {
         parse_provider_status(None, None, &format!("Failed to read audio: {}", e), false)
@@ -335,7 +350,7 @@ pub(crate) async fn transcribe(
 
     let access_token = crate::fetch_gcp_access_token().await?;
     let url = recognize_url(config);
-    let body = build_recognize_request(config, &audio_bytes);
+    let body = build_recognize_request(config, &audio_bytes, language);
 
     let client = reqwest::Client::new();
     let response = client
@@ -544,7 +559,7 @@ mod tests {
     #[test]
     fn builds_recognize_request_body_with_word_offsets() {
         let cfg = test_config();
-        let body = build_recognize_request(&cfg, &b"FAKE_WAV_BYTES"[..]);
+        let body = build_recognize_request(&cfg, &b"FAKE_WAV_BYTES"[..], None);
         let v: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
         assert_eq!(v["config"]["model"], "chirp_3");
         assert_eq!(v["config"]["languageCodes"][0], "en-US");
@@ -559,6 +574,32 @@ mod tests {
             .decode(v["content"].as_str().unwrap())
             .expect("content is valid base64");
         assert_eq!(decoded, b"FAKE_WAV_BYTES");
+    }
+
+    #[test]
+    fn build_recognize_uses_per_request_language_when_provided() {
+        let cfg = test_config();
+        let body = build_recognize_request(&cfg, &b"x"[..], Some("es-ES"));
+        let v: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(v["config"]["languageCodes"][0], "es-ES");
+        assert_eq!(
+            v["config"]["languageCodes"].as_array().unwrap().len(),
+            1,
+            "explicit language overrides multi-code default"
+        );
+    }
+
+    #[test]
+    fn build_recognize_falls_back_to_config_for_auto_or_empty_language() {
+        let cfg = test_config();
+        for sentinel in &["", "  ", "auto", "AUTO", "und"] {
+            let body = build_recognize_request(&cfg, &b"x"[..], Some(*sentinel));
+            let v: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+            assert_eq!(
+                v["config"]["languageCodes"][0], "en-US",
+                "sentinel `{sentinel}` should fall back to config default"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Both providers were silently dropping the language argument. Their function signatures used \`_language: Option<&str>\` (underscore-unused), so the language threaded through six call sites in main.rs never made it into the actual API request. Result: every transcription used \`GOOGLE_STT_LANGUAGE_CODES=en-US\` (env default) and a generic English-implied prompt — Spanish/French/etc. clips transcribed *into* English rather than properly recognized.

Per the journal entry on Chirp 3 architecture, the model's system prompt literally says *\"Transcribe the following speech segment in English\"*. Without overriding \`languageCodes\` per-request, non-English audio is forcibly Englished.

## Changes

- \`build_recognize_request(config, audio_bytes, language)\` — when language is \`Some(non-empty)\` and not \"auto\"/\"und\", override \`languageCodes\` with \`[lang]\`. Otherwise fall through to the configured multi-code default. Drops the leading underscore from \`transcribe()\`'s parameter.
- \`transcribe_via_gemini(config, audio_path, language)\` — drops the underscore, threads language into a new \`build_gemini_prompt\` helper that injects \"Transcribe this audio in {lang}.\" when set. Sentinels (\"\", auto, und) yield the generic prompt for model-side detection.

## Caveat

The edge auto-trigger still passes \`None\` for language at three of four \`trigger_on_demand_transcription\` call sites (\`src/main.rs\`:1670, 3029, 4655). Until the edge is updated to read the Nostr event's language tag at upload time, this PR only helps the explicit \`/v1/subtitles/jobs\` API path (where the API client already provides language). Edge fix is a follow-up — it requires adding a \`language\` field to \`BlobMetadata\` to persist the upload-time language hint.

## Test plan

- [x] \`cargo test --bin divine-transcoder\`: 76 passed (was 72 + 4 new)
- [x] \`build_recognize_uses_per_request_language_when_provided\` confirms \`Some(\"es-ES\")\` → \`languageCodes: [\"es-ES\"]\`
- [x] \`build_recognize_falls_back_to_config_for_auto_or_empty_language\` confirms sentinels (empty / auto / und) defer to env config
- [x] \`gemini_prompt_uses_language_when_provided\` / \`gemini_prompt_omits_language_for_sentinels\` cover both prompt branches
- [ ] Deploy + spot-check a non-English clip (e.g. supply lang via \`/v1/subtitles/jobs\` API)

## Related

- Stacks cleanly with PRs #115, #116, #117, #118, #119 — no overlap.
- Edge follow-up tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)