### PR TITLE
fix(auth): degrade invalid viewer auth to anonymous (Postel)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -243,17 +243,16 @@ fn media_viewer_context(
     match diagnostics.auth_state {
         ViewerAuthState::Missing => Ok((None, diagnostics)),
         ViewerAuthState::Valid => Ok((diagnostics.viewer_pubkey.clone(), diagnostics)),
+        // Postel: a malformed/invalid viewer auth header degrades to anonymous.
+        // `BlobMetadata::access_for(None, ...)` is the single source of truth on
+        // whether the blob requires auth — public blobs serve, restricted blobs
+        // 401 the same way they would for a request with no header at all.
         _ => {
             eprintln!(
                 "{}",
-                format_media_auth_log(route, &diagnostics, "auth_invalid")
+                format_media_auth_log(route, &diagnostics, "auth_invalid_degraded_to_anonymous")
             );
-            Err(BlossomError::AuthInvalid(
-                diagnostics
-                    .auth_error
-                    .clone()
-                    .unwrap_or_else(|| "Invalid viewer authorization".into()),
-            ))
+            Ok((None, diagnostics))
         }
     }
 }


### PR DESCRIPTION
## Summary

`media_viewer_context` short-circuited to `BlossomError::AuthInvalid` (401) whenever a media GET arrived with an Authorization header that failed to parse, used a bad scheme, or failed BUD-01 validation — **including on Public blobs**. That meant any client sending a malformed Nostr header bricked itself out of public-blob playback (symptom: divine-web showing "Failed to load video" on a normal public video that macOS played fine).

This PR makes the viewer-auth gate Postel-lenient: a broken header is treated as no header, and `BlobMetadata::access_for(None, ...)` stays the single source of truth on whether auth is actually required.

### Behavior matrix

| Blob status | Header | Before | After |
| --- | --- | --- | --- |
| Public | none | 200 | 200 |
| Public | valid BUD-01 | 200 | 200 |
| Public | malformed / bad scheme | **401** | **200** ← fix |
| Restricted / AgeRestricted | none | 401/404 | 401/404 |
| Restricted / AgeRestricted | malformed | 401 | 401 (via `access_for` instead of short-circuit) |
| Restricted / AgeRestricted | valid for owner | 200 | 200 |

No regression for restricted content: a malformed header was never going to authenticate anyone, so degrading to anonymous gets the same denial via the proper path.

### Code change

`src/main.rs` — `media_viewer_context` now returns `Ok((None, diagnostics))` for any non-`Missing`/non-`Valid` auth state. The diagnostic outcome is still logged (`auth_invalid_degraded_to_anonymous`) so we can grep Fastly logs for clients sending broken headers.

## Test plan

- [ ] `cargo check --target wasm32-wasip1` — passes locally
- [ ] After deploy + purge, `curl https://media.divine.video/<public-hash>` with `-H 'Authorization: Nostr garbage'` returns **200** (was 401)
- [ ] Same curl with no Authorization header still returns 200
- [ ] `curl` against a known `AgeRestricted` hash with a malformed header still returns **401** with `{"error":"age_restricted"}` (or 404 if `Restricted`)
- [ ] divine-web loads public videos that were previously failing
- [ ] Grep Fastly real-time logs for `auth_invalid_degraded_to_anonymous` after deploy to confirm the new code path is exercised and identify which clients are sending bad headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)