### PR TITLE
ci: use 16-core GitHub runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     steps:
       - uses: actions/checkout@v4
 
@@ -41,7 +41,7 @@ jobs:
   docker:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     permissions:
       contents: read
       packages: write
@@ -85,7 +85,7 @@ jobs:
     concurrency:
       group: fastly-deploy
       cancel-in-progress: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     steps:
       - uses: actions/checkout@v4
 
@@ -115,7 +115,7 @@ jobs:
   deploy-process-blob:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-16core
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- move Ubuntu GitHub Actions jobs from `ubuntu-latest` to the org hosted `ubuntu-24.04-16core` runner
- keep workflow logic unchanged; this only changes runner capacity

## Motivation
Reduce CI/build lead time across Divine repos. The org runner `ubuntu-24.04-16core` is configured as Ubuntu 24.04, 16 cores, 64 GB RAM, max 50 concurrent runners.

## Manual validation
- Parsed changed workflow YAML with Ruby
- Ran `git diff --check -- .github/workflows`