### PR TITLE
fix(transcoder): drop instruction echoes from captions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Run upload service tests
         run: cargo test --manifest-path cloud-run-upload/Cargo.toml --locked
 
+      - name: Run transcoder service tests
+        run: cargo test --manifest-path cloud-run-transcoder/Cargo.toml --locked
+
+      - name: Run transcoder Python tests
+        working-directory: cloud-run-transcoder
+        run: python3 -m unittest discover -s tests -p 'test_*.py'
+
       - name: Run clippy
         run: cargo clippy --locked --all-targets --all-features
 

--- a/cloud-run-transcoder/repair_recent_bad_vtts.py
+++ b/cloud-run-transcoder/repair_recent_bad_vtts.py
@@ -22,6 +22,33 @@ JSON_CORRUPTION_MARKERS = (
     '"total_tokens"',
     '"usage":{',
     '"prompt_tokens"',
+    '"completion_tokens"',
+    '"finish_reason"',
+)
+INSTRUCTION_ECHO_STRONG_MARKERS = (
+    "<bcp47>",
+    "<seconds>",
+    "<spoken words>",
+    "output requirements",
+    "follow the schema",
+    "provided in the context",
+    "extra text outside",
+    "outside of the json",
+    "do not include any extra text",
+    "return only a json",
+    "only a json object",
+    "single json array",
+    "spoken words transcribed verbatim",
+    "text field of every segment",
+)
+INSTRUCTION_ECHO_WEAK_MARKERS = (
+    "valid json",
+    "json array",
+    "json object",
+    "json string",
+    "markdown",
+    "code fences",
+    "response schema",
 )
 USER_AGENT = "divine-blossom/repair_recent_bad_vtts"
 
@@ -85,7 +112,25 @@ def collect_recent_media_hashes(
 
 
 def is_bad_vtt_body(body: str) -> bool:
+    return has_json_artifact(body) or has_instruction_echo(body)
+
+
+def has_json_artifact(body: str) -> bool:
     return any(marker in body for marker in JSON_CORRUPTION_MARKERS)
+
+
+def has_instruction_echo(text: str) -> bool:
+    """Mirror of cloud-run-transcoder/src/main.rs `contains_instruction_echo`."""
+    normalized = " ".join(text.split()).lower()
+    strong_count = sum(
+        1 for marker in INSTRUCTION_ECHO_STRONG_MARKERS if marker in normalized
+    )
+    if strong_count >= 2:
+        return True
+    weak_count = sum(
+        1 for marker in INSTRUCTION_ECHO_WEAK_MARKERS if marker in normalized
+    )
+    return strong_count >= 1 and weak_count >= 2
 
 
 def is_empty_vtt_body(body: str) -> bool:

--- a/cloud-run-transcoder/repair_recent_bad_vtts.py
+++ b/cloud-run-transcoder/repair_recent_bad_vtts.py
@@ -11,45 +11,25 @@ import sys
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 from urllib import error, parse, request
+
+# Share one definition of the quality heuristics with the scanner so the two
+# operator tools (and their marker lists) cannot drift apart. The scan module
+# is a sibling script with no import-time side effects.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scan_and_repair_vtts import (  # noqa: E402
+    has_instruction_echo,
+    has_json_artifact,
+    has_json_envelope_leak,
+    vtt_spoken_text,
+)
 
 
 RELAY_API = "https://relay.divine.video/api"
 MEDIA_URL = "https://media.divine.video"
 REQUEST_TIMEOUT = 30
-JSON_CORRUPTION_MARKERS = (
-    '"total_tokens"',
-    '"usage":{',
-    '"prompt_tokens"',
-    '"completion_tokens"',
-    '"finish_reason"',
-)
-INSTRUCTION_ECHO_STRONG_MARKERS = (
-    "<bcp47>",
-    "<seconds>",
-    "<spoken words>",
-    "output requirements",
-    "follow the schema",
-    "provided in the context",
-    "extra text outside",
-    "outside of the json",
-    "do not include any extra text",
-    "return only a json",
-    "only a json object",
-    "single json array",
-    "spoken words transcribed verbatim",
-    "text field of every segment",
-)
-INSTRUCTION_ECHO_WEAK_MARKERS = (
-    "valid json",
-    "json array",
-    "json object",
-    "json string",
-    "markdown",
-    "code fences",
-    "response schema",
-)
 USER_AGENT = "divine-blossom/repair_recent_bad_vtts"
 
 
