### PR TITLE
docs(agents): add divine-context bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,21 @@
 # Repository Guidelines
 
+## Divine Context And Brain
+
+Before broad product, architecture, protocol, cross-repo, or service-boundary work, read the shared Divine context primer.
+
+Use `DIVINE_CONTEXT_ROOT` if set; otherwise look for `../divine-context`. If it is missing, try:
+
+`gh repo clone divinevideo/divine-context ../divine-context`
+
+The `divine-context` repo is private, so cloning requires GitHub access. If clone, network, or auth fails, continue from the local repo docs and avoid cross-repo assumptions.
+
+Before updating an existing context checkout, verify it is clean and on its default branch. If it is clean and on the default branch, update it with `git -C <context-dir> pull --ff-only`. If it is dirty, on another branch, cannot fast-forward, or network/auth fails, leave it untouched and say the context may be stale.
+
+Read `<context-dir>/AGENT_CONTEXT.md` and follow its instructions. If unavailable, continue from the local repo docs and avoid cross-repo assumptions.
+
+If a Divine Brain search or ask tool is available, you may use it for company memory. Treat it as optional and credentialed: tool names vary by client, and work must continue when Brain is unavailable. When Brain results influence work, cite the returned document ids. Never commit Brain credentials or expose Brain-derived sensitive content in public PRs, issues, branch names, commit messages, code comments, logs, screenshots, release notes, or externally shared agent transcripts.
+
 ## Project Structure & Module Organization
 - Fastly Compute edge service code lives under `src/`.
 - Cloud Run services live under `cloud-run-upload/` and `cloud-run-transcoder/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,1 @@
-# CLAUDE.md
-
-<!-- Canonical guidance lives in AGENTS.md, imported below. Add Claude-only notes after the import. -->
-
 @AGENTS.md


### PR DESCRIPTION
## Summary

Adds the shared Divine Context and optional Divine Brain bootstrap to the repo agent instructions.
This keeps `AGENTS.md` portable across Codex, Claude, OpenCode, and other agents while leaving `CLAUDE.md` as a thin Claude shim.

## Testing

- `git diff --check refs/remotes/https-main/main..HEAD`
- Verified `AGENTS.md` contains the exact `## Divine Context And Brain` template section
- Verified `CLAUDE.md` is exactly `@AGENTS.md` plus trailing newline
- Verified branch is `0` behind and `1` ahead of freshly fetched GitHub `main`
