### PR TITLE
fix(auth): dispatch BUD-01 viewer auth based on path context

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -4,8 +4,9 @@
 use crate::blossom::{AuthAction, BlossomAuthEvent};
 use crate::error::{BlossomError, Result};
 use crate::viewer_auth::{
-    authenticate_blob_viewer, authenticate_generic_viewer, diagnose_viewer_auth_request,
-    parse_auth_header, public_request_url, validate_blossom_event, ViewerAuthDiagnostics,
+    authenticate_blob_viewer, authenticate_generic_viewer, blob_hash_from_path,
+    diagnose_viewer_auth_request, parse_auth_header, public_request_url, validate_blossom_event,
+    ViewerAuthDiagnostics,
 };
 use fastly::http::header::{AUTHORIZATION, HOST};
 use fastly::Request;
@@ -97,17 +98,6 @@ fn request_auth_headers(req: &Request) -> Result<Vec<&str>> {
 enum ViewerScope {
     Generic,
     Blob(String),
-}
-
-fn blob_hash_from_path(path: &str) -> Option<String> {
-    let first_segment = path.trim_start_matches('/').split('/').next()?;
-    let candidate = first_segment.split('.').next().unwrap_or(first_segment);
-
-    if candidate.len() == 64 && candidate.chars().all(|c| c.is_ascii_hexdigit()) {
-        Some(candidate.to_lowercase())
-    } else {
-        None
-    }
 }
 
 fn unix_now() -> u64 {

--- a/src/viewer_auth.rs
+++ b/src/viewer_auth.rs
@@ -268,7 +268,11 @@ pub fn diagnose_viewer_auth_request(
         }
     };
 
-    match validate_viewer_event(&event, method, &request_url, now) {
+    let validation = match blob_hash_from_path(path) {
+        Some(hash) => validate_blob_viewer_event(&event, method, &request_url, &hash, now),
+        None => validate_viewer_event(&event, method, &request_url, now),
+    };
+    match validation {
         Ok(()) => {
             diagnostics.auth_state = ViewerAuthState::Valid;
             diagnostics.viewer_pubkey = Some(event.pubkey);
@@ -291,6 +295,17 @@ fn classify_parse_error(error_message: &str) -> ViewerAuthState {
         ViewerAuthState::InvalidScheme
     } else {
         ViewerAuthState::ParseFailed
+    }
+}
+
+pub(crate) fn blob_hash_from_path(path: &str) -> Option<String> {
+    let first_segment = path.trim_start_matches('/').split('/').next()?;
+    let candidate = first_segment.split('.').next().unwrap_or(first_segment);
+
+    if candidate.len() == 64 && candidate.chars().all(|c| c.is_ascii_hexdigit()) {
+        Some(candidate.to_lowercase())
+    } else {
+        None
     }
 }
 

--- a/src/viewer_auth.rs
+++ b/src/viewer_auth.rs
@@ -906,6 +906,61 @@ mod tests {
         );
     }
 
+    #[test]
+    fn viewer_auth_diagnostics_accepts_bud01_get_on_blob_path() {
+        let hash = "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e";
+        let event = signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "get".into()],
+                vec!["x".into(), hash.into()],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        );
+        let auth_header = encoded_event(event);
+        let path = format!("/{}.mp4", hash);
+
+        let diagnostics = diagnose_viewer_auth_request(
+            "GET",
+            &path,
+            Some("media.divine.video"),
+            TEST_URL,
+            Some(&auth_header),
+            1_100,
+        );
+
+        assert_eq!(diagnostics.auth_state, ViewerAuthState::Valid);
+        assert!(diagnostics.viewer_pubkey.is_some());
+    }
+
+    #[test]
+    fn viewer_auth_diagnostics_rejects_bud01_list_on_blob_path() {
+        let hash = "4a31d696c2275e60dbfe2359e6ff006f78a30f5df11c7290233a7860c4e8c31e";
+        let event = signed_event(
+            BLOSSOM_AUTH_KIND,
+            vec![
+                vec!["t".into(), "list".into()],
+                vec!["expiration".into(), "1300".into()],
+            ],
+            1_000,
+        );
+        let auth_header = encoded_event(event);
+        let path = format!("/{}.mp4", hash);
+
+        let diagnostics = diagnose_viewer_auth_request(
+            "GET",
+            &path,
+            Some("media.divine.video"),
+            TEST_URL,
+            Some(&auth_header),
+            1_100,
+        );
+
+        assert_eq!(diagnostics.auth_state, ViewerAuthState::ValidationFailed);
+        assert!(diagnostics.auth_error.is_some());
+    }
+
     fn signed_event(kind: u32, tags: Vec<Vec<String>>, created_at: u64) -> BlossomAuthEvent {
         let signing_key = SigningKey::from_bytes(&[7u8; 32]).expect("test key should be valid");
         let mut event = BlossomAuthEvent {


### PR DESCRIPTION
## Summary

- `diagnose_viewer_auth_request` always dispatched BUD-01 (kind 24242) events to `validate_viewer_event`, which requires `AuthAction::List`. blob viewer requests (e.g. `/<sha256>.ext`) need `AuthAction::Get`, so valid get-scoped auth was rejected with "Invalid action tag."
- route BUD-01 events through `validate_blob_viewer_event` when the request path contains a blob hash, matching how `viewer_pubkey` in `auth.rs` already dispatches correctly.
- move `blob_hash_from_path` from `auth.rs` to `viewer_auth.rs` as a shared `pub(crate)` helper to avoid duplication.

the live `viewer_pubkey` path in `auth.rs` was already correct. this fix aligns the diagnostic/context path (`media_viewer_context` -> `diagnose_viewer_auth`) with the same logic. NIP-98 (kind 27235) auth is unaffected.

Closes #126

## Test plan

- [x] `cargo test -p blossom-core --locked` passes (99 tests, 0 failures)
- [ ] BUD-01 auth with `['t', 'get']` + `['x', sha256]` succeeds on blob paths (previously rejected)
- [ ] BUD-01 auth with `['t', 'list']` continues to work on non-blob paths (list endpoints)
- [ ] NIP-98 auth (kind 27235) unaffected on all paths
- [ ] unauthenticated requests to non-restricted content unaffected

regression tests added:
- `viewer_auth_diagnostics_accepts_bud01_get_on_blob_path` -- the exact path that was broken
- `viewer_auth_diagnostics_rejects_bud01_list_on_blob_path` -- confirms strict dispatch