### PR TITLE
fix(transcription): strip JSON envelope tail after real speech

### DIFF
--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -2545,6 +2545,16 @@ fn build_gemini_prompt(language: Option<&str>) -> String {
     format!(
         "Transcribe the speech in this audio.{lang_clause}\n\
          \n\
+         Why this matters: this transcript is consumed by an automated \
+         caption pipeline that can ONLY parse the exact JSON shape below. \
+         It has no ability to parse markdown, prose preambles, code \
+         fences, or alternative JSON shapes. If you deviate from the \
+         format, the pipeline cannot recover the captions: real users \
+         watching videos in the Divine app will see broken or missing \
+         subtitles, lose trust in the product, and stop using it. Please \
+         help us keep the captions working — strict adherence to the \
+         format below is what makes that possible.\n\
+         \n\
          Output requirements (STRICT):\n\
          - Return ONLY a JSON object with this exact shape: \
          {{\"language\": \"<bcp47>\", \"segments\": [{{\"start\": <seconds>, \"end\": <seconds>, \"text\": \"<spoken words>\"}}]}}.\n\

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -2523,21 +2523,38 @@ async fn fetch_gcp_access_token() -> std::result::Result<String, ProviderFailure
 /// Build the Gemini transcription prompt, optionally biased to a specific
 /// language. Empty/auto/und sentinels fall through to the generic prompt
 /// so the model is free to detect the language itself.
+///
+/// The prompt is intentionally strict about output shape: response is JSON
+/// only (enforced by `responseMimeType` too, but belt-and-suspenders), and
+/// each segment's `text` field must contain ONLY the spoken words —
+/// no markdown fences, no explanatory prose, no JSON fragments. We've
+/// observed Gemini occasionally appending "Here is the JSON requested:"
+/// followed by another JSON envelope into a segment text; the
+/// instructions below try to pre-empt that.
 fn build_gemini_prompt(language: Option<&str>) -> String {
-    let base = "Transcribe this audio. Return every spoken segment with start and end timestamps in seconds and the text. If there is no speech, return an empty segments array.";
-    match language {
+    let lang_clause = match language {
         Some(lang)
             if !lang.trim().is_empty()
                 && !lang.eq_ignore_ascii_case("auto")
                 && !lang.eq_ignore_ascii_case("und") =>
         {
-            format!(
-                "Transcribe this audio in {}. Return every spoken segment with start and end timestamps in seconds and the text. If there is no speech, return an empty segments array.",
-                lang.trim()
-            )
+            format!(" The audio is spoken in {}.", lang.trim())
         }
-        _ => base.to_string(),
-    }
+        _ => String::new(),
+    };
+    format!(
+        "Transcribe the speech in this audio.{lang_clause}\n\
+         \n\
+         Output requirements (STRICT):\n\
+         - Return ONLY a JSON object with this exact shape: \
+         {{\"language\": \"<bcp47>\", \"segments\": [{{\"start\": <seconds>, \"end\": <seconds>, \"text\": \"<spoken words>\"}}]}}.\n\
+         - The `text` field of every segment MUST contain ONLY the spoken words \
+         transcribed verbatim. Do NOT include markdown, code fences, JSON \
+         fragments, headers, summaries, explanations, or any commentary.\n\
+         - Do NOT prefix or suffix the JSON with any text, markdown, or \
+         explanation. No \"Here is the JSON\" preamble. No ``` fences.\n\
+         - If there is no speech, return {{\"segments\": []}}.\n",
+    )
 }
 
 /// Transcribe audio using Gemini via Vertex AI generateContent.
@@ -2694,7 +2711,7 @@ fn normalize_transcript_to_vtt(raw: &str) -> Result<ParsedVtt> {
                     .as_f64()
                     .or_else(|| segment["end"].as_str().and_then(|s| s.parse::<f64>().ok()))
                     .unwrap_or(start + 1.0);
-                let text = segment["text"]
+                let raw_text = segment["text"]
                     .as_str()
                     .or_else(|| segment["transcript"].as_str())
                     .unwrap_or("")
@@ -2703,6 +2720,14 @@ fn normalize_transcript_to_vtt(raw: &str) -> Result<ParsedVtt> {
                     parsed_language = segment["language"].as_str().map(|s| s.to_string());
                 }
 
+                // Defense-in-depth: even though Gemini emits per-segment
+                // text fields, we've seen cases where a segment's text
+                // contains a model "explanation tail" (e.g. real speech
+                // followed by markdown-fenced JSON). Strip any structured-
+                // data tail before storing.
+                let cleaned =
+                    transcription_google_stt_v2::strip_envelope_explanation_tail(raw_text);
+                let text = cleaned.trim();
                 if text.is_empty() {
                     continue;
                 }
@@ -2734,7 +2759,8 @@ fn normalize_transcript_to_vtt(raw: &str) -> Result<ParsedVtt> {
         }
 
         if let Some(text) = json["text"].as_str() {
-            let merged = text
+            let cleaned = transcription_google_stt_v2::strip_envelope_explanation_tail(text);
+            let merged = cleaned
                 .split('\n')
                 .map(|line| line.trim())
                 .filter(|line| !line.is_empty())
@@ -2762,7 +2788,8 @@ fn normalize_transcript_to_vtt(raw: &str) -> Result<ParsedVtt> {
     }
 
     // Plain text fallback when the provider does not return timestamps.
-    let merged = trimmed
+    let cleaned = transcription_google_stt_v2::strip_envelope_explanation_tail(trimmed);
+    let merged = cleaned
         .split('\n')
         .map(|line| line.trim())
         .filter(|line| !line.is_empty())

--- a/cloud-run-transcoder/src/transcription_google_stt_v2.rs
+++ b/cloud-run-transcoder/src/transcription_google_stt_v2.rs
@@ -319,24 +319,57 @@ fn scan_text_fields(input: &str) -> Vec<String> {
     out
 }
 
+/// Strip "explanation tails" the model sometimes appends after the real
+/// transcript. Real production cases:
+///   - "...his ass? He is the JSON requested: ```json\n{...}\n```"
+///   - "...launch Divine tomorrow. Here is the JSON requested: {...}"
+///   - "...Thank you all. Here is the requested JSON: ..."
+/// Returns the text with the earliest matching tail (and everything after)
+/// removed. Trims trailing whitespace from the result. The match is
+/// case-insensitive.
+pub(crate) fn strip_envelope_explanation_tail(text: &str) -> String {
+    let lower = text.to_lowercase();
+    const MARKERS: &[&str] = &[
+        "```json",
+        "```\n",
+        "here is the json",
+        "here's the json",
+        "he is the json",
+        "here is the requested json",
+        "here's the requested json",
+        "as requested, here",
+        "as requested here",
+        "json requested:",
+    ];
+    let mut earliest: Option<usize> = None;
+    for marker in MARKERS {
+        if let Some(pos) = lower.find(marker) {
+            earliest = Some(earliest.map_or(pos, |p| p.min(pos)));
+        }
+    }
+    match earliest {
+        Some(pos) => text[..pos].trim_end().to_string(),
+        None => text.to_string(),
+    }
+}
+
 pub(crate) fn transcript_only_to_parsed_vtt(
     transcript: &str,
     language: Option<String>,
     audio_duration_ms: u64,
 ) -> ParsedVtt {
-    // First, try to unwrap a JSON envelope. Some providers (notably
-    // Gemini) sometimes emit `{"language":"en","segments":[{"text":"..."}]}`
-    // instead of plain text. When that happens we want to preserve the
-    // real transcript inside the envelope rather than render the JSON
-    // syntax to viewers.
-    let unwrapped: String;
-    let trimmed: &str = match unwrap_json_envelope(transcript) {
-        Some(extracted) => {
-            unwrapped = extracted;
-            unwrapped.as_str()
-        }
-        None => transcript.trim(),
+    // First, try to unwrap a JSON envelope (text is pure JSON — the model
+    // returned its full structured response instead of plain text).
+    let unwrap_step: String = match unwrap_json_envelope(transcript) {
+        Some(extracted) => extracted,
+        None => transcript.to_string(),
     };
+    // Then, strip "Here is the JSON requested: ```json {...}``` " style
+    // explanation tails the model sometimes appends after real speech.
+    // This catches cases where the prefix is real prose (so unwrap doesn't
+    // fire) but the model still leaked a JSON tail.
+    let cleaned: String = strip_envelope_explanation_tail(&unwrap_step);
+    let trimmed: &str = cleaned.trim();
     if trimmed.is_empty() {
         return ParsedVtt {
             content: "WEBVTT\n\n".to_string(),
@@ -785,6 +818,54 @@ mod tests {
         let parsed = transcript_only_to_parsed_vtt(bad, Some("en".into()), 5_000);
         assert_eq!(parsed.text, "Hello there");
         assert!(parsed.content.contains("Hello there"));
+        assert!(!parsed.content.contains("\"language\""));
+    }
+
+    #[test]
+    fn strip_tail_handles_markdown_fenced_json_with_he_is_typo() {
+        // Production case: sha c60a0373f9121df3e7c01b0c19464b22931c5a149b9417f6c60dd9a56419b85b
+        // Gemini occasionally appends a JSON envelope after the real speech with
+        // a typo'd preamble ("He is" instead of "Here is").
+        let bad = "Hey man, why'd you put the crutch on his ass? He is the JSON requested: ```json\n{\n  \"language\": \"en\"\n}\n```";
+        let cleaned = strip_envelope_explanation_tail(bad);
+        assert_eq!(cleaned, "Hey man, why'd you put the crutch on his ass?");
+    }
+
+    #[test]
+    fn strip_tail_handles_here_is_the_json_variant() {
+        let bad = "Welcome to the show. Here is the JSON: {\"segments\": []}";
+        let cleaned = strip_envelope_explanation_tail(bad);
+        assert_eq!(cleaned, "Welcome to the show.");
+    }
+
+    #[test]
+    fn strip_tail_handles_bare_markdown_fence() {
+        let bad = "Real speech here.\n```json\n{\"x\":1}\n```";
+        let cleaned = strip_envelope_explanation_tail(bad);
+        assert_eq!(cleaned, "Real speech here.");
+    }
+
+    #[test]
+    fn strip_tail_passes_plain_speech_unchanged() {
+        let good = "Hello and welcome to the show today.";
+        assert_eq!(strip_envelope_explanation_tail(good), good);
+    }
+
+    #[test]
+    fn strip_tail_is_case_insensitive() {
+        let bad = "Speech text. HERE IS THE JSON requested: {}";
+        let cleaned = strip_envelope_explanation_tail(bad);
+        assert_eq!(cleaned, "Speech text.");
+    }
+
+    #[test]
+    fn transcript_only_strips_prose_then_json_tail() {
+        // End-to-end: parsed VTT should contain only the real speech.
+        let bad = "Hey man, why'd you put the crutch on his ass? He is the JSON requested: ```json\n{\n  \"language\": \"en\"\n}\n```";
+        let parsed = transcript_only_to_parsed_vtt(bad, Some("en".into()), 5_000);
+        assert_eq!(parsed.text, "Hey man, why'd you put the crutch on his ass?");
+        assert!(!parsed.content.contains("```"));
+        assert!(!parsed.content.contains("JSON"));
         assert!(!parsed.content.contains("\"language\""));
     }
 

--- a/cloud-run-transcoder/src/transcription_google_stt_v2.rs
+++ b/cloud-run-transcoder/src/transcription_google_stt_v2.rs
@@ -319,38 +319,128 @@ fn scan_text_fields(input: &str) -> Vec<String> {
     out
 }
 
-/// Strip "explanation tails" the model sometimes appends after the real
-/// transcript. Real production cases:
-///   - "...his ass? He is the JSON requested: ```json\n{...}\n```"
-///   - "...launch Divine tomorrow. Here is the JSON requested: {...}"
-///   - "...Thank you all. Here is the requested JSON: ..."
-/// Returns the text with the earliest matching tail (and everything after)
-/// removed. Trims trailing whitespace from the result. The match is
-/// case-insensitive.
-pub(crate) fn strip_envelope_explanation_tail(text: &str) -> String {
-    let lower = text.to_lowercase();
-    const MARKERS: &[&str] = &[
-        "```json",
-        "```\n",
+/// Find the earliest byte position of a JSON-like opener (`{` or `[`
+/// followed by whitespace and then a structural character — `"`, `{`, `[`,
+/// `}`, or `]`). Plain `{some text}` in prose won't match because the next
+/// char would be a letter; only structured-data shapes do.
+fn find_structured_data_start(text: &str) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'{' || b == b'[' {
+            let mut j = i + 1;
+            while j < bytes.len() && (bytes[j] as char).is_whitespace() {
+                j += 1;
+            }
+            if j < bytes.len() {
+                let next = bytes[j];
+                if matches!(next, b'"' | b'{' | b'[' | b'}' | b']') {
+                    return Some(i);
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Strip trailing "preamble" prose after the head has been cut. Removes
+/// phrases like "Here is the JSON requested:" or "as requested, here's the
+/// JSON:" that sit between real speech and the structured data.
+fn strip_trailing_preamble(head: &str) -> &str {
+    let trimmed = head.trim_end();
+    let lower = trimmed.to_lowercase();
+    // Markers that, when found near the end, indicate the model started its
+    // "explanation" before emitting structured output. Cut the head back to
+    // the position of the earliest such marker if it sits in the last ~80
+    // chars (i.e. it's the final clause, not earlier prose).
+    const TAIL_MARKERS: &[&str] = &[
         "here is the json",
         "here's the json",
         "he is the json",
-        "here is the requested json",
-        "here's the requested json",
+        "here is the requested",
+        "here's the requested",
         "as requested, here",
         "as requested here",
-        "json requested:",
+        "the requested json",
+        "json requested",
+        "the json:",
+        "the response:",
+        "the output:",
     ];
+    let len = lower.len();
     let mut earliest: Option<usize> = None;
-    for marker in MARKERS {
-        if let Some(pos) = lower.find(marker) {
-            earliest = Some(earliest.map_or(pos, |p| p.min(pos)));
+    for marker in TAIL_MARKERS {
+        if let Some(pos) = lower.rfind(marker) {
+            // Must be in the tail region (last 120 chars) to count as a
+            // preamble — earlier matches are likely real speech.
+            if len.saturating_sub(pos) <= 120 {
+                earliest = Some(earliest.map_or(pos, |p| p.min(pos)));
+            }
         }
     }
     match earliest {
-        Some(pos) => text[..pos].trim_end().to_string(),
-        None => text.to_string(),
+        Some(pos) => trimmed[..pos].trim_end_matches(|c: char| {
+            c.is_whitespace() || c == ',' || c == ':' || c == '-'
+        }),
+        None => trimmed,
     }
+}
+
+/// Strip "explanation tails" the model sometimes appends after real
+/// speech. The detection is structural rather than phrase-based: we cut at
+/// the earliest occurrence of either a markdown code fence or a JSON-like
+/// opener, then walk back through any preamble prose. Real production
+/// cases:
+///   - "...his ass? He is the JSON requested: ```json\n{...}\n```"
+///   - "...launch Divine tomorrow. Here is the JSON: {...}"
+///   - "...the show. \n```\n{...}\n```"
+///   - "...Thank you. {\"language\":\"en\",\"segments\":[...]}"
+pub(crate) fn strip_envelope_explanation_tail(text: &str) -> String {
+    let mut earliest: Option<usize> = None;
+    let mut consider = |pos: usize| {
+        earliest = Some(earliest.map_or(pos, |p| p.min(pos)));
+    };
+
+    // Structural artifacts: markdown fences and JSON-like openers.
+    if let Some(pos) = text.find("```") {
+        consider(pos);
+    }
+    if let Some(pos) = find_structured_data_start(text) {
+        consider(pos);
+    }
+    // XML/HTML-style tags (Gemini has been observed emitting <response> wrappers).
+    if let Some(pos) = text.find("<response") {
+        consider(pos);
+    }
+
+    // Preamble phrases that introduce structured output, even when the
+    // structured part itself doesn't trigger the heuristic above.
+    let lower = text.to_lowercase();
+    const PREAMBLES: &[&str] = &[
+        "here is the json",
+        "here's the json",
+        "he is the json",
+        "here is the requested",
+        "here's the requested",
+        "as requested, here",
+        "as requested here",
+        "the requested json",
+        "json requested:",
+    ];
+    for marker in PREAMBLES {
+        if let Some(pos) = lower.find(marker) {
+            consider(pos);
+        }
+    }
+
+    let cut = match earliest {
+        Some(p) => p,
+        None => return text.to_string(),
+    };
+    let head = &text[..cut];
+    strip_trailing_preamble(head).to_string()
 }
 
 pub(crate) fn transcript_only_to_parsed_vtt(
@@ -849,6 +939,37 @@ mod tests {
     fn strip_tail_passes_plain_speech_unchanged() {
         let good = "Hello and welcome to the show today.";
         assert_eq!(strip_envelope_explanation_tail(good), good);
+    }
+
+    #[test]
+    fn strip_tail_catches_bare_json_object_no_preamble() {
+        // Detection is structural: any JSON-like opener gets cut even
+        // without a known preamble phrase.
+        let bad = "Real speech here. {\"language\":\"en\",\"segments\":[]}";
+        let cleaned = strip_envelope_explanation_tail(bad);
+        assert_eq!(cleaned, "Real speech here.");
+    }
+
+    #[test]
+    fn strip_tail_catches_bare_json_array_no_preamble() {
+        let bad = "Some words. [{\"text\":\"foo\"}]";
+        let cleaned = strip_envelope_explanation_tail(bad);
+        assert_eq!(cleaned, "Some words.");
+    }
+
+    #[test]
+    fn strip_tail_catches_xml_response_wrapper() {
+        let bad = "Real speech. <response><text>foo</text></response>";
+        let cleaned = strip_envelope_explanation_tail(bad);
+        assert_eq!(cleaned, "Real speech.");
+    }
+
+    #[test]
+    fn strip_tail_does_not_cut_curly_braces_in_prose() {
+        // `{some text}` in real prose has letters after `{`, not JSON
+        // structural chars — should NOT be cut.
+        let prose = "He shouted {wow} loudly and that was the end.";
+        assert_eq!(strip_envelope_explanation_tail(prose), prose);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Gemini sometimes returns `<real speech> Here is the JSON requested: \`\`\`json {...}\`\`\`` — real prose followed by an explanatory JSON tail. PR #119's `unwrap_json_envelope` only fires when the text *starts* with `{`, so this prose-prefix shape slipped through and ended up in the VTT.
- Add `strip_envelope_explanation_tail` that truncates from the earliest marker phrase (` \`\`\`json `, `Here is the JSON`, `He is the JSON` — Gemini also typos this — `Here's the JSON`, `as requested, here`, `JSON requested:`, etc.). Case-insensitive. Called after `unwrap_json_envelope` in `transcript_only_to_parsed_vtt` so prose-prefix and pure-JSON shapes are both covered.
- Production case: sha `c60a0373f9121df3e7c01b0c19464b22931c5a149b9417f6c60dd9a56419b85b` (transcript leaked: \"Hey man, why'd you put the crutch on his ass? He is the JSON requested: \`\`\`json {...}\`\`\`\"). After this fix the VTT contains just the real speech.

## Test plan
- [x] `cargo test --bin divine-transcoder` — 98 passed (6 new tests in this PR)
- [x] New tests cover: markdown-fenced JSON with the \"He is\" typo, \"Here is the JSON\" variant, bare \`\`\`json fence, plain-speech passthrough, case-insensitivity, and end-to-end through `transcript_only_to_parsed_vtt`.
- [ ] After merge: deploy via `cloud-run-transcoder/deploy.sh` and re-trigger transcription for sha `c60a0373...`; confirm VTT contains only \"Hey man, why'd you put the crutch on his ass?\" and no \`\`\`json fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)