### PR TITLE
docs: unify CLAUDE.md and AGENTS.md structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,23 @@
 - Public issues, PRs, branch names, screenshots, and descriptions must not mention corporate partners, customers, brands, campaign names, or other sensitive external identities unless a maintainer explicitly approves it. Use generic descriptors instead.
 - Respect the existing deployment rule: use `fastly compute publish` for Fastly deploys, not separate build and deploy commands.
 
+## Fastly Compute Deployment Rules
+
+**ALWAYS use `fastly compute publish` instead of `fastly compute build` + `fastly compute deploy`.** The `publish` command does build+deploy in a single atomic operation.
+
+### Deployment Workflow
+```bash
+fastly compute publish --comment "description" && fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR
+```
+
+### Key Lessons
+- `fastly compute publish --comment "description"` is the correct way to deploy.
+- Do NOT use `fastly compute deploy` separately.
+- Local testing with `fastly compute serve` works correctly for verification.
+- **CRITICAL: Always purge after deploy!** Run `fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR` after publishing.
+- **Propagation can be SLOW** — even after purge, Compute package propagation to all POPs can take several minutes. The version may show as "active" in the API but edge POPs may still serve old code. Be patient.
+- Remember it takes a few minutes for Fastly deploys to roll out; relax and let it happen.
+
 ## Pull Request Guardrails
 - PR titles must use Conventional Commit format: `type(scope): summary` or `type: summary`.
 - Set the correct PR title when opening the PR. Do not rely on fixing it later.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,5 @@
-# Fastly Compute Deployment Rules
+# CLAUDE.md
 
-**ALWAYS use `fastly compute publish` instead of `fastly compute build` + `fastly compute deploy`**
+<!-- Canonical guidance lives in AGENTS.md, imported below. Add Claude-only notes after the import. -->
 
-The `publish` command does build+deploy in a single atomic operation.
-
-## Deployment Workflow
-```bash
-fastly compute publish --comment "description" && fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR
-```
-
-## Key Lessons
-- `fastly compute publish --comment "description"` is the correct way to deploy
-- Do NOT use `fastly compute deploy` separately
-- Local testing with `fastly compute serve` works correctly for verification
-- **CRITICAL: Always purge after deploy!** Run `fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR` after publishing
-- **Propagation can be SLOW** - even after purge, Compute package propagation to all POPs can take several minutes. The version may show as "active" in the API but edge POPs may still serve old code. Be patient.
-- memorize it takes a few minutes for fastly deploys to roll out, relax, and let it happen.
+@AGENTS.md


### PR DESCRIPTION
## Summary
Unifies this repo's agent-instruction files so Claude Code and other agents share one source of truth. `AGENTS.md` becomes canonical (absorbs content that previously lived only in `CLAUDE.md`); `CLAUDE.md` becomes a thin `@AGENTS.md` import.

## Motivation
Claude Code reads only `CLAUDE.md` and never reads `AGENTS.md` automatically. The two files held different content, so each tool saw only part of the guidance and they drifted. The `@AGENTS.md` import (Anthropic's recommended pattern) bridges them with zero duplication.

## Content moved (no information lost)
- Added a `## Fastly Compute Deployment Rules` section to `AGENTS.md` capturing everything that previously lived only in `CLAUDE.md`:
  - The rule to always use `fastly compute publish` instead of `fastly compute build` + `fastly compute deploy`, and that `publish` does build+deploy in a single atomic operation.
  - The deployment workflow command, including the `--comment` flag and the post-deploy `fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR`.
  - The key lessons: do not use `fastly compute deploy` separately; `fastly compute serve` works for local verification; CRITICAL always purge after deploy; propagation to all POPs can be slow even after purge (version may show "active" while POPs serve old code); deploys take a few minutes to roll out.

No code or functional change.
