### PR TITLE
chore(deploy): broaden default GOOGLE_STT_LANGUAGE_CODES for multi-language detection

### DIFF
--- a/cloud-run-transcoder/deploy.sh
+++ b/cloud-run-transcoder/deploy.sh
@@ -48,7 +48,12 @@ SENTRY_ENVIRONMENT="${SENTRY_ENVIRONMENT:-production}"
 GOOGLE_CLOUD_LOCATION="${GOOGLE_CLOUD_LOCATION:-us}"
 GOOGLE_STT_RECOGNIZER="${GOOGLE_STT_RECOGNIZER:-_}"
 GOOGLE_STT_MODEL="${GOOGLE_STT_MODEL:-chirp_3}"
-GOOGLE_STT_LANGUAGE_CODES="${GOOGLE_STT_LANGUAGE_CODES:-en-US}"
+# Multi-language detection default. Chirp 3's `languageCodes` accepts a
+# comma list and the model picks per-clip. Without this, every transcription
+# is forced to English and non-English audio is mis-transcribed. Override
+# at deploy time if a stricter single-language policy is wanted (e.g.
+# GOOGLE_STT_LANGUAGE_CODES=en-US for English-only).
+GOOGLE_STT_LANGUAGE_CODES="${GOOGLE_STT_LANGUAGE_CODES:-en-US,es-US,es-ES,pt-BR,fr-FR,de-DE,it-IT,ja-JP,ko-KR,zh-CN}"
 TRANSCRIPTION_FALLBACK_PROVIDER="${TRANSCRIPTION_FALLBACK_PROVIDER:-}"
 TRANSCRIPTION_FALLBACK_ON_PROVIDER_ERROR="${TRANSCRIPTION_FALLBACK_ON_PROVIDER_ERROR:-true}"
 SENTRY_SECRET="${SENTRY_SECRET:-sentry_dsn}"


### PR DESCRIPTION
## Summary

Previous default \`en-US\` forced every transcription through English regardless of the audio's actual language — Spanish/French/etc. clips came out as English-mistranscribed gibberish. Chirp 3's \`languageCodes\` accepts a comma-separated list and the model picks per-clip.

New default: \`en-US,es-US,es-ES,pt-BR,fr-FR,de-DE,it-IT,ja-JP,ko-KR,zh-CN\` — the largest content languages we see. Operators wanting a strict English-only policy can still override at deploy time.

## Why now

User reported transcription guessing language wrong. Diagnosis showed three layers dropping the language hint (see journal \`2026-05-06-transcription-language-hint-dropped-three-layers.md\`):

1. Edge auto-trigger: passes \`None\` for language at three of four call sites — the dominant production path.
2. Chirp 3 + Gemini: silently drop the per-request \`language\` argument (fixed in PR #120).
3. Default \`languageCodes\` env: only \`en-US\` (this PR).

For the auto-trigger path (where no language is supplied), the only workable knob without a client-protocol change is the env default — broadening it to a multi-code list lets the model detect language from the audio rather than forcing English.

## Pairs with

- PR #120 (per-request language hint plumbing): when the API client supplies language explicitly, that wins via \`build_recognize_request\`'s override.
- Future: edge-side fix to extract language from the Nostr 34236 event's \`l\` tag and persist on \`BlobMetadata\`. Bigger surface; deferred.

## Test plan

- [x] \`bash -n deploy.sh\` passes
- [ ] Deploy + spot-check a known Spanish clip: confirm transcription comes back in Spanish (vs. English-mistranscribed)
- [ ] Watch for false-positive language detection on edge cases (e.g. heavily-accented English misclassified as another language). Override to \`en-US\` if any specific tenant wants strict English.

## Risk

Low. Multi-language hint is the documented Chirp 3 use case for unknown-language audio. Worst case: occasional language misdetection where the user expected English. Single-line revert if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)