### PR TITLE
ci: reduce GitHub Actions runner size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     steps:
       - uses: actions/checkout@v4
 
@@ -41,7 +41,7 @@ jobs:
   docker:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     permissions:
       contents: read
       packages: write
@@ -85,7 +85,7 @@ jobs:
     concurrency:
       group: fastly-deploy
       cancel-in-progress: false
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     steps:
       - uses: actions/checkout@v4
 
@@ -115,7 +115,7 @@ jobs:
   deploy-process-blob:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-24.04-16core
+    runs-on: ubuntu-24.04-4core
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- replace `ubuntu-24.04-16core` GitHub larger runner labels with `ubuntu-24.04-4core`
- reduce Actions spend while keeping larger-than-standard Linux runner capacity

## Motivation
The Divine org has used 90% of its May 2026 Actions budget. 4-core Linux larger runners are materially cheaper than 16-core runners while still giving build/test jobs more CPU than the default runner.

## Linked issue
None.

## Manual validation
- Verified changed workflow files no longer contain `ubuntu-24.04-16core`.
- Verified changed workflow files now use `ubuntu-24.04-4core`.
