### PR TITLE
docs: align README with Divine brand guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,3 +278,7 @@ a moderate/delete request.
 ## License
 
 MIT
+
+---
+
+Part of [Divine](https://divine.video) — your playground for human creativity · [Brand guidelines](https://github.com/divinevideo/brand-guidelines)


### PR DESCRIPTION
Branding/docs pass aligning the README with the Divine brand guidelines.

## Changes
- Added the standard Divine brand footer at the end of README.md.

No prose brand-name fixes were needed: every `divine-*` reference in the README is a code identifier (GCS bucket `divine-blossom-media`, service label `divine-blossom`, `divine-moderation-service`) or a domain (`media.divine.video`), all of which are machine-read and left untouched. The title "Fastly Blossom Server" and standalone "Blossom" refer to the Blossom protocol, not the Divine product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)