@@ -111,26 +91,26 @@ def collect_recent_media_hashes(
     return hashes
 
 
+def bad_vtt_reason(body: str) -> str | None:
+    """Classify a VTT body the same way the deployed gate and scanner do.
+
+    Detectors run on the *spoken* text (not the raw body) so a leaked
+    instruction split across cue boundaries — the normal one-cue-per-segment
+    shape — is still seen as a contiguous phrase. Returns a short reason
+    string for the operator log, or None when the body looks clean.
+    """
+    if has_json_artifact(body):
+        return "json_artifact"
+    spoken = vtt_spoken_text(body)
+    if has_json_envelope_leak(spoken):
+        return "json_envelope_leak"
+    if has_instruction_echo(spoken):
+        return "instruction_echo"
+    return None
+
+
 def is_bad_vtt_body(body: str) -> bool:
-    return has_json_artifact(body) or has_instruction_echo(body)
-
-
-def has_json_artifact(body: str) -> bool:
-    return any(marker in body for marker in JSON_CORRUPTION_MARKERS)
-
-
-def has_instruction_echo(text: str) -> bool:
-    """Mirror of cloud-run-transcoder/src/main.rs `contains_instruction_echo`."""
-    normalized = " ".join(text.split()).lower()
-    strong_count = sum(
-        1 for marker in INSTRUCTION_ECHO_STRONG_MARKERS if marker in normalized
-    )
-    if strong_count >= 2:
-        return True
-    weak_count = sum(
-        1 for marker in INSTRUCTION_ECHO_WEAK_MARKERS if marker in normalized
-    )
-    return strong_count >= 1 and weak_count >= 2
+    return bad_vtt_reason(body) is not None
 
 
 def is_empty_vtt_body(body: str) -> bool:
@@ -342,16 +322,16 @@ def main() -> int:
                 print(f"SKIP {media_hash}: vtt status={status}")
             continue
 
-        bad_vtt = is_bad_vtt_body(body)
+        reason = bad_vtt_reason(body)
         empty_vtt = args.check_empty and is_empty_vtt_body(body)
-        if not bad_vtt and not empty_vtt:
+        if reason is None and not empty_vtt:
             summary.clean_vtts += 1
             if args.verbose:
                 print(f"CLEAN {media_hash}")
             continue
 
         summary.bad_vtts += 1
-        reason = "json" if bad_vtt else "empty"
+        reason = reason or "empty"
         print(f"BAD {media_hash}: {reason}")
 
         if args.dry_run:

--- a/cloud-run-transcoder/scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/scan_and_repair_vtts.py
@@ -333,17 +333,41 @@ def has_json_envelope_leak(text: str) -> bool:
     return sum(1 for k in JSON_ENVELOPE_KEYS if k in text) >= 2
 
 
+def distinct_marker_phrases(normalized: str, markers: Iterable[str]) -> int:
+    """Mirror of `distinct_marker_phrases` in main.rs.
+
+    Collect every marker match span, then merge spans that overlap or are
+    separated only by whitespace, so one contiguous instruction sentence
+    counts as a single phrase. This keeps the threshold meaning "multiple
+    distinct phrases" instead of inflating on overlapping markers.
+    """
+    spans: list[tuple[int, int]] = []
+    for marker in markers:
+        start = normalized.find(marker)
+        while start != -1:
+            spans.append((start, start + len(marker)))
+            start = normalized.find(marker, start + 1)
+    if not spans:
+        return 0
+    spans.sort()
+    clusters = 1
+    cluster_end = spans[0][1]
+    for start, end in spans[1:]:
+        if start <= cluster_end or not normalized[cluster_end:start].strip():
+            cluster_end = max(cluster_end, end)
+        else:
+            clusters += 1
+            cluster_end = end
+    return clusters
+
+
 def has_instruction_echo(text: str) -> bool:
     """Mirror of `contains_instruction_echo` in main.rs."""
     normalized = " ".join(text.split()).lower()
-    strong_count = sum(
-        1 for marker in INSTRUCTION_ECHO_STRONG_MARKERS if marker in normalized
-    )
+    strong_count = distinct_marker_phrases(normalized, INSTRUCTION_ECHO_STRONG_MARKERS)
     if strong_count >= 2:
         return True
-    weak_count = sum(
-        1 for marker in INSTRUCTION_ECHO_WEAK_MARKERS if marker in normalized
-    )
+    weak_count = distinct_marker_phrases(normalized, INSTRUCTION_ECHO_WEAK_MARKERS)
     return strong_count >= 1 and weak_count >= 2
 
 

--- a/cloud-run-transcoder/scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/scan_and_repair_vtts.py
@@ -49,21 +49,21 @@ JSON_ENVELOPE_KEYS = (
 )
 
 # Mirrors cloud-run-transcoder/src/main.rs `contains_instruction_echo`.
-# Keep these markers conservative: common technical speech about JSON should
-# not trigger a repair unless multiple prompt/schema-specific phrases leaked.
+# Keep this list byte-identical with the Rust STRONG_MARKERS (CI asserts parity).
+# Every marker is high-specificity: a literal template token or a verbatim
+# prompt/responseSchema clause that does not occur in ordinary speech. Generic
+# English fragments that were merely substrings of a leaked clause were removed
+# so legitimate developer/API speech is never dropped (a drop is terminal —
+# empty VTT, status=complete, edge-cached, no auto-retranscribe).
 INSTRUCTION_ECHO_STRONG_MARKERS = (
     "<bcp47>",
     "<seconds>",
     "<spoken words>",
-    "output requirements",
-    "follow the schema",
-    "provided in the context",
+    "do not include any extra text",
     "extra text outside",
     "outside of the json",
-    "do not include any extra text",
-    "return only a json",
-    "only a json object",
     "single json array",
+    "follow the schema provided in the context",
     "spoken words transcribed verbatim",
     "text field of every segment",
 )
@@ -352,9 +352,20 @@ def distinct_marker_phrases(normalized: str, markers: Iterable[str]) -> int:
     return clusters
 
 
+def normalize_for_marker_scan(text: str) -> str:
+    """Mirror of `normalize_for_marker_scan` in main.rs.
+
+    Map every C0 control char (U+0000-U+001F) to a space before collapsing
+    whitespace so this matches Rust's `split_whitespace` (Unicode White_Space,
+    which excludes U+001C-U+001F) byte-for-byte.
+    """
+    cleaned = "".join(" " if ord(ch) < 0x20 else ch for ch in text)
+    return " ".join(cleaned.split()).lower()
+
+
 def has_instruction_echo(text: str) -> bool:
     """Mirror of `contains_instruction_echo` in main.rs."""
-    normalized = " ".join(text.split()).lower()
+    normalized = normalize_for_marker_scan(text)
     return distinct_marker_phrases(normalized, INSTRUCTION_ECHO_STRONG_MARKERS) >= 2
 
 

--- a/cloud-run-transcoder/scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/scan_and_repair_vtts.py
@@ -48,6 +48,35 @@ JSON_ENVELOPE_KEYS = (
     '"results":',
 )
 
+# Mirrors cloud-run-transcoder/src/main.rs `contains_instruction_echo`.
+# Keep these markers conservative: common technical speech about JSON should
+# not trigger a repair unless prompt/schema-specific phrasing also leaked.
+INSTRUCTION_ECHO_STRONG_MARKERS = (
+    "<bcp47>",
+    "<seconds>",
+    "<spoken words>",
+    "output requirements",
+    "follow the schema",
+    "provided in the context",
+    "extra text outside",
+    "outside of the json",
+    "do not include any extra text",
+    "return only a json",
+    "only a json object",
+    "single json array",
+    "spoken words transcribed verbatim",
+    "text field of every segment",
+)
+INSTRUCTION_ECHO_WEAK_MARKERS = (
+    "valid json",
+    "json array",
+    "json object",
+    "json string",
+    "markdown",
+    "code fences",
+    "response schema",
+)
+
 # Mirrors cloud-run-transcoder/src/main.rs `is_loop_hallucination` and
 # `is_repeated_phrase_hallucination`. Keep parameters in lockstep so the
 # scanner flags exactly what the deployed service would reject.
@@ -292,6 +321,8 @@ def is_implausible_text_density(text: str, duration_seconds: float | None) -> bo
     if chars < 100:
         return False
     return chars / duration_seconds > 40.0
+
+
 def has_json_envelope_leak(text: str) -> bool:
     """True if the text contains >=2 distinct STT-response JSON keys.
 
@@ -300,6 +331,20 @@ def has_json_envelope_leak(text: str) -> bool:
     term won't fire (needs at least two co-occurring quoted keys).
     """
     return sum(1 for k in JSON_ENVELOPE_KEYS if k in text) >= 2
+
+
+def has_instruction_echo(text: str) -> bool:
+    """Mirror of `contains_instruction_echo` in main.rs."""
+    normalized = " ".join(text.split()).lower()
+    strong_count = sum(
+        1 for marker in INSTRUCTION_ECHO_STRONG_MARKERS if marker in normalized
+    )
+    if strong_count >= 2:
+        return True
+    weak_count = sum(
+        1 for marker in INSTRUCTION_ECHO_WEAK_MARKERS if marker in normalized
+    )
+    return strong_count >= 1 and weak_count >= 2
 
 
 def is_loop_hallucination(text: str) -> bool:
@@ -400,6 +445,8 @@ def classify_vtt(body: str, *, check_empty: bool) -> str | None:
     text = vtt_spoken_text(body)
     if has_json_envelope_leak(text):
         return "json_envelope_leak"
+    if has_instruction_echo(text):
+        return "instruction_echo"
     if check_empty and is_empty_text(text):
         return "empty"
     duration_seconds = vtt_max_end_seconds(body)

--- a/cloud-run-transcoder/scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/scan_and_repair_vtts.py
@@ -50,7 +50,7 @@ JSON_ENVELOPE_KEYS = (
 
 # Mirrors cloud-run-transcoder/src/main.rs `contains_instruction_echo`.
 # Keep these markers conservative: common technical speech about JSON should
-# not trigger a repair unless prompt/schema-specific phrasing also leaked.
+# not trigger a repair unless multiple prompt/schema-specific phrases leaked.
 INSTRUCTION_ECHO_STRONG_MARKERS = (
     "<bcp47>",
     "<seconds>",
@@ -66,15 +66,6 @@ INSTRUCTION_ECHO_STRONG_MARKERS = (
     "single json array",
     "spoken words transcribed verbatim",
     "text field of every segment",
-)
-INSTRUCTION_ECHO_WEAK_MARKERS = (
-    "valid json",
-    "json array",
-    "json object",
-    "json string",
-    "markdown",
-    "code fences",
-    "response schema",
 )
 
 # Mirrors cloud-run-transcoder/src/main.rs `is_loop_hallucination` and
@@ -364,11 +355,7 @@ def distinct_marker_phrases(normalized: str, markers: Iterable[str]) -> int:
 def has_instruction_echo(text: str) -> bool:
     """Mirror of `contains_instruction_echo` in main.rs."""
     normalized = " ".join(text.split()).lower()
-    strong_count = distinct_marker_phrases(normalized, INSTRUCTION_ECHO_STRONG_MARKERS)
-    if strong_count >= 2:
-        return True
-    weak_count = distinct_marker_phrases(normalized, INSTRUCTION_ECHO_WEAK_MARKERS)
-    return strong_count >= 1 and weak_count >= 2
+    return distinct_marker_phrases(normalized, INSTRUCTION_ECHO_STRONG_MARKERS) >= 2
 
 
 def is_loop_hallucination(text: str) -> bool:

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -3294,11 +3294,52 @@ fn transcript_drop_reason(
     None
 }
 
+/// Count distinct instruction-phrase clusters in `normalized`.
+///
+/// Collects every marker match span, then merges spans that overlap *or* are
+/// separated only by whitespace, so one contiguous instruction sentence counts
+/// as a single phrase rather than several. This is what makes the threshold in
+/// `contains_instruction_echo` mean "multiple distinct phrases": redundant,
+/// overlapping markers (e.g. "return only a json" + "only a json object" inside
+/// "return only a JSON object") collapse to one cluster instead of inflating the
+/// count and tripping the gate on ordinary speech.
+fn distinct_marker_phrases(normalized: &str, markers: &[&str]) -> usize {
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    for marker in markers {
+        let mut from = 0;
+        while let Some(rel) = normalized[from..].find(marker) {
+            let start = from + rel;
+            spans.push((start, start + marker.len()));
+            from = start + 1;
+        }
+    }
+    if spans.is_empty() {
+        return 0;
+    }
+    spans.sort_unstable();
+
+    let mut clusters = 1;
+    let mut cluster_end = spans[0].1;
+    for &(start, end) in &spans[1..] {
+        // Same cluster when overlapping, or separated only by whitespace
+        // (one contiguous instruction). A non-whitespace gap means another
+        // distinct phrase.
+        if start <= cluster_end || normalized[cluster_end..start].trim().is_empty() {
+            cluster_end = cluster_end.max(end);
+        } else {
+            clusters += 1;
+            cluster_end = end;
+        }
+    }
+    clusters
+}
+
 /// Detect model output-format instructions that leaked into caption text.
 ///
-/// This intentionally requires multiple prompt/schema-derived phrases. Common
-/// technical speech such as "valid JSON" or "JSON array" alone must not trip a
-/// universal provider guard.
+/// This intentionally requires multiple *distinct* prompt/schema-derived
+/// phrases (see `distinct_marker_phrases`). Common technical speech such as
+/// "valid JSON" or "JSON array" alone — or a single contiguous instruction
+/// sentence — must not trip a universal provider guard.
 fn contains_instruction_echo(text: &str) -> bool {
     let normalized = text
         .split_whitespace()
@@ -3332,18 +3373,12 @@ fn contains_instruction_echo(text: &str) -> bool {
         "response schema",
     ];
 
-    let strong_count = STRONG_MARKERS
-        .iter()
-        .filter(|marker| normalized.contains(**marker))
-        .count();
+    let strong_count = distinct_marker_phrases(&normalized, STRONG_MARKERS);
     if strong_count >= 2 {
         return true;
     }
 
-    let weak_count = WEAK_MARKERS
-        .iter()
-        .filter(|marker| normalized.contains(**marker))
-        .count();
+    let weak_count = distinct_marker_phrases(&normalized, WEAK_MARKERS);
     strong_count >= 1 && weak_count >= 2
 }
 
@@ -4132,6 +4167,21 @@ mod tests {
         let tech_talk = "In our API docs, follow the schema provided for each endpoint \
             before sending the request body.";
         assert!(!contains_instruction_echo(tech_talk));
+    }
+
+    #[test]
+    fn instruction_echo_guard_passes_overlapping_strong_markers() {
+        // Ordinary speech where several STRONG markers overlap inside one
+        // contiguous clause must not reach the >=2 threshold. Before the
+        // cluster fix this dropped a whole transcript on a single sentence.
+        assert!(!contains_instruction_echo(
+            "The endpoint should return only a JSON object with the user's data."
+        ));
+        // A single contiguous instruction phrase (three overlapping markers)
+        // is one phrase, not three — needs a second distinct phrase to fire.
+        assert!(!contains_instruction_echo(
+            "Do not include any extra text outside of the JSON string."
+        ));
     }
 
     #[test]

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -1799,6 +1799,14 @@ async fn process_transcribe(
             );
             ParsedVtt::empty(audio_analysis.duration_ms)
         }
+        Some(TranscriptDropReason::InstructionEcho) => {
+            warn!(
+                hash,
+                text_preview = %first_chars(&parsed_vtt.text, 120),
+                "Dropping transcript with leaked output-format instructions"
+            );
+            ParsedVtt::empty(audio_analysis.duration_ms)
+        }
         None => parsed_vtt,
     };
 
@@ -3240,6 +3248,7 @@ enum TranscriptDropReason {
     LowSignalHeuristic,
     LoopHallucination,
     ImplausibleTextDensity,
+    InstructionEcho,
 }
 
 fn transcript_drop_reason(
@@ -3274,11 +3283,68 @@ fn transcript_drop_reason(
         return Some(TranscriptDropReason::LoopHallucination);
     }
 
+    if contains_instruction_echo(&parsed_vtt.text) {
+        return Some(TranscriptDropReason::InstructionEcho);
+    }
+
     if should_drop_low_signal_transcript(audio, parsed_vtt) {
         return Some(TranscriptDropReason::LowSignalHeuristic);
     }
 
     None
+}
+
+/// Detect model output-format instructions that leaked into caption text.
+///
+/// This intentionally requires multiple prompt/schema-derived phrases. Common
+/// technical speech such as "valid JSON" or "JSON array" alone must not trip a
+/// universal provider guard.
+fn contains_instruction_echo(text: &str) -> bool {
+    let normalized = text
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+
+    const STRONG_MARKERS: &[&str] = &[
+        "<bcp47>",
+        "<seconds>",
+        "<spoken words>",
+        "output requirements",
+        "follow the schema",
+        "provided in the context",
+        "extra text outside",
+        "outside of the json",
+        "do not include any extra text",
+        "return only a json",
+        "only a json object",
+        "single json array",
+        "spoken words transcribed verbatim",
+        "text field of every segment",
+    ];
+    const WEAK_MARKERS: &[&str] = &[
+        "valid json",
+        "json array",
+        "json object",
+        "json string",
+        "markdown",
+        "code fences",
+        "response schema",
+    ];
+
+    let strong_count = STRONG_MARKERS
+        .iter()
+        .filter(|marker| normalized.contains(**marker))
+        .count();
+    if strong_count >= 2 {
+        return true;
+    }
+
+    let weak_count = WEAK_MARKERS
+        .iter()
+        .filter(|marker| normalized.contains(**marker))
+        .count();
+    strong_count >= 1 && weak_count >= 2
 }
 
 /// Drop when the transcript contains more text than is physically utterable
@@ -3419,7 +3485,7 @@ async fn finalize_transcript(
 mod tests {
     use super::{
         build_transcode_status_webhook_payload, classify_audio_extract_error,
-        decide_transcript_lock_action, identity_token_cache_for_audience,
+        contains_instruction_echo, decide_transcript_lock_action, identity_token_cache_for_audience,
         is_empty_transcript_normalize_error, is_implausible_text_density, is_loop_hallucination,
         is_retryable_provider_failure, normalize_transcript_to_vtt, parakeet_request_url,
         parse_audio_analysis_output, parse_provider_status, retry_delay_for_attempt,
@@ -4044,6 +4110,59 @@ mod tests {
         // but the floor avoids false positives on tiny clips.
         let text = "x".repeat(99);
         assert!(!is_implausible_text_density(&text, 1));
+    }
+
+    #[test]
+    fn instruction_echo_guard_flags_prompt_schema_leak() {
+        let bad = "Well, that's not really freedom now, is it, you freaking idiot? \
+            a single JSON array. Do not include any extra text outside of the JSON string. \
+            When producing JSON you must follow the schema provided in the context.";
+        assert!(contains_instruction_echo(bad));
+    }
+
+    #[test]
+    fn instruction_echo_guard_passes_single_technical_marker() {
+        let tech_talk = "Today we're comparing a JSON array with a JSON object and explaining \
+            why valid JSON matters for API compatibility.";
+        assert!(!contains_instruction_echo(tech_talk));
+    }
+
+    #[test]
+    fn instruction_echo_guard_passes_overlapping_schema_speech() {
+        let tech_talk = "In our API docs, follow the schema provided for each endpoint \
+            before sending the request body.";
+        assert!(!contains_instruction_echo(tech_talk));
+    }
+
+    #[test]
+    fn instruction_echo_guard_passes_normal_speech() {
+        assert!(!contains_instruction_echo(
+            "Well, that's not really freedom now, is it? I think people deserve better."
+        ));
+    }
+
+    #[test]
+    fn transcript_drop_reason_flags_instruction_echo() {
+        let text = "Return only a JSON object. The text field of every segment must contain \
+            only the spoken words transcribed verbatim.";
+        let parsed = ParsedVtt {
+            content: format!("WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n{}\n\n", text),
+            text: text.to_string(),
+            language: None,
+            duration_ms: 8_000,
+            cue_count: 1,
+            confidence: None,
+        };
+        let analysis = AudioAnalysis {
+            duration_ms: 8_000,
+            silent_duration_ms: 0,
+            mean_volume_db: Some(-20.0),
+            max_volume_db: Some(-4.0),
+        };
+        assert_eq!(
+            transcript_drop_reason(&analysis, &parsed),
+            Some(TranscriptDropReason::InstructionEcho)
+        );
     }
 
     /// Real-world failure from production: a 6-second clip Gemini transcribed

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -3338,8 +3338,8 @@ fn distinct_marker_phrases(normalized: &str, markers: &[&str]) -> usize {
 ///
 /// This intentionally requires multiple *distinct* prompt/schema-derived
 /// phrases (see `distinct_marker_phrases`). Common technical speech such as
-/// "valid JSON" or "JSON array" alone — or a single contiguous instruction
-/// sentence — must not trip a universal provider guard.
+/// "valid JSON", "JSON array", or "response schema" — or a single contiguous
+/// instruction sentence — must not trip a universal provider guard.
 fn contains_instruction_echo(text: &str) -> bool {
     let normalized = text
         .split_whitespace()
@@ -3363,23 +3363,7 @@ fn contains_instruction_echo(text: &str) -> bool {
         "spoken words transcribed verbatim",
         "text field of every segment",
     ];
-    const WEAK_MARKERS: &[&str] = &[
-        "valid json",
-        "json array",
-        "json object",
-        "json string",
-        "markdown",
-        "code fences",
-        "response schema",
-    ];
-
-    let strong_count = distinct_marker_phrases(&normalized, STRONG_MARKERS);
-    if strong_count >= 2 {
-        return true;
-    }
-
-    let weak_count = distinct_marker_phrases(&normalized, WEAK_MARKERS);
-    strong_count >= 1 && weak_count >= 2
+    distinct_marker_phrases(&normalized, STRONG_MARKERS) >= 2
 }
 
 /// Drop when the transcript contains more text than is physically utterable
@@ -4166,6 +4150,13 @@ mod tests {
     fn instruction_echo_guard_passes_overlapping_schema_speech() {
         let tech_talk = "In our API docs, follow the schema provided for each endpoint \
             before sending the request body.";
+        assert!(!contains_instruction_echo(tech_talk));
+    }
+
+    #[test]
+    fn instruction_echo_guard_passes_one_strong_with_weak_json_terms() {
+        let tech_talk = "Follow the schema for this endpoint: it returns a JSON array, \
+            accepts a JSON object, and the docs call this the response schema.";
         assert!(!contains_instruction_echo(tech_talk));
     }
 

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -3340,30 +3340,52 @@ fn distinct_marker_phrases(normalized: &str, markers: &[&str]) -> usize {
 /// phrases (see `distinct_marker_phrases`). Common technical speech such as
 /// "valid JSON", "JSON array", or "response schema" — or a single contiguous
 /// instruction sentence — must not trip a universal provider guard.
+///
+/// Every marker below is high-specificity: a literal template token
+/// (`<bcp47>`), or a verbatim prompt/`responseSchema` clause that does not
+/// occur in ordinary speech. Generic English fragments that happened to be
+/// substrings of a leaked clause ("output requirements", "follow the schema",
+/// "provided in the context", "return only a json", "only a json object")
+/// were deliberately removed: split out of their leaked sentence they fire on
+/// legitimate developer/API speech ("our output requirements changed, follow
+/// the schema in the docs"), and because a drop is terminal (empty VTT →
+/// status=complete → edge-cached, no auto-retranscribe) a false positive is
+/// permanent caption loss. The real #134 leak still carries several of the
+/// retained phrases, so detection is unaffected.
 fn contains_instruction_echo(text: &str) -> bool {
-    let normalized = text
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_ascii_lowercase();
+    let normalized = normalize_for_marker_scan(text);
 
     const STRONG_MARKERS: &[&str] = &[
         "<bcp47>",
         "<seconds>",
         "<spoken words>",
-        "output requirements",
-        "follow the schema",
-        "provided in the context",
+        "do not include any extra text",
         "extra text outside",
         "outside of the json",
-        "do not include any extra text",
-        "return only a json",
-        "only a json object",
         "single json array",
+        "follow the schema provided in the context",
         "spoken words transcribed verbatim",
         "text field of every segment",
     ];
     distinct_marker_phrases(&normalized, STRONG_MARKERS) >= 2
+}
+
+/// Collapse whitespace and lowercase for marker scanning, mapping every C0
+/// control char (U+0000–U+001F) to a space first. Python's `str.split()`
+/// treats U+001C–U+001F as whitespace but Rust's `split_whitespace()` (Unicode
+/// White_Space) does not, so without this the Rust gate and the Python scanner
+/// would cluster the same bytes differently. Normalizing controls up front
+/// keeps the two implementations byte-for-byte identical.
+fn normalize_for_marker_scan(text: &str) -> String {
+    let cleaned: String = text
+        .chars()
+        .map(|c| if (c as u32) < 0x20 { ' ' } else { c })
+        .collect();
+    cleaned
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
 }
 
 /// Drop when the transcript contains more text than is physically utterable
@@ -4172,6 +4194,34 @@ mod tests {
         // is one phrase, not three — needs a second distinct phrase to fire.
         assert!(!contains_instruction_echo(
             "Do not include any extra text outside of the JSON string."
+        ));
+    }
+
+    #[test]
+    fn instruction_echo_guard_passes_split_generic_schema_speech() {
+        // Generic English fragments ("output requirements", "follow the
+        // schema", "provided in the context") that were once markers fire on
+        // legitimate developer/API speech when ordinary words separate them.
+        // Pruning them to the contiguous leaked clause keeps these transcripts.
+        for legit in [
+            "Our API output requirements changed, so please follow the schema in the new docs.",
+            "You should follow the schema that was provided in the context of the previous lesson.",
+            "Our output requirements say to return only a JSON object for each user record.",
+        ] {
+            assert!(
+                !contains_instruction_echo(legit),
+                "legitimate speech must not drop: {legit}"
+            );
+        }
+    }
+
+    #[test]
+    fn instruction_echo_guard_normalizes_c0_controls() {
+        // C0 control chars between two markers must be treated as whitespace so
+        // the Rust gate and the Python scanner cluster identically. A single
+        // contiguous instruction split only by a control char is one phrase.
+        assert!(!contains_instruction_echo(
+            "do not include any extra text\u{1c}outside of the json"
         ));
     }
 

--- a/cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py
+++ b/cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py
@@ -133,6 +133,28 @@ class RepairRecentBadVttsTests(unittest.TestCase):
 
         self.assertTrue(detector(body))
 
+    def test_ignores_split_generic_schema_speech(self):
+        # Generic fragments that were once markers must not flag a legitimate
+        # transcript for repair when ordinary words separate them. A false
+        # positive here force-retranscribes a good caption.
+        module = load_script_module(self)
+        detector = getattr(module, "is_bad_vtt_body", None)
+        self.assertIsNotNone(detector, "is_bad_vtt_body should exist")
+
+        for spoken in (
+            "Our API output requirements changed, so please follow the schema "
+            "in the new docs.",
+            "You should follow the schema that was provided in the context of "
+            "the previous lesson.",
+            "Our output requirements say to return only a JSON object for each "
+            "user record.",
+        ):
+            body = f"WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n{spoken}\n"
+            self.assertFalse(
+                detector(body),
+                f"legitimate speech must not be flagged: {spoken!r}",
+            )
+
     def test_collects_recent_media_hashes_with_age_filter_and_dedupe(self):
         module = load_script_module(self)
         collector = getattr(module, "collect_recent_media_hashes", None)

--- a/cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py
+++ b/cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py
@@ -47,6 +47,46 @@ class RepairRecentBadVttsTests(unittest.TestCase):
 
         self.assertFalse(detector(body))
 
+    def test_detects_instruction_echo_vtt_body(self):
+        module = load_script_module(self)
+        detector = getattr(module, "is_bad_vtt_body", None)
+        self.assertIsNotNone(detector, "is_bad_vtt_body should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:07.000\n"
+            "Well, that's not really freedom now, is it? a single JSON array. "
+            "Do not include any extra text outside of the JSON string. "
+            "When producing JSON you must follow the schema provided in the context.\n"
+        )
+
+        self.assertTrue(detector(body))
+
+    def test_ignores_technical_json_speech(self):
+        module = load_script_module(self)
+        detector = getattr(module, "is_bad_vtt_body", None)
+        self.assertIsNotNone(detector, "is_bad_vtt_body should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n"
+            "Today we're comparing a JSON array with a JSON object and explaining "
+            "why valid JSON matters for API compatibility.\n"
+        )
+
+        self.assertFalse(detector(body))
+
+    def test_ignores_overlapping_schema_speech(self):
+        module = load_script_module(self)
+        detector = getattr(module, "is_bad_vtt_body", None)
+        self.assertIsNotNone(detector, "is_bad_vtt_body should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n"
+            "In our API docs, follow the schema provided for each endpoint "
+            "before sending the request body.\n"
+        )
+
+        self.assertFalse(detector(body))
+
     def test_collects_recent_media_hashes_with_age_filter_and_dedupe(self):
         module = load_script_module(self)
         collector = getattr(module, "collect_recent_media_hashes", None)

--- a/cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py
+++ b/cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py
@@ -87,6 +87,19 @@ class RepairRecentBadVttsTests(unittest.TestCase):
 
         self.assertFalse(detector(body))
 
+    def test_ignores_one_strong_with_weak_json_terms(self):
+        module = load_script_module(self)
+        detector = getattr(module, "is_bad_vtt_body", None)
+        self.assertIsNotNone(detector, "is_bad_vtt_body should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n"
+            "Follow the schema for this endpoint: it returns a JSON array, "
+            "accepts a JSON object, and the docs call this the response schema.\n"
+        )
+
+        self.assertFalse(detector(body))
+
     def test_ignores_overlapping_strong_markers(self):
         # Ordinary speech where several STRONG markers overlap inside one
         # contiguous clause must not trip the gate (cluster counting).

--- a/cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py
+++ b/cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py
@@ -87,6 +87,39 @@ class RepairRecentBadVttsTests(unittest.TestCase):
 
         self.assertFalse(detector(body))
 
+    def test_ignores_overlapping_strong_markers(self):
+        # Ordinary speech where several STRONG markers overlap inside one
+        # contiguous clause must not trip the gate (cluster counting).
+        module = load_script_module(self)
+        detector = getattr(module, "is_bad_vtt_body", None)
+        self.assertIsNotNone(detector, "is_bad_vtt_body should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n"
+            "The endpoint should return only a JSON object with the user's data.\n"
+        )
+
+        self.assertFalse(detector(body))
+
+    def test_detects_instruction_echo_split_across_cues(self):
+        # The normal Gemini path emits one cue per segment, so a leaked
+        # instruction is split across cue boundaries. Detecting on spoken
+        # text (not the raw body) keeps the phrases contiguous.
+        module = load_script_module(self)
+        detector = getattr(module, "is_bad_vtt_body", None)
+        self.assertIsNotNone(detector, "is_bad_vtt_body should exist")
+
+        body = (
+            "WEBVTT\n\n"
+            "1\n00:00:00.000 --> 00:00:03.000\na single JSON array.\n\n"
+            "2\n00:00:03.000 --> 00:00:06.000\n"
+            "Do not include any extra text outside of the JSON string.\n\n"
+            "3\n00:00:06.000 --> 00:00:09.000\n"
+            "Follow the schema provided in the context.\n"
+        )
+
+        self.assertTrue(detector(body))
+
     def test_collects_recent_media_hashes_with_age_filter_and_dedupe(self):
         module = load_script_module(self)
         collector = getattr(module, "collect_recent_media_hashes", None)

--- a/cloud-run-transcoder/tests/test_scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/tests/test_scan_and_repair_vtts.py
@@ -62,6 +62,19 @@ class ScanAndRepairVttsTests(unittest.TestCase):
 
         self.assertIsNone(classifier(body, check_empty=False))
 
+    def test_ignores_one_strong_with_weak_json_terms(self):
+        module = load_script_module(self)
+        classifier = getattr(module, "classify_vtt", None)
+        self.assertIsNotNone(classifier, "classify_vtt should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n"
+            "Follow the schema for this endpoint: it returns a JSON array, "
+            "accepts a JSON object, and the docs call this the response schema.\n"
+        )
+
+        self.assertIsNone(classifier(body, check_empty=False))
+
     def test_ignores_overlapping_strong_markers(self):
         # Several STRONG markers overlapping inside one contiguous clause must
         # not reach the >=2 threshold (cluster counting, not raw substring hits).

--- a/cloud-run-transcoder/tests/test_scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/tests/test_scan_and_repair_vtts.py
@@ -1,0 +1,67 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scan_and_repair_vtts.py"
+
+
+def load_script_module(test_case: unittest.TestCase):
+    if not SCRIPT_PATH.exists():
+        test_case.fail(f"missing script: {SCRIPT_PATH}")
+
+    spec = importlib.util.spec_from_file_location("scan_and_repair_vtts", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        test_case.fail(f"unable to load script module: {SCRIPT_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class ScanAndRepairVttsTests(unittest.TestCase):
+    def test_classifies_instruction_echo(self):
+        module = load_script_module(self)
+        classifier = getattr(module, "classify_vtt", None)
+        self.assertIsNotNone(classifier, "classify_vtt should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:07.000\n"
+            "Well, that's not really freedom now, is it? a single JSON array. "
+            "Do not include any extra text outside of the JSON string. "
+            "When producing JSON you must follow the schema provided in the context.\n"
+        )
+
+        self.assertEqual(classifier(body, check_empty=False), "instruction_echo")
+
+    def test_ignores_technical_json_speech(self):
+        module = load_script_module(self)
+        classifier = getattr(module, "classify_vtt", None)
+        self.assertIsNotNone(classifier, "classify_vtt should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n"
+            "Today we're comparing a JSON array with a JSON object and explaining "
+            "why valid JSON matters for API compatibility.\n"
+        )
+
+        self.assertIsNone(classifier(body, check_empty=False))
+
+    def test_ignores_overlapping_schema_speech(self):
+        module = load_script_module(self)
+        classifier = getattr(module, "classify_vtt", None)
+        self.assertIsNotNone(classifier, "classify_vtt should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n"
+            "In our API docs, follow the schema provided for each endpoint "
+            "before sending the request body.\n"
+        )
+
+        self.assertIsNone(classifier(body, check_empty=False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud-run-transcoder/tests/test_scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/tests/test_scan_and_repair_vtts.py
@@ -62,6 +62,20 @@ class ScanAndRepairVttsTests(unittest.TestCase):
 
         self.assertIsNone(classifier(body, check_empty=False))
 
+    def test_ignores_overlapping_strong_markers(self):
+        # Several STRONG markers overlapping inside one contiguous clause must
+        # not reach the >=2 threshold (cluster counting, not raw substring hits).
+        module = load_script_module(self)
+        classifier = getattr(module, "classify_vtt", None)
+        self.assertIsNotNone(classifier, "classify_vtt should exist")
+
+        body = (
+            "WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n"
+            "The endpoint should return only a JSON object with the user's data.\n"
+        )
+
+        self.assertIsNone(classifier(body, check_empty=False))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cloud-run-transcoder/tests/test_scan_and_repair_vtts.py
+++ b/cloud-run-transcoder/tests/test_scan_and_repair_vtts.py
@@ -89,6 +89,63 @@ class ScanAndRepairVttsTests(unittest.TestCase):
 
         self.assertIsNone(classifier(body, check_empty=False))
 
+    def test_ignores_split_generic_schema_speech(self):
+        # Generic fragments that were once markers ("output requirements",
+        # "follow the schema", "provided in the context") must not drop a
+        # legitimate transcript when ordinary words separate them.
+        module = load_script_module(self)
+        classifier = getattr(module, "classify_vtt", None)
+        self.assertIsNotNone(classifier, "classify_vtt should exist")
+
+        for spoken in (
+            "Our API output requirements changed, so please follow the schema "
+            "in the new docs.",
+            "You should follow the schema that was provided in the context of "
+            "the previous lesson.",
+            "Our output requirements say to return only a JSON object for each "
+            "user record.",
+        ):
+            body = f"WEBVTT\n\n1\n00:00:00.000 --> 00:00:08.000\n{spoken}\n"
+            self.assertIsNone(
+                classifier(body, check_empty=False),
+                f"legitimate speech must not classify as bad: {spoken!r}",
+            )
+
+    def test_marker_scan_normalizes_c0_controls(self):
+        # A single contiguous instruction split only by a C0 control char is
+        # one phrase, matching the Rust gate's control normalization.
+        module = load_script_module(self)
+        has_echo = getattr(module, "has_instruction_echo", None)
+        self.assertIsNotNone(has_echo, "has_instruction_echo should exist")
+        self.assertFalse(
+            has_echo("do not include any extra text\x1coutside of the json")
+        )
+
+
+class MarkerParityTests(unittest.TestCase):
+    """The Rust gate and the Python scanner must use the same marker list."""
+
+    def test_rust_and_python_strong_markers_match(self):
+        module = load_script_module(self)
+        python_markers = tuple(module.INSTRUCTION_ECHO_STRONG_MARKERS)
+
+        rust_path = SCRIPT_PATH.parent / "src" / "main.rs"
+        source = rust_path.read_text(encoding="utf-8")
+        marker = "const STRONG_MARKERS: &[&str] = &["
+        start = source.index(marker) + len(marker)
+        end = source.index("];", start)
+        rust_markers = tuple(
+            line.strip().strip(",").strip('"')
+            for line in source[start:end].splitlines()
+            if line.strip()
+        )
+
+        self.assertEqual(
+            rust_markers,
+            python_markers,
+            "STRONG_MARKERS drifted between main.rs and scan_and_repair_vtts.py",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a universal transcoder quality-gate reason for leaked output-format/schema instruction echoes in captions
- mirror the detector into both VTT repair scanners so stored bad captions can be found and retranscribed
- add Rust and Python regression coverage for the real failure shape and technical-speech false-positive boundaries

## Motivation
Gemini-as-STT can echo its own JSON/schema output instructions into segment text as plain prose. Existing structural JSON cleanup and provider-specific Google guards do not catch that failure mode, so the echoed instructions can ship as WebVTT captions.

Closes #134.

## Root Cause
The Gemini request asks for strict structured transcript output. When Gemini copies output-format/schema prose into a segment text field, the existing cleanup only strips structural JSON/fence tails, and the universal transcript drop gate only checks confidence, text density, loops, and low-signal hallucinations.

## User / Developer Impact
Bad instruction-echo captions are now dropped before upload, which triggers the existing empty-VTT/self-heal behavior rather than serving leaked model instructions. The operational scanners now classify the same prose-instruction leak as `instruction_echo` for repair runs. The detector requires prompt/schema-specific phrase co-occurrence to avoid dropping normal developer or API-related speech.

## Manual Validation
- `python3 -m unittest cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py cloud-run-transcoder/tests/test_scan_and_repair_vtts.py`
- `cargo test --manifest-path cloud-run-transcoder/Cargo.toml --locked`
- `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked`
- `cargo check --tests --locked`
- `cargo clippy --locked --all-targets --all-features`
- `python3 -m py_compile cloud-run-transcoder/repair_recent_bad_vtts.py cloud-run-transcoder/scan_and_repair_vtts.py cloud-run-transcoder/tests/test_repair_recent_bad_vtts.py cloud-run-transcoder/tests/test_scan_and_repair_vtts.py`

## Notes
No visual change. Root-level clippy/check commands exit successfully but still print pre-existing warnings in unrelated Fastly/root code.