### PR TITLE
fix(ci): copy blossom-core into local image builder

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -9,6 +9,7 @@ RUN rustup target add wasm32-wasip1
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
+COPY blossom-core/ blossom-core/
 
 # Build the WASM binary
 RUN cargo build --locked --target wasm32-wasip1 --release


### PR DESCRIPTION
The local Docker image could not build after `blossom-core` became a Cargo workspace member.
This change gives the builder the missing crate so local and CI image builds can compile the WASM service again.

## Summary

- Copy the complete `blossom-core` crate into the Docker builder before the locked WASM build.

## Motivation

- The root Cargo manifest declares `blossom-core` as a workspace member and path dependency, but `Dockerfile.local` copied only the root manifests and `src/`. Cargo therefore stopped before dependency resolution because `/app/blossom-core/Cargo.toml` was missing.
- Copying the complete crate includes both its manifest and source while keeping unrelated services out of the build context.
- The separate process-blob authentication failure is not changed here because its target project and masked secret destinations are not confirmed.

## Related Issue

- Part of #144

## Validation

- [x] `cargo check --tests --locked`
- [x] `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked`
- [x] `cargo clippy --locked --all-targets --all-features`
- [x] relevant service-local checks for touched Cloud Run or Python code
- [x] I could not run some validation locally, and I explained why below

## Manual Test Plan / Notes

- Reproduced the original linux/amd64 missing-manifest failure before the change.
- Built both the linux/amd64 builder stage and complete runtime image after the change.
- Ran 99 `blossom-core` tests, 18 upload tests, 125 transcoder Rust tests, and 23 transcoder Python tests.
- Local Buildx advertises only amd64-family platforms, so linux/arm64 needs the approved GitHub Actions multi-architecture run.

## Visuals / API Examples

- [x] No visual change
- [ ] Screenshots, sample payloads, or logs attached if needed

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved