### PR TITLE
feat(edge): forward POST /transcribe to the upload service

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,9 @@ fn handle_request(req: Request) -> Result<Response> {
         (Method::PUT, "/upload") => handle_upload(req),
         // BUD-06: Upload requirements/pre-validation
         (Method::HEAD, "/upload") => handle_upload_requirements(req),
+        // Synchronous audio transcription — thin forward to the upload service's
+        // authenticated /transcribe proxy (which calls the transcoder).
+        (Method::POST, "/transcribe") => handle_transcribe_proxy(req),
         // Divine resumable control plane
         (Method::POST, "/upload/init") => handle_upload_init(req),
         (Method::POST, p) if p.starts_with("/upload/") && p.ends_with("/complete") => {
@@ -3671,6 +3674,52 @@ fn handle_upload_complete(mut req: Request, path: &str) -> Result<Response> {
             dim: complete_response.dim,
         },
     )
+}
+
+/// POST /transcribe — thin forward to the upload service's authenticated
+/// transcription proxy (`upload.divine.video/transcribe`), which validates the
+/// Blossom auth and calls the transcoder. The mobile editor only addresses this
+/// edge host, so transcription has to enter here.
+///
+/// The body (audio) is streamed straight through — Fastly Compute has a ~5 MB
+/// WASM memory limit, so we never buffer it. Auth is passed through unchanged;
+/// the upload service is the authority that validates it (`t=media`).
+fn handle_transcribe_proxy(mut req: Request) -> Result<Response> {
+    let auth_header = extract_authorization_header(&req)?;
+    let content_type = req
+        .get_header(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("audio/wav")
+        .to_string();
+    let query = req.get_query_str().map(str::to_string);
+    let body = req.take_body();
+
+    let mut url = format!("https://{}/transcribe", UPLOAD_SERVICE_HOST);
+    if let Some(query) = query.filter(|q| !q.is_empty()) {
+        url.push('?');
+        url.push_str(&query);
+    }
+
+    let mut proxy_req = Request::new(Method::POST, &url);
+    proxy_req.set_header("Host", UPLOAD_SERVICE_HOST);
+    proxy_req.set_header(header::AUTHORIZATION, &auth_header);
+    proxy_req.set_header(header::CONTENT_TYPE, &content_type);
+    proxy_req.set_body(body);
+
+    let mut proxy_resp = proxy_req
+        .send(UPLOAD_SERVICE_BACKEND)
+        .map_err(|e| BlossomError::Internal(format!("Failed to proxy transcription: {}", e)))?;
+
+    // Pass the upload service's response (WebVTT or its error) straight back.
+    let status = proxy_resp.get_status();
+    let resp_content_type = proxy_resp
+        .get_header(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("text/vtt; charset=utf-8")
+        .to_string();
+    Ok(Response::from_status(status)
+        .with_header(header::CONTENT_TYPE, resp_content_type)
+        .with_body(proxy_resp.take_body()))
 }
 
 /// Handle large uploads by proxying to the upload service


### PR DESCRIPTION
## Summary

Adds a thin **`POST /transcribe`** route to the edge (`media.divine.video`) that forwards to the upload service's authenticated `/transcribe` proxy.

- Streams the request body (audio) straight through — never buffered, so it stays within Fastly Compute's ~5 MB WASM memory limit (same reason large uploads are proxied).
- Passes the `Authorization` header through unchanged; the upload service is the authority that validates the Blossom auth (`t=media`). The edge does not re-validate.
- Reuses the existing `upload_service` backend (already configured for `upload.divine.video`) — **no new Fastly backend needed**.
- Passes the upload service's response (WebVTT, or its error status) straight back. CORS preflight is covered by the existing global `OPTIONS` handler.

## Motivation

Completes the reachability chain for the mobile editor's pre-publish caption generation. The mobile Blossom client only ever addresses the `media.divine.video` edge (there is no `upload.divine.video` in the app), and the edge matches every route explicitly with no catch-all forward — so without this route the editor cannot reach the transcription endpoint at all.

Chain:
- **This PR** — edge `POST /transcribe` → forwards to ↓
- divinevideo/divine-upload-server#12 — authenticated `POST /transcribe` proxy → calls ↓
- divinevideo/divine-blossom#141 — transcoder `POST /transcribe/audio` (Gemini) → WebVTT

## Rate limiting

The rate-limiting requirement lives at the authenticated proxy (divine-upload-server#12), which knows the caller pubkey. This edge route is a pass-through and adds no throttle of its own.

## Test plan

- `cargo check` — clean (pre-existing warnings only).
- `cargo fmt --check` — my lines are clean (the repo has unrelated pre-existing fmt drift elsewhere, left untouched to keep this scoped).
- Not unit-tested: this is a thin I/O forward mirroring the existing `handle_upload_service_proxy`; the repo's unit tests cover pure path parsers, not proxy handlers. Reviewer should smoke-test `POST media.divine.video/transcribe` (signed kind-24242 `t=media` + short WAV) against staging once #12 is deployed and confirm WebVTT returns.

Closes #none