### PR TITLE
fix: durable derivative status delivery via Cloud Tasks + fix webhook 403

### DIFF
--- a/blossom-core/src/delete_policy.rs
+++ b/blossom-core/src/delete_policy.rs
@@ -223,6 +223,8 @@ mod tests {
             transcript_retry_after: None,
             transcript_attempt_count: 0,
             transcript_terminal: false,
+            transcode_generation: None,
+            transcript_generation: None,
         }
     }
 

--- a/blossom-core/src/types.rs
+++ b/blossom-core/src/types.rs
@@ -76,6 +76,11 @@ pub struct BlobMetadata {
     /// Whether HLS generation has reached a terminal failure state
     #[serde(default)]
     pub transcode_terminal: bool,
+    /// Monotonic ordering token from the last applied transcode status callback.
+    /// A callback carrying a smaller generation is stale (superseded) and is
+    /// dropped by the receiver. Sourced from the transcoder's send-time clock.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcode_generation: Option<u64>,
     /// Video dimensions as "WIDTHxHEIGHT" (display dimensions after rotation)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dim: Option<String>,
@@ -100,6 +105,10 @@ pub struct BlobMetadata {
     /// Whether transcript generation has reached a terminal failure state
     #[serde(default)]
     pub transcript_terminal: bool,
+    /// Monotonic ordering token from the last applied transcript status
+    /// callback. A callback carrying a smaller generation is stale and dropped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transcript_generation: Option<u64>,
 }
 
 /// Moderation status for blobs
@@ -821,6 +830,8 @@ mod tests {
             transcript_retry_after: None,
             transcript_attempt_count: 0,
             transcript_terminal: false,
+            transcode_generation: None,
+            transcript_generation: None,
         }
     }
 
@@ -1000,6 +1011,8 @@ mod tests {
             transcript_retry_after: None,
             transcript_attempt_count: 0,
             transcript_terminal: false,
+            transcode_generation: None,
+            transcript_generation: None,
         }
     }
 

--- a/cloud-run-transcoder/src/main.rs
+++ b/cloud-run-transcoder/src/main.rs
@@ -102,6 +102,14 @@ struct Config {
     /// `transcription_provider == "parakeet"`. Audience for the
     /// Cloud Run identity token is the same URL.
     parakeet_asr_url: Option<String>,
+    /// When true, status callbacks are enqueued to Cloud Tasks (durable, retried)
+    /// instead of POSTed directly to Fastly. Default false — the direct POST is
+    /// the rollback path. See docs/superpowers/plans/2026-07-24-derivative-status-queue-simple.md
+    status_queue_enabled: bool,
+    /// Cloud Tasks location for the status queue (e.g. "us-central1").
+    status_queue_location: String,
+    /// Cloud Tasks queue id for status callbacks.
+    status_queue_name: String,
 }
 
 impl Config {
@@ -236,6 +244,13 @@ impl Config {
             parakeet_asr_url: lookup("PARAKEET_ASR_URL")
                 .map(|v| v.trim().to_string())
                 .filter(|v| !v.is_empty()),
+            status_queue_enabled: parse_bool(&mut lookup, "STATUS_QUEUE_ENABLED", false),
+            status_queue_location: lookup("STATUS_QUEUE_LOCATION")
+                .filter(|v| !v.trim().is_empty())
+                .unwrap_or_else(|| "us-central1".to_string()),
+            status_queue_name: lookup("STATUS_QUEUE_NAME")
+                .filter(|v| !v.trim().is_empty())
+                .unwrap_or_else(|| "derivative-status".to_string()),
         }
     }
 
@@ -3525,7 +3540,8 @@ async fn finalize_transcript(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_transcode_status_webhook_payload, classify_audio_extract_error,
+        attach_generation, build_cloud_tasks_task_body, build_transcode_status_webhook_payload,
+        classify_audio_extract_error,
         contains_instruction_echo, decide_transcript_lock_action, identity_token_cache_for_audience,
         is_empty_transcript_normalize_error, is_implausible_text_density, is_loop_hallucination,
         is_retryable_provider_failure, normalize_transcript_to_vtt, parakeet_request_url,
@@ -3727,6 +3743,62 @@ mod tests {
         assert!(payload.get("error_message").is_none());
         assert!(payload.get("retry_after").is_none());
         assert!(payload.get("terminal").is_none());
+    }
+
+    #[test]
+    fn attach_generation_adds_monotonic_field() {
+        let mut payload = serde_json::json!({"sha256": "abc123", "status": "complete"});
+        attach_generation(&mut payload, 1_700_000_000_123);
+        assert_eq!(payload["generation"], 1_700_000_000_123_u64);
+        // Original fields survive.
+        assert_eq!(payload["sha256"], "abc123");
+        assert_eq!(payload["status"], "complete");
+    }
+
+    #[test]
+    fn cloud_tasks_body_wraps_payload_as_base64_http_request() {
+        let payload = serde_json::json!({
+            "sha256": "abc123",
+            "status": "complete",
+            "generation": 1_700_000_000_123_u64
+        });
+        let body = build_cloud_tasks_task_body(
+            "https://edge.example/admin/transcode-status",
+            Some("s3cr3t"),
+            &payload,
+        );
+
+        let http = &body["task"]["httpRequest"];
+        assert_eq!(http["url"], "https://edge.example/admin/transcode-status");
+        assert_eq!(http["httpMethod"], "POST");
+        assert_eq!(http["headers"]["Content-Type"], "application/json");
+        assert_eq!(http["headers"]["Authorization"], "Bearer s3cr3t");
+
+        // The task body is base64-encoded JSON; decode and confirm it round-trips
+        // the payload including the generation field.
+        use base64::Engine as _;
+        let b64 = http["body"].as_str().expect("body should be a string");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .expect("body should be valid base64");
+        let round: serde_json::Value =
+            serde_json::from_slice(&decoded).expect("decoded body should be JSON");
+        assert_eq!(round["sha256"], "abc123");
+        assert_eq!(round["status"], "complete");
+        assert_eq!(round["generation"], 1_700_000_000_123_u64);
+    }
+
+    #[test]
+    fn cloud_tasks_body_omits_authorization_when_no_secret() {
+        let payload = serde_json::json!({"sha256": "x", "status": "pending"});
+        let body = build_cloud_tasks_task_body(
+            "https://edge.example/admin/transcode-status",
+            None,
+            &payload,
+        );
+        assert!(body["task"]["httpRequest"]["headers"]
+            .get("Authorization")
+            .is_none());
     }
 
     #[test]
@@ -5149,7 +5221,6 @@ async fn send_status_webhook(
         }
     };
 
-    let client = reqwest::Client::new();
     let payload = build_transcode_status_webhook_payload(
         hash,
         status,
@@ -5172,30 +5243,8 @@ async fn send_status_webhook(
         );
     }
 
-    let mut request = client.post(webhook_url).json(&payload);
-
-    // Add auth header if secret is configured
-    if let Some(secret) = &config.webhook_secret {
-        request = request.header("Authorization", format!("Bearer {}", secret));
-    }
-
-    match request.send().await {
-        Ok(response) => {
-            if response.status().is_success() {
-                info!("Status webhook sent for {}: {}", hash, status);
-            } else {
-                error!(
-                    "Status webhook failed for {}: {} - {}",
-                    hash,
-                    response.status(),
-                    response.text().await.unwrap_or_default()
-                );
-            }
-        }
-        Err(e) => {
-            error!("Status webhook request failed for {}: {}", hash, e);
-        }
-    }
+    let target = webhook_url.clone();
+    deliver_status_payload(config, hash, "transcode", &target, payload).await;
 }
 
 fn resolve_transcript_webhook_url(config: &Config) -> Option<String> {
@@ -5255,6 +5304,145 @@ fn build_transcode_status_webhook_payload(
     payload
 }
 
+/// Monotonically increasing per-sha ordering token, sourced from wall-clock
+/// milliseconds at send time. Later callbacks carry a larger value, so the
+/// receiver can drop a stale update that arrives after a newer one. A clock
+/// that never goes backwards is all this needs; it is not a global sequence.
+fn current_generation_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Stamp a `generation` onto an existing status payload in place.
+fn attach_generation(payload: &mut serde_json::Value, generation: u64) {
+    payload["generation"] = serde_json::json!(generation);
+}
+
+/// Build the Cloud Tasks `CreateTask` request body that will deliver `payload`
+/// to `target_url` as a POST. The status payload is base64-encoded per the
+/// Cloud Tasks HTTP-target contract. Auth to Fastly rides in the task's own
+/// headers (the same bearer secret the direct POST used), so a redelivery
+/// authenticates exactly like the original.
+fn build_cloud_tasks_task_body(
+    target_url: &str,
+    webhook_secret: Option<&str>,
+    payload: &serde_json::Value,
+) -> serde_json::Value {
+    use base64::Engine as _;
+    let body_b64 = base64::engine::general_purpose::STANDARD
+        .encode(serde_json::to_vec(payload).unwrap_or_default());
+
+    let mut headers = serde_json::json!({ "Content-Type": "application/json" });
+    if let Some(secret) = webhook_secret {
+        headers["Authorization"] = serde_json::json!(format!("Bearer {}", secret));
+    }
+
+    serde_json::json!({
+        "task": {
+            "httpRequest": {
+                "url": target_url,
+                "httpMethod": "POST",
+                "headers": headers,
+                "body": body_b64,
+            }
+        }
+    })
+}
+
+/// Deliver a status payload either by enqueuing to Cloud Tasks (durable, when
+/// `status_queue_enabled`) or by POSTing directly to Fastly (the rollback
+/// path). Fire-and-forget in both cases: a failure is logged, never fatal to
+/// the transcode. The queue path is what makes a lost callback recoverable —
+/// Cloud Tasks retries with backoff and dead-letters on exhaustion.
+async fn deliver_status_payload(
+    config: &Config,
+    hash: &str,
+    label: &str,
+    target_url: &str,
+    mut payload: serde_json::Value,
+) {
+    attach_generation(&mut payload, current_generation_ms());
+
+    if config.status_queue_enabled {
+        if let Err(e) = enqueue_status_task(config, target_url, &payload).await {
+            error!(
+                "Failed to enqueue {} status task for {}: {} — NOT falling back to direct POST (Cloud Tasks owns durability)",
+                label, hash, e
+            );
+        } else {
+            info!("{} status enqueued for {}", label, hash);
+        }
+        return;
+    }
+
+    // Direct POST rollback path.
+    let client = reqwest::Client::new();
+    let mut request = client.post(target_url).json(&payload);
+    if let Some(secret) = &config.webhook_secret {
+        request = request.header("Authorization", format!("Bearer {}", secret));
+    }
+    match request.send().await {
+        Ok(response) if response.status().is_success() => {
+            info!("{} status webhook sent for {}", label, hash);
+        }
+        Ok(response) => {
+            error!(
+                "{} status webhook failed for {}: {} - {}",
+                label,
+                hash,
+                response.status(),
+                response.text().await.unwrap_or_default()
+            );
+        }
+        Err(e) => {
+            error!("{} status webhook request failed for {}: {}", label, hash, e);
+        }
+    }
+}
+
+/// POST a `CreateTask` to the Cloud Tasks REST API using the instance's GCP
+/// access token. Returns Err on any non-2xx so the caller can log it; the task
+/// itself, once created, is retried by Cloud Tasks independently.
+async fn enqueue_status_task(
+    config: &Config,
+    target_url: &str,
+    payload: &serde_json::Value,
+) -> anyhow::Result<()> {
+    let token = fetch_gcp_access_token()
+        .await
+        .map_err(|e| anyhow!("access token: {:?}", e))?;
+
+    let queue_path = format!(
+        "projects/{}/locations/{}/queues/{}",
+        config.gcp_project_id, config.status_queue_location, config.status_queue_name
+    );
+    let create_url = format!(
+        "https://cloudtasks.googleapis.com/v2/{}/tasks",
+        queue_path
+    );
+
+    let body = build_cloud_tasks_task_body(target_url, config.webhook_secret.as_deref(), payload);
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(&create_url)
+        .header("Authorization", format!("Bearer {}", token))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| anyhow!("create task request failed: {}", e))?;
+
+    if resp.status().is_success() {
+        Ok(())
+    } else {
+        let code = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        Err(anyhow!("create task returned {}: {}", code, text))
+    }
+}
+
 fn classify_invalid_media_error(
     message: &str,
     fallback_code: &'static str,
@@ -5298,7 +5486,6 @@ async fn send_transcript_status_webhook(
         }
     };
 
-    let client = reqwest::Client::new();
     let mut payload = serde_json::json!({
         "sha256": hash,
         "status": status
@@ -5331,29 +5518,5 @@ async fn send_transcript_status_webhook(
         payload["terminal"] = serde_json::json!(true);
     }
 
-    let mut request = client.post(webhook_url).json(&payload);
-    if let Some(secret) = &config.webhook_secret {
-        request = request.header("Authorization", format!("Bearer {}", secret));
-    }
-
-    match request.send().await {
-        Ok(response) => {
-            if response.status().is_success() {
-                info!("Transcript status webhook sent for {}: {}", hash, status);
-            } else {
-                error!(
-                    "Transcript status webhook failed for {}: {} - {}",
-                    hash,
-                    response.status(),
-                    response.text().await.unwrap_or_default()
-                );
-            }
-        }
-        Err(e) => {
-            error!(
-                "Transcript status webhook request failed for {}: {}",
-                hash, e
-            );
-        }
-    }
+    deliver_status_payload(config, hash, "transcript", &webhook_url, payload).await;
 }

--- a/docs/superpowers/plans/2026-07-24-derivative-status-queue-simple.md
+++ b/docs/superpowers/plans/2026-07-24-derivative-status-queue-simple.md
@@ -1,0 +1,101 @@
+# Durable Derivative Status Delivery — Simplest Thing That Could Work
+
+**Goal:** Stop losing transcoder status callbacks. Nothing else.
+
+**Approach:** Put Cloud Tasks between the transcoder and Fastly. Cloud Tasks owns retries, backoff, and dead-lettering — that is the durability, and it is queue configuration, not code. The receiver becomes idempotent and drops stale updates. Done.
+
+**What already exists** (do not rebuild):
+- `cloud-run-transcoder/src/main.rs` has `send_status_webhook` (8 call sites: `:1061, 1095, 1123, 1211, 1244, 1262`) and `send_transcript_status_webhook` (`:1306, 1363`). One function to change, not eight.
+- Fastly already routes both callbacks: `src/main.rs:164` (moderation), `:167` (transcode status), with parsers at `:1366` and `:1411`.
+- **`src/admin_sweep.rs` already reconciles lost webhooks** — it checks GCS for the HLS master manifest and marks `Complete` when the callback never arrived (`src/admin.rs:1270`). The reconciliation layer is built. The queue's job is to make it fire rarely, not to replace it.
+
+**Non-goals:** no new crate, no Firestore outbox, no HMAC rotation scheme, no admission pause/drain, no dead-replay tooling, no lease-and-cursor reconciler. Every one of those is deferrable until a queue in production shows it is needed.
+
+---
+
+## Step 1: Create the queue
+
+- [x] Enabled `cloudtasks.googleapis.com` on `rich-compiler-479518-d2` (was disabled) and created the queue:
+
+```
+gcloud tasks queues create derivative-status \
+  --location=us-central1 --project=rich-compiler-479518-d2 \
+  --max-attempts=10 --max-backoff=600s --min-backoff=5s \
+  --max-concurrent-dispatches=50
+# -> Created queue [us-central1/derivative-status]
+```
+
+Retries, exponential backoff, and attempt limits are now handled. No code.
+
+## Step 2: Enqueue instead of POST
+
+**Files:** `cloud-run-transcoder/src/main.rs`
+
+- [x] `generation` = wall-clock milliseconds at send time (`current_generation_ms`). Monotonic per-sha, no new storage or plumbing. `attach_generation` stamps it onto any payload.
+- [x] `send_status_webhook` and `send_transcript_status_webhook` now both call `deliver_status_payload`, which enqueues to Cloud Tasks when `status_queue_enabled` else direct-POSTs. All 8 + 2 call sites unchanged. `enqueue_status_task` POSTs `CreateTask` to the Cloud Tasks REST API using the instance access token; the Fastly bearer secret rides in the task's own headers, so a redelivery authenticates like the original.
+- [x] `STATUS_QUEUE_ENABLED` (default `false`), `STATUS_QUEUE_LOCATION` (default `us-central1`), `STATUS_QUEUE_NAME` (default `derivative-status`) added to `Config`. Default false = direct POST = rollback.
+- [x] **Tests (pass):** `attach_generation_adds_monotonic_field`, `cloud_tasks_body_wraps_payload_as_base64_http_request`, `cloud_tasks_body_omits_authorization_when_no_secret`. Cloud Tasks client stubbed via pure-function body builder; no network. Note: on enqueue failure the code does **not** fall back to direct POST — Cloud Tasks owns durability, and a silent double-path would defeat the ordering guarantee.
+
+## Step 3: Make the receiver idempotent and order-safe
+
+**Files:** `src/main.rs` (the two webhook handlers)
+
+- [x] Added `transcode_generation` and `transcript_generation` (`Option<u64>`, skip-if-none) to `BlobMetadata` — separate axes, since transcode and transcript are independent update streams. Persisted via a `generation` field on both `TranscodeMetadataUpdate`/`TranscriptMetadataUpdate`; internal callers pass `None`, which preserves any stored value.
+- [x] Both webhook handlers pre-check `is_stale_generation(incoming, stored)`: incoming `<` stored → return `200 {"ignored":"stale_generation"}` without applying or purging. A `200` so Cloud Tasks stops retrying.
+- [x] Equal generation with unchanged status → the update writes the same value; harmless no-op idempotency. Malformed-payload handling already returns structured responses, not 5xx storms.
+- [x] `generation` parsed from both payloads (`parse_transcode/transcript_status_webhook_payload`); absent = `None` = always applied (legacy senders, first update).
+- [x] **Tests (type-check clean; edge `#[test]`s can't link natively — Fastly SDK is WASM-only, per AGENTS.md `cargo check --tests`):** `stale_generation_ordering` (3<5 stale, 5==5 not, 6>5 not, any `None` not), `transcode_payload_parses_generation` (incl. legacy `None`), `transcript_payload_parses_generation`. blossom-core: 99 pass incl. the new BlobMetadata fixtures.
+
+## Step 4: Alert on the dead-letter path
+
+- [x] Alert `derivative-status queue depth sustained high` — `cloudtasks.googleapis.com/queue/depth` > 100 for 15m. Policy `6130752747029271836`, notifies existing `GCP DevOps Email` channel.
+- [x] Alert `derivative-status delivery attempts failing` — `queue/task_attempt_count` with `response_code != 200`, rate > 0 for 15m. Policy `2336123773137320083`. This is the pre-dead-letter signal; the cases `admin_sweep` must catch.
+- [ ] Live-fire check deferred to after the flag flip — a failing-URL test task would need the queue exercised in production.
+
+---
+
+## Rollout
+
+- [x] `roles/cloudtasks.enqueuer` granted to the transcoder SA `149672065768-compute@developer.gserviceaccount.com`.
+- [x] Transcoder deployed on image `a7a9aed-queue` (revision `divine-transcoder-00042-99z`) via `gcloud run services update --image` — env preserved (all 17 vars intact, incl. `WEBHOOK_SECRET`/`PARAKEET_ASR_URL`). `STATUS_QUEUE_ENABLED` unset ⇒ still direct-POST. No behavior change.
+- [ ] **Deploy the Fastly edge** (receiver). Needs your token — CLI can't auth non-interactively here:
+  ```
+  fastly compute publish --comment "durable derivative status: queue-aware receiver" \
+    && fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR
+  ```
+- [ ] **Cutover (the real behavior change):** after the edge is live, flip the transcoder:
+  ```
+  gcloud run services update divine-transcoder --region us-central1 \
+    --project rich-compiler-479518-d2 --update-env-vars STATUS_QUEUE_ENABLED=true
+  ```
+  (`--update-env-vars` is additive — does not wipe the other 17.)
+- [ ] Watch `admin_sweep`'s lost-webhook rate fall toward zero, and the two alert policies stay quiet. Roll back by setting `STATUS_QUEUE_ENABLED=false` (or `--remove-env-vars`).
+- [x] `admin_sweep` stays as the permanent backstop — already works, catches residual cases.
+
+## Incident found during rollout: 100% webhook 403 (pre-existing)
+
+The cutover surfaced that **every** transcoder→edge status callback had been failing `403 Invalid webhook secret` for 6h+ (present on the untouched May-17 revision, so far older). Root cause: the transcoder's GCP `webhook_secret` (`c47e8db7…`, v1 since Jan 31) never matched the edge's Fastly `blossom_secrets/webhook_secret` (`d3f3e56e…`). The system had been surviving on `admin_sweep` reconciliation alone — which is *why* derivatives appeared "stuck."
+
+Diagnosis path (all via gcloud/fastly, no plaintext exposed):
+- Compared SHA-256 of GCP secret vs the Fastly store's exposed digest — mismatch.
+- Confirmed the same `webhook_secret` guards the moderation inbound webhook (`src/main.rs:4782`), and `divine-moderation-service` (Cloudflare Worker) is healthy at ~250k req/day (`divine-brain ops_status`) → the **edge value is canonical**, the transcoder's copy is stale.
+- The canonical plaintext is a Cloudflare Worker secret (write-only); scanned ~290 GCP secrets across 5 projects — no copy. So it can't be re-keyed into the transcoder directly.
+
+Fix applied (touches nothing moderation depends on):
+- [x] Edge: `validate_transcoder_webhook` now accepts a dedicated `transcoder_webhook_secret` **in addition to** the shared `webhook_secret`. Both `/admin/transcode-status` and `/admin/transcript-status` use it. Edge deployed v317.
+- [x] Generated a fresh secret; added it to Fastly `blossom_secrets/transcoder_webhook_secret` and to GCP `webhook_secret` v2 (sole consumer: `divine-transcoder`). Transcoder redeployed rev `00044-rxc`.
+- [x] Verified: `POST /admin/transcode-status` with the new secret → 404 (past auth); `/admin/transcript-status` → 202; wrong secret → 403. No new 403s from rev 00044. Moderation's `webhook_secret` untouched.
+
+## When to build more
+
+Do not pre-build these. Each becomes justified only by a specific observed failure:
+
+| Signal in production | Then consider |
+|---|---|
+| Dead-letter volume is non-trivial | Replay tooling |
+| Status updates apply out of order despite `generation` | A real ordering layer |
+| A callback is forged or replayed by a third party | HMAC signing + rotation |
+| Cloud Tasks itself drops messages | A Firestore outbox |
+| The queue overwhelms Fastly under backlog | Admission pause and drain |
+
+The existing 1,568-line design and 1,666-line plan are not wasted — they become this table's implementation notes if a row ever triggers.

--- a/docs/superpowers/plans/2026-07-24-durable-derivative-status-delivery.md
+++ b/docs/superpowers/plans/2026-07-24-durable-derivative-status-delivery.md
@@ -1,0 +1,1764 @@
+# Durable Derivative Status Delivery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace fire-and-forget transcript/transcode callbacks with an authenticated, durable, idempotent Cloud Tasks delivery path that recovers automatically from temporary failures without retranscoding.
+
+**Architecture:** A pure `derivative-status-core` crate owns the event, HMAC, validation, ordering, transition, and response contracts. The Fastly service adds generation-matched metadata mutation and versioned status endpoints; a small Cloud Run delivery crate owns GCS outbox, Cloud Tasks REST, Firestore REST, delivery, reconciliation, and recovery adapters. The existing transcoder publishes queue-first events and enforces authenticated admission, attempt allocation, and immutable terminal suppression.
+
+**Tech Stack:** Rust 1.83, Fastly Compute SDK 0.11.12, Axum 0.7, GCS, Cloud Tasks REST v2, Firestore REST v1, Cloud Run, Cloud Scheduler, HMAC-SHA256, serde, reqwest, cargo-llvm-cov.
+
+**Approved design:** `docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md`
+
+**Production boundary:** Tasks 1–14 change and verify repository code only.
+Task 15 contains production repair/rollout commands and must not execute
+without an explicit production deployment instruction. Task 16 is a later
+source-cleanup change and cannot begin until Task 15 records fourteen stable
+production days and receives separate approval.
+
+---
+
+## File and dependency map
+
+Create the following focused modules:
+
+- `derivative-status-core/`
+  - `src/event.rs`: versioned event/update types and canonical bytes.
+  - `src/validation.rs`: exact field matrix and bounds.
+  - `src/ordering.rs`: watermark comparisons and integrity conflicts.
+  - `src/transition.rs`: blob/job/mapping mutations and effect aggregation.
+  - `src/auth.rs`: canonical HMAC preimages and constant-time verification.
+  - `src/response.rs`: exact success/error response contracts.
+  - `tests/hmac_vectors.rs`: one fixture consumed by all Rust runtimes.
+- `fixtures/derivative-status-hmac-v1.json`: byte-level cross-runtime vectors.
+- `src/metadata_cas.rs`: injected generation-aware Fastly KV adapter and retry loop.
+- `src/derivative_status.rs`: Fastly route auth, apply orchestration, and response serialization.
+- `src/derivative_rate_limit.rs`: injected Fastly ERL adapter keyed by verified signer.
+- `src/subtitle_mapping.rs`: legacy/v2 mapping bridge and fail-closed write gate.
+- `cloud-run-transcoder/status-delivery/`
+  - `src/ports.rs`: storage, queue, clock, token, secret, and webhook interfaces.
+  - `src/publisher.rs`: pending-first publication.
+  - `src/gcp_auth.rs`: metadata-server access-token cache.
+  - `src/gcs.rs`: pending/dead/suppression/control bucket adapters.
+  - `src/cloud_tasks.rs`: deterministic CreateTask REST adapter.
+  - `src/firestore.rs`: transactional attempt/preparation REST adapter.
+  - `src/fastly_client.rs`: signed, bounded delivery client.
+  - `src/delivery.rs`: delivery state machine.
+  - `src/reconciler.rs`: lease/cursor/paginated reconciliation.
+  - `src/recovery.rs`: discover/intent/prepare/apply/verify domain workflow.
+  - `src/bin/status-delivery.rs`, `status-reconciler.rs`, `derivative-status-admin.rs`: thin binaries.
+- `cloud-run-transcoder/src/processor_auth.rs`: route-bound HMAC middleware and verification route.
+- `cloud-run-transcoder/src/processor_rate_limit.rs`: bounded per-signer verification limiter.
+- `cloud-run-transcoder/src/derivative_admission.rs`: lock/preflight/attempt/suppression behavior.
+- `cloud-run-transcoder/src/status_publisher.rs`: typed producer facade.
+- `cloud-run-upload/src/processor_request.rs`: shared-HMAC caller.
+- `src/processor_request.rs`: pure Fastly processor-request signer and retry classifier.
+- `cloud-run-transcoder/deploy-derivative-status.sh`: provision/deploy declarative resources.
+- `scripts/provision-derivative-fastly-resources.sh`: render/confirm Fastly controls, secret names, and ERL entitlement.
+- `cloud-run-transcoder/status-delivery/Dockerfile`: small non-GPU delivery/reconciler/admin image.
+- `scripts/check-derivative-status-coverage.sh`: exact coverage gate.
+- `docs/runbooks/derivative-status-delivery.md`: P1 repair, rollout, rotation, pause, replay, and rollback.
+
+Modify integration points:
+
+- `Cargo.toml`, `Cargo.lock`, `.github/workflows/ci.yml`, `.coverage-thresholds.json`.
+- `blossom-core/src/types.rs`.
+- `src/lib.rs`, `src/main.rs`, `src/metadata.rs`, `src/admin.rs`.
+- `fastly.toml.example`, `fastly.toml.local`, `config-store-data.json`,
+  `secret-store-data.json.example` (never the ignored real secret file).
+- `cloud-run-transcoder/Cargo.toml`, `Cargo.lock`, `Dockerfile`, `deploy.sh`, `src/main.rs`.
+- `cloud-run-upload/Cargo.toml`, `Cargo.lock`, `Dockerfile`, `deploy.sh`, `src/main.rs`.
+- `cloud-run-transcoder/backfill.sh`, `backfill-prioritized.sh`, `scripts/backfill-fmp4.sh`.
+
+Dependency order is strict:
+
+```text
+core contracts
+  -> Fastly CAS bridge and v2 mapping
+  -> Fastly status endpoints
+  -> delivery/publisher adapters
+  -> processor and caller integration
+  -> infrastructure/recovery/observability
+  -> production rollout
+```
+
+The pinned Rust 1.83 toolchain cannot parse current edition-2024 generated
+Google clients. Cloud Tasks and Firestore therefore use small REST adapters
+with the existing metadata-server OAuth token pattern; do not upgrade the
+toolchain or add `google-cloud-tasks-v2`.
+
+---
+
+### Task 1: Scaffold the shared contract crate and coverage command
+
+**Files:**
+- Create: `derivative-status-core/Cargo.toml`
+- Create: `derivative-status-core/src/lib.rs`
+- Create: `derivative-status-core/src/event.rs`
+- Create: `fixtures/derivative-status-hmac-v1.json`
+- Create: `scripts/check-derivative-status-coverage.sh`
+- Modify: `Cargo.toml`
+- Modify: `.coverage-thresholds.json`
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Create the crate shell and write the failing shared-contract smoke test**
+
+Create `derivative-status-core/Cargo.toml`:
+
+```toml
+[package]
+name = "derivative-status-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+base64 = "0.22"
+hex = "0.4"
+hmac = "0.12"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+subtle = "2"
+thiserror = "1"
+uuid = { version = "=1.12.1", features = ["serde", "v5", "v7"] }
+```
+
+Create `derivative-status-core/src/lib.rs` with this module declaration and
+test before `event.rs` exists:
+
+```rust
+pub mod event;
+
+#[cfg(test)]
+mod tests {
+    use crate::event::{Derivative, StatusEvent};
+
+    #[test]
+    fn event_contract_is_versioned_and_derivative_typed() {
+        let value = serde_json::json!({
+            "schema_version": 1,
+            "derivative": "transcode"
+        });
+        let error = serde_json::from_value::<StatusEvent>(value).unwrap_err();
+        assert!(error.to_string().contains("missing field"));
+        assert_eq!(Derivative::Transcript.as_str(), "transcript");
+    }
+}
+```
+
+Add `derivative-status-core` to the root workspace and run
+`cargo generate-lockfile` so the RED command tests the missing implementation,
+not workspace or lockfile setup. Also add it as a direct path dependency of
+the root `fastly-blossom` package; Task 11's Fastly signer imports the crate
+directly and must not rely on the transitive `blossom-core` dependency.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+cargo test --manifest-path derivative-status-core/Cargo.toml --locked
+```
+
+Expected: FAIL because `event.rs` and its types do not exist.
+
+- [ ] **Step 3: Add the Rust-1.83-compatible event skeleton**
+
+Create `event.rs` and define `Derivative`,
+`DerivativeStatus`, and the initial `StatusEvent` in `event.rs`;
+derive `Serialize`, `Deserialize`, `Clone`, `Debug`, `Eq` where valid. Keep the
+smoke-test wire type minimal here; Task 2 replaces it with the custom exact-key
+envelope parser and applies `#[serde(deny_unknown_fields)]` only to compatible
+nested structs.
+
+Initialize `fixtures/derivative-status-hmac-v1.json` as an empty JSON array;
+Task 2 replaces it with the reviewed byte vectors.
+
+- [ ] **Step 4: Make the smoke test GREEN**
+
+Run:
+
+```bash
+cargo test --manifest-path derivative-status-core/Cargo.toml --locked
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add the real coverage entrypoint**
+
+`scripts/check-derivative-status-coverage.sh` must run:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cargo llvm-cov --manifest-path derivative-status-core/Cargo.toml \
+  --all-targets --all-features \
+  --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100
+cargo llvm-cov --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml \
+  --all-targets --all-features \
+  --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100
+```
+
+Point `.coverage-thresholds.json` at this script. Add CI installation of a
+pinned `cargo-llvm-cov` with
+`cargo install cargo-llvm-cov --version 0.8.7 --locked`, and run the script
+after both crates exist; until Task 6 creates the delivery crate, keep the
+second command behind an explicit file-exists guard that Task 6 removes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock derivative-status-core fixtures/derivative-status-hmac-v1.json scripts/check-derivative-status-coverage.sh .coverage-thresholds.json .github/workflows/ci.yml
+git commit -m "feat(status): scaffold derivative status contracts"
+```
+
+---
+
+### Task 2: Implement event validation, HMAC, ordering, and transitions
+
+**Files:**
+- Modify: `derivative-status-core/src/event.rs`
+- Create: `derivative-status-core/src/auth.rs`
+- Create: `derivative-status-core/src/ordering.rs`
+- Create: `derivative-status-core/src/response.rs`
+- Create: `derivative-status-core/src/transition.rs`
+- Create: `derivative-status-core/src/validation.rs`
+- Create: `derivative-status-core/tests/hmac_vectors.rs`
+- Modify: `fixtures/derivative-status-hmac-v1.json`
+
+- [ ] **Step 1: Write failing serialization and validation tests**
+
+Cover both tagged variants and every status field matrix. Representative tests:
+
+```rust
+#[test]
+fn complete_transcript_rejects_failure_fields() {
+    let event = transcript_event(json!({
+        "status": "complete",
+        "last_attempt_at_ms": 1_784_847_001_200_u64,
+        "error_code": "invalid_media"
+    }));
+    assert_eq!(validate_event(&event), Err(ValidationError::ForbiddenField("error_code")));
+}
+
+#[test]
+fn failed_transcode_requires_terminal_and_error_code() {
+    let event = transcode_event(json!({
+        "status": "failed",
+        "last_attempt_at_ms": 1_784_847_001_200_u64
+    }));
+    assert_eq!(validate_event(&event), Err(ValidationError::MissingField("error_code")));
+}
+```
+
+Include bounds for 32 KiB canonical bytes, hash, UUID versions, UUID timestamp
+agreement, sequence `1..=32`, attempt `1..=100`, times, dimensions, cue count,
+language, safe errors, and unknown fields.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test --manifest-path derivative-status-core/Cargo.toml --locked validation
+```
+
+Expected: FAIL because complete types/validation are absent.
+
+- [ ] **Step 3: Implement the exact event types**
+
+Use these domain shapes:
+
+```rust
+#[derive(Clone, Debug)]
+pub struct StatusEvent {
+    pub schema_version: u16,
+    pub event_id: Uuid,
+    pub sha256: String,
+    pub operation_id: Uuid,
+    pub operation_started_at_ms: u64,
+    pub sequence: u8,
+    pub created_at_ms: u64,
+    pub attempt_epoch: Uuid,
+    pub attempt_number: u8,
+    pub derivative: DerivativeUpdate,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "derivative", content = "update", rename_all = "lowercase")]
+pub enum DerivativeUpdate {
+    Transcript(TranscriptUpdate),
+    Transcode(TranscodeUpdate),
+}
+```
+
+Do not combine `#[serde(flatten)]` with outer
+`#[serde(deny_unknown_fields)]`; Serde does not support that contract. Instead,
+implement `Serialize`/`Deserialize` for `StatusEvent` through a private wire
+visitor that emits and accepts the approved flat envelope with exact keys:
+
+```text
+schema_version,event_id,sha256,operation_id,operation_started_at_ms,
+sequence,created_at_ms,attempt_epoch,attempt_number,derivative,update
+```
+
+The visitor rejects unknown, duplicate, and missing top-level fields before
+constructing the typed `DerivativeUpdate`; the update structs retain
+`#[serde(deny_unknown_fields)]`. Round-trip and negative tests assert the
+literal approved JSON shape.
+
+Define typed update structs with the exact optional fields and bounds from the
+approved spec:
+
+```rust
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TranscriptUpdate {
+    pub status: DerivativeStatus,
+    pub job_id: Option<String>,
+    pub language: Option<String>,
+    pub duration_ms: Option<u64>,
+    pub cue_count: Option<u32>,
+    pub transcript_confidence: Option<TranscriptConfidence>,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+    pub retry_at_ms: Option<u64>,
+    pub terminal: Option<bool>,
+    pub last_attempt_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TranscriptConfidence {
+    pub average_token_confidence: f64,
+    pub average_logprob: f64,
+    pub low_confidence_token_ratio: f64,
+    pub token_count: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TranscodeUpdate {
+    pub status: DerivativeStatus,
+    pub new_size: Option<u64>,
+    pub display_width: Option<u32>,
+    pub display_height: Option<u32>,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+    pub retry_at_ms: Option<u64>,
+    pub terminal: Option<bool>,
+    pub last_attempt_at_ms: u64,
+}
+```
+
+`canonical_bytes()` must call one deterministic serde path and
+`canonical_digest()` must hash those bytes. Define one fixed UUID namespace
+constant and derive event IDs as UUIDv5 over canonical
+`"<operation_uuid>:<sequence>"` ASCII bytes; test the literal expected UUID so
+all producers share the same identity rule.
+
+- [ ] **Step 4: Write and verify failing ordering/transition tests**
+
+```rust
+#[test]
+fn equal_coordinates_with_different_digest_conflict() {
+    let current = watermark("event-a", "digest-a", 1000, op_uuid(), 2);
+    let incoming = envelope("event-a", "digest-b", 1000, current.operation_id, 2);
+    assert_eq!(compare(&current, &incoming), ApplyOrder::IntegrityConflict);
+}
+
+#[test]
+fn out_of_order_failures_converge_to_max_attempt() {
+    let mut state = transcript_state("epoch-a", 0);
+    apply_failure(&mut state, failure("epoch-a", 2)).unwrap();
+    apply_failure(&mut state, failure("epoch-a", 1)).unwrap();
+    assert_eq!(state.attempt_count, 2);
+}
+
+#[test]
+fn mixed_duplicate_and_stale_aggregates_stale() {
+    assert_eq!(
+        aggregate(Effect::AlreadyApplied, Effect::Stale, Effect::NotRequired),
+        Ok(Outcome::Stale)
+    );
+}
+```
+
+Run and expect FAIL:
+
+```bash
+cargo test --manifest-path derivative-status-core/Cargo.toml --locked ordering
+cargo test --manifest-path derivative-status-core/Cargo.toml --locked transition
+```
+
+- [ ] **Step 5: Implement total order, watermarks, transitions, and responses**
+
+Define:
+
+```rust
+pub struct DeliveryWatermark {
+    pub operation_started_at_ms: u64,
+    pub operation_id: Uuid,
+    pub sequence: u8,
+    pub event_id: Uuid,
+    pub canonical_digest: String,
+}
+
+pub enum Effect { NotRequired, Applied, AlreadyApplied, Stale }
+pub enum Outcome { Applied, Duplicate, Stale }
+pub enum ApplyOrder { Newer, Duplicate, Stale, IntegrityConflict }
+```
+
+Implement separate transcript/transcode blob transitions, subtitle-job
+transition, mapping transition, matching-epoch `max(attempt_number)`, terminal
+and complete stale guards, and the exhaustive aggregate matrix. No transition
+may read wall-clock time.
+
+- [ ] **Step 6: Write failing HMAC vector tests**
+
+Fixture records must contain `protocol`, `key_hex`, `method`, `path`,
+`timestamp`, optional `request_id`, `raw_body_hex`, `preimage_hex`, and
+`signature_hex`.
+
+```rust
+#[test]
+fn every_checked_in_vector_matches_bytes_and_signature() {
+    for vector in vectors() {
+        assert_eq!(hex::encode(vector.preimage()), vector.preimage_hex);
+        assert_eq!(vector.sign().unwrap(), vector.signature_hex);
+    }
+}
+```
+
+Run and expect FAIL:
+
+```bash
+cargo test --manifest-path derivative-status-core/Cargo.toml --locked --test hmac_vectors
+```
+
+- [ ] **Step 7: Implement canonical HMAC bytes and constant-time verify**
+
+Expose:
+
+```rust
+pub fn processor_preimage(input: &ProcessorSignatureInput<'_>) -> Result<Vec<u8>, AuthError>;
+pub fn status_preimage(input: &StatusSignatureInput<'_>) -> Result<Vec<u8>, AuthError>;
+pub fn sign_sha256(key: &[u8], preimage: &[u8]) -> Result<String, AuthError>;
+pub fn verify_sha256(key: &[u8], preimage: &[u8], signature_hex: &str) -> Result<(), AuthError>;
+```
+
+Reject leading-zero timestamps, uppercase/noncanonical UUIDs, query strings,
+percent-encoded paths, duplicate slashes, trailing slash, dot segments,
+invalid hex, and keys shorter than 32 bytes.
+
+- [ ] **Step 8: Verify and commit**
+
+```bash
+cargo test --manifest-path derivative-status-core/Cargo.toml --locked
+cargo clippy --manifest-path derivative-status-core/Cargo.toml --locked --all-targets --all-features -- -D warnings
+git add derivative-status-core fixtures/derivative-status-hmac-v1.json Cargo.lock
+git commit -m "feat(status): define durable event contracts"
+```
+
+Expected: all core tests PASS and clippy emits no warnings.
+
+---
+
+### Task 3: Add the Fastly generation-aware bridge
+
+**Files:**
+- Create: `src/metadata_cas.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/metadata.rs:54-136`
+- Modify: `src/metadata.rs:253-485`
+- Modify: `src/main.rs`
+- Modify: `src/admin.rs`
+- Modify: `blossom-core/Cargo.toml`
+- Modify: `blossom-core/src/types.rs:36-103`
+- Modify: `blossom-core/src/types.rs:342-367`
+
+- [ ] **Step 1: Write failing adapter-level CAS tests**
+
+The pure adapter test must model value plus `u64` generation:
+
+```rust
+#[test]
+fn conflict_reloads_and_preserves_unrelated_fields() {
+    let kv = FakeKv::with_conflict_once(blob_fixture());
+    mutate_with_retry(&kv, "blob:abc", |mut blob| {
+        blob.transcript_status = Some(TranscriptStatus::Processing);
+        Ok(blob)
+    }).unwrap();
+    assert_eq!(kv.writes(), 2);
+    assert_eq!(kv.current().status, BlobStatus::Restricted);
+}
+```
+
+Also test create-only generation zero, missing values, five-conflict
+exhaustion, and cache purge only after successful durable write.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test -p fastly-blossom --locked --lib metadata_cas
+```
+
+Expected: FAIL because `metadata_cas` is absent.
+
+- [ ] **Step 3: Implement the injected CAS helper**
+
+Use `LookupResponse::current_generation()`; never use deprecated
+`generation()`. The runtime write must be:
+
+```rust
+store
+    .build_insert()
+    .if_generation_match(generation)
+    .execute(key, serialized)
+```
+
+Define and inject:
+
+```rust
+pub struct VersionedValue {
+    pub bytes: Vec<u8>,
+    pub generation: u64,
+}
+
+pub trait VersionedKv {
+    fn read(&self, key: &str) -> Result<Option<VersionedValue>>;
+    fn compare_and_swap(&self, key: &str, generation: u64, bytes: &[u8]) -> Result<()>;
+    fn create(&self, key: &str, bytes: &[u8]) -> Result<()>;
+}
+
+pub fn mutate_with_retry<T, F>(
+    store: &impl VersionedKv,
+    key: &str,
+    mutate: F,
+) -> Result<T>
+where
+    T: Serialize + DeserializeOwned,
+    F: FnMut(T) -> Result<T>;
+```
+
+Keep the raw unconditional insert private so inventory tests can reject new
+full-record writers.
+
+- [ ] **Step 4: Add serde-defaulted bridge fields**
+
+Add optional transcript/transcode `DeliveryWatermark` plus attempt epoch fields
+to `BlobMetadata`, transcript watermark/epoch to `SubtitleJob`, all with
+`#[serde(default, skip_serializing_if = "Option::is_none")]`. Update every
+literal fixture in `blossom-core`, `src/main.rs`, and `src/admin.rs`. Add the
+path dependency on `derivative-status-core` to
+`blossom-core/Cargo.toml`; keep the dependency one-way (the core contract crate
+must not depend on `blossom-core`).
+
+- [ ] **Step 5: Migrate every existing full-record mutation**
+
+Replace `get_blob_metadata` + `put_blob_metadata` and job equivalents with
+`mutate_existing`. Add an inventory test that scans `src/*.rs` and permits
+`KVStore::insert` only in explicitly listed non-full-record helpers and
+`metadata_cas.rs`.
+
+- [ ] **Step 6: Verify bridge compatibility**
+
+```bash
+cargo test -p blossom-core --locked
+cargo test -p fastly-blossom --locked --lib
+cargo check --tests --locked
+```
+
+Expected: PASS, including deserialize/serialize round trips of legacy records
+without watermark fields.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add blossom-core/Cargo.toml blossom-core/src/types.rs src/lib.rs src/metadata.rs src/metadata_cas.rs src/main.rs src/admin.rs Cargo.lock
+git commit -m "refactor(metadata): add generation-aware writes"
+```
+
+---
+
+### Task 4: Implement the v2 subtitle mapping and fail-closed freeze
+
+**Files:**
+- Create: `src/subtitle_mapping.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/metadata.rs:42-47`
+- Modify: `src/main.rs:1780-2090`
+- Modify: `fastly.toml.local`
+- Modify: `fastly.toml.example`
+- Create: `operational-controls-data.json`
+
+- [ ] **Step 1: Write failing migration and gate tests**
+
+Cover legacy fallback, baseline sentinel, v2 preference, forced replacement,
+late old-job stale behavior, missing/malformed config, conditional legacy
+dual-write, paginated baseline migration, and the inventory:
+
+```rust
+#[test]
+fn real_operation_always_supersedes_legacy_baseline() {
+    let baseline = MappingWatermark::legacy_baseline("job-old");
+    let forced = forced_mapping("job-new", 1_784_847_000_000);
+    assert_eq!(decide_mapping(&baseline, &forced), MappingDecision::Apply);
+}
+
+#[test]
+fn unreadable_pause_control_fails_closed() {
+    assert_eq!(
+        mapping_write_permission(Err(ControlError::Unavailable)),
+        Err(MappingWriteError::Paused)
+    );
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test -p fastly-blossom --locked --lib subtitle_mapping
+```
+
+Expected: FAIL because v2 types/helpers are absent.
+
+- [ ] **Step 3: Implement typed v2 reads and migration**
+
+Use `subtitle_job_map_v2:<sha256>` and keep the legacy
+`subtitle_hash:<sha256>` raw string. Implement:
+
+```rust
+pub fn get_mapping(hash: &str) -> Result<Option<ResolvedSubtitleMapping>>;
+pub fn initialize_legacy_baseline(hash: &str, job_id: &str) -> Result<TypedSubtitleMapping>;
+pub fn mutate_hash_job_mapping(input: MappingMutation) -> Result<MappingEffect>;
+```
+
+The baseline is timestamp 0, nil UUID, sequence 0, and its own canonical
+digest. Real mutations use UUIDv7 ordering and generation match.
+
+- [ ] **Step 4: Implement the operational control**
+
+Open `ConfigStore::open("operational_controls")`, read
+`mapping_writes_paused` on every mapping mutation, and return exact retryable
+503 JSON from all route callers. Add local store binding/data with
+`mapping_writes_paused=false`, `legacy_mapping_writes_enabled=true`, and
+`legacy_status_endpoints_enabled=true`. Missing/malformed pause state fails
+closed. The two retirement flags preserve legacy behavior until an explicit
+rollout toggle.
+
+- [ ] **Step 5: Add a bounded paginated migration endpoint**
+
+Add an existing-admin-authenticated endpoint that lists only
+`subtitle_hash:` keys, accepts `cursor` and `limit <= 100`, creates v2
+baseline records with generation-match semantics, and returns the next cursor
+plus migrated/already-present/conflict counts. It refuses to run unless
+`mapping_writes_paused=true`. Tests cover multiple pages, retry after a
+conflict, legacy/v2 parity, idempotent rerun, and no non-mapping key access.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+cargo test -p fastly-blossom --locked --lib subtitle_mapping
+cargo check --tests --locked
+git add src/subtitle_mapping.rs src/lib.rs src/metadata.rs src/main.rs fastly.toml.local fastly.toml.example operational-controls-data.json
+git commit -m "feat(subtitles): add ordered v2 mapping bridge"
+```
+
+---
+
+### Task 5: Add versioned Fastly durable-apply endpoints
+
+**Files:**
+- Create: `src/derivative_status.rs`
+- Create: `src/derivative_rate_limit.rs`
+- Modify: `src/lib.rs`
+- Modify: `src/main.rs:150-180`
+- Modify: `src/main.rs:4890-5190`
+- Modify: `src/metadata.rs`
+- Modify: `secret-store-data.json.example`
+
+- [ ] **Step 1: Write failing route/auth/response tests**
+
+Test exact paths, body limit, unknown fields, signature skew, primary/secondary
+secrets, derivative/path mismatch, missing blob/job, partial effects, purges,
+per-signer rate limiting, legacy endpoint controls, and exact response schema.
+
+```rust
+#[test]
+fn duplicate_blob_does_not_skip_missing_job_effect() {
+    let stores = fixtures::blob_duplicate_job_new();
+    let response = apply_transcript(&stores, event()).unwrap();
+    assert_eq!(response.blob_effect, Effect::AlreadyApplied);
+    assert_eq!(response.job_effect, Effect::Applied);
+    assert_eq!(response.outcome, Outcome::Applied);
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test -p fastly-blossom --locked --lib derivative_status
+```
+
+Expected: FAIL because the route module does not exist.
+
+- [ ] **Step 3: Implement auth and verify route**
+
+Add:
+
+```text
+POST /internal/derivative-status/v1/verify
+POST /internal/derivative-status/v1/transcript
+POST /internal/derivative-status/v1/transcode
+```
+
+Read only `derivative_status_secret_primary` and optional secondary from
+`blossom_secrets`. The verify route must mutate nothing. Enforce exact HMAC
+fixture bytes, five-minute skew, no query, duplicate-header rejection, and
+32 KiB event/16 KiB response bounds.
+
+- [ ] **Step 4: Implement the Fastly ERL boundary**
+
+Wrap Fastly SDK 0.11.12 `RateCounter`/`Penaltybox` behind an injected
+`StatusRateLimiter`. Key by the verified signer slot plus normalized route,
+check it after constant-time signature verification and before JSON parsing or
+KV work, and return bounded 429 with `Retry-After: 120`. Use
+`ERL::check_rate` with
+`RateWindow::TenSecs`, limit 40 requests/second, and a 120-second penalty
+(Fastly's effective minimum);
+the queue's 20 requests/second ceiling stays below that safety boundary. The
+verify endpoint and both status endpoints use the same policy with distinct
+route keys. Unit tests use a fake limiter; Task 12 links the Config Store and
+verifies Fastly Edge Rate Limiting entitlement before any route deploy.
+Limiter errors fail closed with bounded retryable 503, so Cloud Tasks retains
+the event; only a confirmed limit returns 429.
+
+- [ ] **Step 5: Implement independently watermarked durable effects**
+
+Apply blob, optional job, optional mapping, and cache purge separately. Return
+200 only when every required effect and purge succeeds. Return exact retryable
+409 errors for metadata/job not ready and conflict exhaustion; return
+event-bound 400 only for `validation_failed`.
+
+- [ ] **Step 6: Add controlled legacy endpoint retirement**
+
+Guard only `/admin/transcript-status` and `/admin/transcode-status` with
+`legacy_status_endpoints_enabled`; default local/setup state remains true for
+the compatibility window. False returns 410 without accepting either legacy
+or new credentials. Missing/unreadable operational controls fail closed after
+Task 12's deployment preflight has proven the store is linked.
+
+- [ ] **Step 7: Verify legacy isolation and commit**
+
+```bash
+cargo test -p fastly-blossom --locked --lib
+cargo check --tests --locked
+git add src/derivative_status.rs src/derivative_rate_limit.rs src/lib.rs src/main.rs src/metadata.rs secret-store-data.json.example
+git commit -m "feat(status): add durable Fastly apply endpoints"
+```
+
+Expected: legacy admin routes do not accept the derivative credential and all
+tests PASS.
+
+---
+
+### Task 6: Scaffold the delivery runtime and pending-first publisher
+
+**Files:**
+- Create: `cloud-run-transcoder/status-delivery/Cargo.toml`
+- Create: `cloud-run-transcoder/status-delivery/Cargo.lock`
+- Create: `cloud-run-transcoder/status-delivery/src/lib.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/ports.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/publisher.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/bin/derivative-status-admin.rs`
+- Modify: `cloud-run-transcoder/Cargo.toml`
+- Modify: `cloud-run-transcoder/Cargo.lock`
+
+- [ ] **Step 1: Write failing publisher tests with in-memory ports**
+
+Create the standalone crate manifest with Rust 2021 and a direct
+`derivative-status-core = { path = "../../derivative-status-core" }`
+dependency. Add `async-trait`, pinned UUID `=1.12.1`, serde/serde_json,
+thiserror, and Tokio test/runtime features. Add these direct dependencies to
+the parent transcoder:
+
+```toml
+derivative-status-core = { path = "../derivative-status-core" }
+status-delivery = { path = "status-delivery" }
+```
+
+Create `lib.rs` with `pub mod ports; pub mod publisher;`, then place the
+failing tests in `publisher.rs` before defining the implementation types:
+
+```rust
+#[tokio::test]
+async fn pending_is_durable_before_task_creation() {
+    let calls = SharedCalls::default();
+    let publisher = Publisher::new(fake_outbox(calls.clone()), fake_queue(calls.clone()));
+    publisher.publish(event()).await.unwrap();
+    assert_eq!(calls.values(), ["create_pending", "create_task"]);
+}
+
+#[tokio::test]
+async fn task_failure_returns_pending_reconciliation() {
+    let publisher = Publisher::new(memory_outbox(), failing_queue());
+    assert_eq!(
+        publisher.publish(event()).await.unwrap(),
+        Publication::PendingReconciliation
+    );
+}
+
+#[tokio::test]
+async fn allocation_mismatch_fails_before_pending_creation() {
+    let publisher = publisher_with_allocation(stored_allocation(7), event_with_attempt(6));
+    assert_eq!(publisher.publish().await.unwrap_err(), PublishError::AllocationMismatch);
+    assert_eq!(publisher.outbox_creates(), 0);
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo generate-lockfile --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml
+cargo generate-lockfile --manifest-path cloud-run-transcoder/Cargo.toml
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked publisher
+```
+
+Expected: FAIL because the publisher types/implementation are absent, not
+because a manifest, path dependency, or lockfile is missing.
+
+- [ ] **Step 3: Define narrow async ports**
+
+Use `async-trait` and exact result types:
+
+```rust
+#[async_trait]
+pub trait PendingStore {
+    async fn create(&self, event: &CanonicalEvent) -> Result<CreateOutcome, StoreError>;
+    async fn read(&self, event_id: Uuid) -> Result<Option<StoredEvent>, StoreError>;
+    async fn delete_generation(&self, event_id: Uuid, generation: i64) -> Result<(), StoreError>;
+}
+
+#[async_trait]
+pub trait TaskQueue {
+    async fn create(&self, event_id: Uuid) -> Result<TaskCreate, QueueError>;
+}
+```
+
+Also define `DeadStore`, `SuppressionStore`, `ControlStore`, `AttemptStore`,
+`SecretProvider`, `WebhookClient`, `TokenProvider`, `Clock`, and `IdGenerator`.
+Create the admin binary now as a thin command parser with no mutating
+subcommands; later tasks add commands without forward-referencing a missing
+target.
+
+- [ ] **Step 4: Implement publication state machine**
+
+Validate/canonicalize first, fetch the persisted allocation by operation ID,
+and reject any attempt epoch/ordinal mismatch before touching the outbox.
+Then create pending with create-only semantics, compare bytes on conflict, and
+create the deterministic task with bounded retry. Pending success plus task
+failure returns `PendingReconciliation`; pending failure is an error. Processor
+and recovery publishers both use this same path. Only a confirmed new task
+creation returns `Queued`; Cloud Tasks `AlreadyExists` returns
+`PendingReconciliation` because the name may be an active task or a 24-hour
+tombstone. Tests lock this truthful response distinction.
+
+- [ ] **Step 5: Remove the initial coverage guard and commit**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked
+git add cloud-run-transcoder/status-delivery cloud-run-transcoder/Cargo.toml cloud-run-transcoder/Cargo.lock scripts/check-derivative-status-coverage.sh
+git commit -m "feat(status): add pending-first publisher"
+```
+
+---
+
+### Task 7: Implement GCS, Cloud Tasks, and Firestore REST adapters
+
+**Files:**
+- Create: `cloud-run-transcoder/status-delivery/src/gcp_auth.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/gcs.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/cloud_tasks.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/firestore.rs`
+- Modify: `cloud-run-transcoder/status-delivery/src/lib.rs`
+- Modify: `cloud-run-transcoder/status-delivery/Cargo.toml`
+- Modify: `cloud-run-transcoder/src/main.rs:2494-2645`
+
+- [ ] **Step 1: Write failing HTTP-contract tests**
+
+Use a local Axum/wiremock server to assert:
+
+```rust
+#[tokio::test]
+async fn create_task_uses_deterministic_name_and_inert_url() {
+    let request = capture_create_task(event_id()).await;
+    assert_eq!(request.task.name, expected_task_name(event_id()));
+    assert_eq!(request.task.http_request.url, "https://invalid.invalid/");
+    assert!(request.task.http_request.oidc_token.is_none());
+    assert_eq!(request.task.dispatch_deadline, "20s");
+}
+```
+
+Add Firestore tests for begin/get/commit, transaction retry, stable operation
+allocation, atomic `recovery_preparations` write, max 100, and no delete/list
+API. Add GCS tests for create-only pending/suppression/dead, exact-generation
+delete, list pagination, and lease/cursor generations.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked adapters
+```
+
+Expected: FAIL because adapters are absent.
+
+- [ ] **Step 3: Extract a reusable metadata-server token provider**
+
+Move the existing access-token cache behavior from
+`cloud-run-transcoder/src/main.rs:2494-2645` into `gcp_auth.rs`: 50-minute
+cache, three 5-second metadata attempts, 200/400/800 ms backoff, and local
+`gcloud auth print-access-token` fallback only outside Cloud Run. Update the
+parent transcoder to call the shared provider for its existing Vertex/GCP
+paths, preserve its provider-error classification, and move the existing cache
+tests rather than duplicating two token implementations.
+
+- [ ] **Step 4: Implement Cloud Tasks REST CreateTask**
+
+POST to:
+
+```text
+https://cloudtasks.googleapis.com/v2/projects/{project}/locations/{location}/queues/{queue}/tasks
+```
+
+Send deterministic task name, base64 JSON `{"event_id":"..."}`, fixed inert
+URL, POST, content type, and a 20-second task dispatch deadline only. Treat
+HTTP 409 as `AlreadyExists`; classify 429/5xx/network as retryable and every
+bounded other response explicitly.
+
+- [ ] **Step 5: Implement Firestore transactional REST**
+
+Use `documents:beginTransaction`, transactional document reads, and
+`documents:commit`. Serialize only typed integer/string/map/null fields.
+Retry ABORTED conflicts with bounded jitter. One transaction updates
+`derivative_attempts/<derivative>:<sha>` and, for recovery prepare,
+`recovery_preparations/<run>:<index>`.
+
+- [ ] **Step 6: Implement GCS stores**
+
+Use existing `google-cloud-storage = 0.17.0`; keep each bucket in its own
+adapter/config field. Pending/suppression/dead creation uses generation zero;
+cleanup/release uses exact generation.
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked adapters
+cargo clippy --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked --all-targets --all-features -- -D warnings
+git add cloud-run-transcoder/status-delivery cloud-run-transcoder/src/main.rs cloud-run-transcoder/Cargo.lock
+git commit -m "feat(status): add Google Cloud adapters"
+```
+
+---
+
+### Task 8: Implement the private delivery service
+
+**Files:**
+- Create: `cloud-run-transcoder/status-delivery/src/fastly_client.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/delivery.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/config.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/bin/status-delivery.rs`
+- Create: `cloud-run-transcoder/status-delivery/Dockerfile`
+
+- [ ] **Step 1: Write failing delivery state-machine tests**
+
+Create one test per table row in the spec, including:
+
+```rust
+#[tokio::test]
+async fn fastly_404_retains_pending_and_retries() {
+    let result = worker_with_fastly(404, r#"{"error":"not_found"}"#).deliver(id()).await;
+    assert_eq!(result.http_status(), 503);
+    assert!(pending_exists(id()).await);
+    assert!(!dead_exists(id()).await);
+}
+
+#[tokio::test]
+async fn only_matching_validation_failed_moves_dead() {
+    let body = format!(r#"{{"event_id":"{}","error":"validation_failed"}}"#, id());
+    assert_eq!(worker_with_fastly(400, &body).deliver(id()).await.http_status(), 204);
+    assert!(!pending_exists(id()).await);
+    assert!(dead_exists(id()).await);
+}
+```
+
+Also cover both-present cleanup, digest mismatch, unknown schema, malformed
+2xx, exact effect validation, 401/403, timeouts, cleanup failure, and redirect
+rejection.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked delivery
+```
+
+Expected: FAIL because delivery service is absent.
+
+- [ ] **Step 3: Implement bounded signed Fastly client**
+
+Use one reqwest client with redirects disabled, 3-second connect/10-second
+total timeout, 16 KiB response cap, fixed origin/path, current secret file read
+per attempt, and exact response parser.
+
+- [ ] **Step 4: Implement delivery orchestration and router**
+
+Expose only health/readiness and `POST /tasks/deliver`. The task body is at
+most 128 bytes and unknown fields fail. Return 204 only after validated Fastly
+acceptance plus exact pending cleanup, or an already-clean state.
+
+- [ ] **Step 5: Verify and commit**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked delivery
+docker build -f cloud-run-transcoder/status-delivery/Dockerfile .
+git add cloud-run-transcoder/status-delivery
+git commit -m "feat(status): add private delivery worker"
+```
+
+---
+
+### Task 9: Implement reconciliation with durable lease and cursor
+
+**Files:**
+- Create: `cloud-run-transcoder/status-delivery/src/reconciler.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/bin/status-reconciler.rs`
+
+- [ ] **Step 1: Write failing crash-boundary and pagination tests**
+
+Cover more than one page, permanently failing first page, invalid token reset,
+task tombstones, eight-minute/5,000 cap, overlapping job, exact lease release,
+release race, and crash expiry.
+
+```rust
+#[tokio::test]
+async fn successful_run_releases_exact_lease_generation() {
+    let control = recording_control_store();
+    Reconciler::new(control.clone(), pending(), queue()).run().await.unwrap();
+    assert_eq!(control.deleted_generation(), Some(control.acquired_generation()));
+}
+```
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked reconciler
+```
+
+Expected: FAIL because reconciler is absent.
+
+- [ ] **Step 3: Implement lease/cursor reconciliation**
+
+Acquire `lease.json`, exit successfully on live lease, reclaim expired lease
+with generation match, persist cursor after each page, recreate tasks for
+pending older than two minutes, and release in a finally-style guard on every
+normal/error return. A process abort intentionally leaves expiry recovery.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked reconciler
+git add cloud-run-transcoder/status-delivery/src/reconciler.rs cloud-run-transcoder/status-delivery/src/bin/status-reconciler.rs
+git commit -m "feat(status): add outbox reconciliation"
+```
+
+---
+
+### Task 10: Authenticate processor routes and add queue-first admission
+
+**Files:**
+- Create: `cloud-run-transcoder/src/processor_auth.rs`
+- Create: `cloud-run-transcoder/src/processor_rate_limit.rs`
+- Create: `cloud-run-transcoder/src/derivative_admission.rs`
+- Create: `cloud-run-transcoder/src/status_publisher.rs`
+- Modify: `cloud-run-transcoder/src/main.rs:1-180`
+- Modify: `cloud-run-transcoder/src/main.rs:650-820`
+- Modify: `cloud-run-transcoder/src/main.rs:1285-1760`
+- Modify: `cloud-run-transcoder/src/main.rs:5128-5359`
+- Modify: `cloud-run-transcoder/Cargo.toml`
+- Modify: `cloud-run-transcoder/Dockerfile`
+- Modify: `cloud-run-transcoder/deploy.sh`
+
+- [ ] **Step 1: Write failing auth and maintenance router tests**
+
+Test unsigned/wrong/stale/duplicate headers, route/body/request-ID binding,
+pre-auth body limits, replay marker ordering, exact verify response with no
+mutation, primary/secondary overlap, per-signer verification rate limiting,
+`dual_accept` versus `enforce` rollout modes, production-only CORS, and
+maintenance 503 on all compute routes. In dual-accept, unsigned legacy
+requests are accepted and counted, valid signed requests use normal replay
+protection, and malformed/invalid signed requests are always rejected.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/Cargo.toml --locked processor_auth
+```
+
+Expected: FAIL because middleware/routes do not exist.
+
+- [ ] **Step 3: Implement route-bound raw-body HMAC middleware**
+
+Buffer only the route-specific limit, verify exact raw bytes before JSON,
+reconstruct the request body, then create replay marker before expensive work.
+Exclude health and `/internal/processor-auth/v1/verify` from replay markers,
+but not from HMAC. Read verifier primary plus optional secondary; callers read
+primary only. Mount verifier secrets as files and reload them for each request
+so rotation does not require a worker revision; readiness fails on a missing,
+empty, short, or unreadable primary. Add a bounded in-process token bucket keyed by the verified
+signer slot for the low-volume verify route: burst 5 and refill 5 per minute,
+checked after authentication and before JSON. Cap the key map at the two
+recognized signer slots, and test refill with an injected clock. Make the sole
+allowed browser origin explicit configuration and reject wildcard CORS in
+production. Read `PROCESSOR_AUTH_MODE=dual_accept|enforce`; emit a
+low-cardinality unsigned-caller counter in dual-accept, and reject all unsigned
+compute requests in enforce. The verify route always requires valid HMAC in
+both modes.
+
+- [ ] **Step 4: Write failing admission/suppression tests**
+
+Cover lock then suppression recheck, Firestore allocation, ordinal exhaustion,
+all four permanent-input codes, transient non-suppression, suppression-first
+crash, preflight reconstruction, existing artifact completion, and reviewed
+epoch clear ordering.
+
+- [ ] **Step 5: Implement admission**
+
+Order exactly:
+
+```text
+signed request:
+  verify HMAC -> create replay marker -> read suppression -> acquire hash lock
+  -> re-read suppression -> allocate operation/attempt -> publish processing
+  -> start compute
+
+unsigned request while dual_accept only:
+  classify/count legacy caller -> read suppression -> acquire hash lock
+  -> re-read suppression -> allocate operation/attempt -> publish processing
+  -> start compute
+```
+
+Unsigned dual-accept requests have no replay marker because they have no
+authenticated request ID; existing per-hash locks still suppress duplicate
+compute. This branch is transitional and is removed from reach when
+`PROCESSOR_AUTH_MODE=enforce`.
+
+For permanent input failure:
+
+```text
+create immutable suppression -> create pending -> create task -> return
+```
+
+Fail closed on suppression/attempt/pending failures. Instrument
+`active_derivative_operations` by revision.
+
+- [ ] **Step 6: Map publication state into processor responses**
+
+Every accepted compute/admission response includes exactly
+`"status_delivery":"queued"` when task creation succeeded or
+`"status_delivery":"pending_reconciliation"` when the durable pending object
+exists but task creation exhausted its bounded retry. Add route-level tests
+for both values and prove neither response is returned when pending creation
+failed.
+
+- [ ] **Step 7: Replace active fire-and-forget dispatch**
+
+Route
+pending, processing, complete, and failed transitions through one typed
+`StatusPublisher`. Terminal persistence errors return 503 even after artifact
+upload; existing artifacts publish complete without recompute. Retain the
+legacy sender implementation behind `LEGACY_STATUS_SENDER_ENABLED=false` for
+the bounded rollback window, and add an inventory test proving no normal-mode
+call path invokes it when false. Task 16 removes the dormant code only after
+the fourteen-day production gate.
+
+- [ ] **Step 8: Add maintenance image mode and root-context build**
+
+Read `PROCESSOR_MODE=normal|maintenance`. Maintenance initializes neither
+GPU/FFmpeg nor publishers. Update Docker build context so path dependencies on
+`../derivative-status-core` and `status-delivery` compile under Rust 1.83.
+Deploy named revisions without automatic latest traffic.
+
+- [ ] **Step 9: Verify and commit**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/Cargo.toml --locked
+cargo clippy --manifest-path cloud-run-transcoder/Cargo.toml --locked --all-targets --all-features -- -D warnings
+git add cloud-run-transcoder/src/processor_auth.rs \
+  cloud-run-transcoder/src/processor_rate_limit.rs \
+  cloud-run-transcoder/src/derivative_admission.rs \
+  cloud-run-transcoder/src/status_publisher.rs \
+  cloud-run-transcoder/src/main.rs \
+  cloud-run-transcoder/Cargo.toml \
+  cloud-run-transcoder/Cargo.lock \
+  cloud-run-transcoder/Dockerfile \
+  cloud-run-transcoder/deploy.sh
+git commit -m "feat(transcoder): publish derivative status durably"
+```
+
+---
+
+### Task 11: Sign every processor caller
+
+**Files:**
+- Create: `cloud-run-upload/src/processor_request.rs`
+- Create: `src/processor_request.rs`
+- Modify: `cloud-run-upload/src/main.rs:1791-1845`
+- Modify: `cloud-run-upload/Cargo.toml`
+- Modify: `cloud-run-upload/Dockerfile`
+- Modify: `cloud-run-upload/deploy.sh`
+- Modify: `src/main.rs:2700-3050`
+- Modify: `src/storage.rs:1430-1505`
+- Modify: `secret-store-data.json.example`
+- Modify: `cloud-run-transcoder/status-delivery/src/bin/derivative-status-admin.rs`
+- Modify: `cloud-run-transcoder/backfill.sh`
+- Modify: `cloud-run-transcoder/backfill-prioritized.sh`
+- Modify: `scripts/backfill-fmp4.sh`
+
+- [ ] **Step 1: Write failing shared-vector caller tests**
+
+Run the same `fixtures/derivative-status-hmac-v1.json` through upload, Fastly
+pure caller helper, and admin CLI tests. Add wiremock assertions for all four
+headers and exact raw JSON digest.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test --manifest-path cloud-run-upload/Cargo.toml --locked processor_request
+cargo test -p fastly-blossom --locked --lib processor_request
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked admin
+```
+
+Expected: FAIL because signing callers are absent.
+
+- [ ] **Step 3: Implement upload and Fastly callers**
+
+Use `derivative-status-core::auth` and canonical raw JSON bytes. Fetch only
+`processor_request_secret_primary`; verifier secondary is never exposed to a
+caller. Upload reads the mounted `latest` secret file for every request,
+Fastly reads its Secret Store entry for every request, and the operator CLI
+fetches the secret only in memory under its impersonated identity. Generate a
+fresh UUIDv7/timestamp for every intentional retry. Treat
+503 plus `Retry-After` as retryable and 409 replay as non-retryable for that
+request ID.
+
+- [ ] **Step 4: Implement safe operator submission**
+
+`derivative-status-admin processor-request` reads the secret in memory,
+constructs/signs/sends the request, and never prints auth headers. Backfill
+scripts invoke this binary rather than handling the secret or raw curl auth.
+
+- [ ] **Step 5: Update upload deployment/build**
+
+Build from repo root so upload can depend on the shared crate. Mount only the
+processor request signer secret, not derivative/admin credentials. Document
+the primary and optional verifier-only secondary names in
+`secret-store-data.json.example`; never add the ignored real secret file.
+
+- [ ] **Step 6: Verify shell callers and commit**
+
+```bash
+cargo test --manifest-path cloud-run-upload/Cargo.toml --locked
+cargo test -p fastly-blossom --locked --lib
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked
+bash -n cloud-run-transcoder/backfill.sh
+bash -n cloud-run-transcoder/backfill-prioritized.sh
+bash -n scripts/backfill-fmp4.sh
+rg -n 'derivative-status-admin processor-request' \
+  cloud-run-transcoder/backfill.sh \
+  cloud-run-transcoder/backfill-prioritized.sh \
+  scripts/backfill-fmp4.sh
+! rg -n 'processor_request_secret|X-Processor-(Timestamp|Request-Id|Signature)' \
+  cloud-run-transcoder/backfill.sh \
+  cloud-run-transcoder/backfill-prioritized.sh \
+  scripts/backfill-fmp4.sh
+git add cloud-run-upload/src/processor_request.rs \
+  cloud-run-upload/src/main.rs \
+  cloud-run-upload/Cargo.toml \
+  cloud-run-upload/Cargo.lock \
+  cloud-run-upload/Dockerfile \
+  cloud-run-upload/deploy.sh \
+  src/processor_request.rs \
+  src/main.rs \
+  src/storage.rs \
+  secret-store-data.json.example \
+  cloud-run-transcoder/status-delivery/src/bin/derivative-status-admin.rs \
+  cloud-run-transcoder/backfill.sh \
+  cloud-run-transcoder/backfill-prioritized.sh \
+  scripts/backfill-fmp4.sh
+git commit -m "feat(auth): sign every processor request"
+```
+
+---
+
+### Task 12: Provision least-privilege infrastructure and deployment contracts
+
+**Files:**
+- Create: `cloud-run-transcoder/deploy-derivative-status.sh`
+- Create: `cloud-run-transcoder/status-delivery/tests/deployment_contract.rs`
+- Create: `scripts/provision-derivative-fastly-resources.sh`
+- Modify: `cloud-run-transcoder/deploy.sh`
+- Modify: `cloud-run-upload/deploy.sh`
+- Modify: `README.md`
+
+- [ ] **Step 1: Write failing rendered-config/IAM tests**
+
+The deployment script must support `--render` with no cloud mutation. Parse
+its JSON/YAML output and assert five buckets, one Firestore database, queue
+ALWAYS overrides, exact retry/dispatch settings, private service/job,
+scheduler, identities, and exact allow/deny matrix. The Fastly script must
+also support a non-mutating `--render` whose output names the operational
+Config Store, its initial entries and service link, fixed SDK rate-counter and
+penalty-box names, Edge Rate Limiting entitlement preflight, and required
+secret entry names without secret values.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked deployment_contract
+```
+
+Expected: FAIL because render mode/resources are absent.
+
+- [ ] **Step 3: Implement idempotent provisioning**
+
+Create:
+
+```text
+pending-event bucket
+dead-event bucket (30-day lifecycle)
+processor-replay bucket (24-hour lifecycle)
+terminal-suppression bucket
+reconciliation-control bucket
+dedicated Firestore attempt database
+derivative-status-delivery queue
+private delivery Cloud Run service
+private reconciler Cloud Run Job
+one-minute Scheduler trigger
+all dedicated service identities, Secret Manager containers, and bindings
+```
+
+Queue overrides must be `ALWAYS` for HTTPS host/path, empty query, POST,
+content type, OIDC identity, and audience. Task creators get no `actAs`.
+Runtime IAM must omit forbidden list/delete/secret permissions.
+Configure Scheduler to POST the Cloud Run v2 Job `:run` API once per minute
+with an OAuth service-account token (not the task OIDC identity); its identity
+gets only the target job execution permission.
+Bootstrap derivative-delivery and processor-request primary/secondary
+credentials only from operator-supplied files/stdin, write the matching halves
+to Fastly Secret Store and Google Secret Manager, never accept secret bytes on
+argv, and never print or render them. The delivery worker receives only the
+derivative primary; processor callers receive only the processor primary;
+verifiers receive primary plus optional secondary. Cloud Run consumes secret
+versions through mounted `latest` files, not environment variables. Secret
+material is exactly 64 lowercase hex characters encoding 32 random bytes with
+no whitespace; every runtime decodes it before HMAC use and readiness rejects
+any other form. Bootstrap uses the same validated input bytes for both writes
+and never attempts to read back or print secret values.
+
+- [ ] **Step 4: Set and verify the exact queue contract**
+
+Render and provision:
+
+```text
+minBackoff=5s
+maxBackoff=900s
+maxRetryDuration=2592000s
+maxAttempts=-1
+maxDoublings=8
+maxConcurrentDispatches=10
+maxDispatchesPerSecond=20
+```
+
+The deployment-contract test parses rendered configuration and fails on any
+different or omitted queue value. The adapter contract separately requires
+every created task's `dispatchDeadline=20s`. `--smoke-queue-override` submits
+the inert placeholder task and proves queue routing reaches the private worker
+within the declared few-second path; it also inspects the live queue plus
+synthetic task for all retry, deadline, concurrency, and rate values.
+
+- [ ] **Step 5: Render/provision Fastly controls before route deployment**
+
+`scripts/provision-derivative-fastly-resources.sh` must idempotently create or
+resolve the `operational_controls` store, seed
+`mapping_writes_paused=false`, `legacy_mapping_writes_enabled=true`, and
+`legacy_status_endpoints_enabled=true`, and link the store to the staged
+service version using the installed Fastly CLI's Config Store/resource-link
+commands. Fastly Compute rate counters and penalty boxes are SDK primitives,
+not CLI-created resource links: use fixed names
+`derivative_status_rate_counter` and `derivative_status_penalty_box`, verify
+Edge Rate Limiting entitlement/enablement before route deployment, and run a
+bounded post-publish route smoke test that exercises the SDK primitive. It
+prints exact service, version, store, and link IDs before requiring
+`--confirm`; render and contract tests never mutate Fastly. Production rollout
+must run its live preflight before publishing code that fails closed on these
+bindings.
+
+- [ ] **Step 6: Add deploy smoke subcommands without executing them**
+
+Implement `--smoke-auth`, `--smoke-queue-override`, `--smoke-iam`,
+`--pause-dispatch`, and `--resume-dispatch`. Commands print exact target
+project/region/resources before requiring `--confirm`.
+
+- [ ] **Step 7: Verify and commit**
+
+```bash
+bash -n cloud-run-transcoder/deploy-derivative-status.sh
+bash -n scripts/provision-derivative-fastly-resources.sh
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked deployment_contract
+git add cloud-run-transcoder/deploy-derivative-status.sh cloud-run-transcoder/status-delivery/tests/deployment_contract.rs scripts/provision-derivative-fastly-resources.sh cloud-run-transcoder/deploy.sh cloud-run-upload/deploy.sh README.md
+git commit -m "ops(status): define durable delivery infrastructure"
+```
+
+---
+
+### Task 13: Implement reviewed incident recovery and dead replay
+
+**Files:**
+- Create: `cloud-run-transcoder/status-delivery/src/recovery.rs`
+- Create: `cloud-run-transcoder/status-delivery/src/suppression_clear.rs`
+- Modify: `cloud-run-transcoder/status-delivery/src/bin/derivative-status-admin.rs`
+- Create: `cloud-run-transcoder/status-delivery/tests/recovery_cli.rs`
+- Create: `cloud-run-transcoder/status-delivery/tests/suppression_clear.rs`
+
+- [ ] **Step 1: Write failing phase-boundary tests**
+
+Cover non-mutating discover/intent, exact digest changes, Firestore prepare
+transaction, crash after transaction, second review requirement, identical
+re-prepare/apply, hundreds of hashes, eligibility exclusion, no processor
+invocation, terminal suppression, dead corrective replay, paginated mapping
+migration, and reviewed suppression clearing.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked recovery
+```
+
+Expected: FAIL because recovery workflow is absent.
+
+- [ ] **Step 3: Implement discover and plan-intent**
+
+List only artifact metadata for `*/vtt/main.vtt` and `*/hls/master.m3u8`; never
+read media bodies. Also accept an explicit operator-supplied canonical JSON
+manifest of terminal failures derived from the sanitized structured-log/Sentry
+fields; validate schema, hash, derivative, bounded safe error code/message,
+evidence timestamp, duplicates, and digest, and never query raw Sentry payloads
+or logs automatically. Fetch current Fastly derivative metadata, exclude
+absent/deleted/ineligible entries, and emit canonical intent plus digest with
+no mutation. Use the existing authenticated
+`GET /admin/api/blob/<sha256>` response with an operator-supplied short-lived
+admin bearer read from a file; never accept it on argv, persist it, or log it.
+Tests prove 401/403/404 fail closed and that banned/deleted/ineligible metadata
+is excluded. Tests also prove invalid/duplicate terminal entries are rejected
+and valid entries flow through prepare/apply without artifact discovery.
+
+- [ ] **Step 4: Implement prepare**
+
+Require reviewed intent digest and `--confirm-prepare`. In one Firestore
+transaction per entry, allocate/reuse operation/ordinal and write the known
+`recovery_preparations/<run>:<index>` record. Emit exact canonical event bytes
+and prepared digest; publish nothing.
+
+- [ ] **Step 5: Implement apply/verify and dead replay**
+
+Require reviewed prepared digest and `--confirm-apply`. Publish exact prepared
+bytes through the normal outbox publisher. Dead replay creates a new corrective
+operation and leaves original dead data untouched.
+
+- [ ] **Step 6: Implement fleet mapping migration orchestration**
+
+`derivative-status-admin mapping-migrate` requires both processor admissions
+and Fastly mapping writes to be paused, walks the Task 4 admin endpoint cursor
+until exhaustion, writes a canonical per-page audit record, reruns parity
+inspection, and refuses authority cutover on any legacy/v2 mismatch. Tests
+cover hundreds of entries, cursor resume, idempotent rerun, and a conflict
+that is retried without skipping a key.
+
+- [ ] **Step 7: Implement reviewed suppression clearing**
+
+`suppression-clear plan` reads exactly one named suppression object plus
+generation and current Firestore attempt epoch, then emits a canonical intent
+and digest without mutation. `suppression-clear apply` requires the reviewed
+digest and `--confirm`, transactionally rotates the attempt epoch first, then
+deletes only the reviewed exact GCS generation. It emits bounded audit
+evidence. A crash before delete remains suppressed; a generation mismatch or
+changed Firestore state aborts. The suppression-operator identity has only
+the permissions needed by this command.
+
+- [ ] **Step 8: Verify and commit**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked recovery
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked suppression_clear
+git add cloud-run-transcoder/status-delivery/src/recovery.rs cloud-run-transcoder/status-delivery/src/suppression_clear.rs cloud-run-transcoder/status-delivery/src/bin/derivative-status-admin.rs cloud-run-transcoder/status-delivery/tests/recovery_cli.rs cloud-run-transcoder/status-delivery/tests/suppression_clear.rs
+git commit -m "feat(status): add reviewed incident recovery"
+```
+
+---
+
+### Task 14: Add observability, runbook, and full verification gates
+
+**Files:**
+- Create: `docs/runbooks/derivative-status-delivery.md`
+- Modify: `cloud-run-transcoder/deploy-derivative-status.sh`
+- Modify: `scripts/provision-derivative-fastly-resources.sh`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `scripts/check-derivative-status-coverage.sh`
+- Modify: `cloud-run-transcoder/src/main.rs`
+- Modify: `cloud-run-transcoder/status-delivery/src/delivery.rs`
+- Modify: `cloud-run-transcoder/status-delivery/src/reconciler.rs`
+
+- [ ] **Step 1: Write failing metrics/log schema tests**
+
+Assert low-cardinality labels only, bounded/redacted fields, distinct Sentry
+fingerprints, and absence of hashes/event IDs in metric labels.
+
+- [ ] **Step 2: Implement metrics and alert render output**
+
+Emit enqueue/delivery/reconciliation/CAS/suppression/mapping-freeze metrics,
+pending/dead age/count, convergence latency, and active-operation gauges.
+Render alert policies with exact thresholds from the spec.
+
+- [ ] **Step 3: Write the checked-in runbook**
+
+Include exact non-secret commands, expected output, owner role, escalation,
+pause impact, auto-expiring maintenance mutes, post-maintenance check, and
+procedures for:
+
+```text
+current legacy-secret P1 repair
+health/readiness
+processor non-compute auth verification
+queue and pending inspection
+dispatch pause/resume
+processor maintenance traffic/drain/resume
+Fastly mapping freeze/probe/parity/resume
+dual-secret rotation
+suppression inspect/reviewed clear
+dead inspect/prepare/apply replay
+reconciler cursor/lease repair
+recovery discover/intent/prepare/review/apply/verify
+rollback floor and backlog drain
+```
+
+- [ ] **Step 4: Run the full local verification**
+
+```bash
+cargo test -p blossom-core --locked
+cargo test --manifest-path derivative-status-core/Cargo.toml --locked
+cargo test --manifest-path cloud-run-upload/Cargo.toml --locked
+cargo test --manifest-path cloud-run-transcoder/Cargo.toml --locked
+cargo test --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked
+cargo check --tests --locked
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo clippy --manifest-path derivative-status-core/Cargo.toml --locked --all-targets --all-features -- -D warnings
+cargo clippy --manifest-path cloud-run-upload/Cargo.toml --locked --all-targets --all-features -- -D warnings
+cargo clippy --manifest-path cloud-run-transcoder/Cargo.toml --locked --all-targets --all-features -- -D warnings
+cargo clippy --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml --locked --all-targets --all-features -- -D warnings
+bash scripts/check-derivative-status-coverage.sh
+bash -n cloud-run-transcoder/deploy-derivative-status.sh
+bash -n scripts/provision-derivative-fastly-resources.sh
+bash -n cloud-run-transcoder/backfill.sh
+bash -n cloud-run-transcoder/backfill-prioritized.sh
+bash -n scripts/backfill-fmp4.sh
+docker build -f cloud-run-transcoder/status-delivery/Dockerfile .
+docker build -f cloud-run-transcoder/Dockerfile .
+docker build -f cloud-run-upload/Dockerfile .
+```
+
+Expected: every command exits 0; coverage reports 100% lines/functions/regions
+for both new crates.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/runbooks/derivative-status-delivery.md \
+  cloud-run-transcoder/deploy-derivative-status.sh \
+  cloud-run-transcoder/src/main.rs \
+  cloud-run-transcoder/status-delivery/src/delivery.rs \
+  cloud-run-transcoder/status-delivery/src/reconciler.rs \
+  scripts/provision-derivative-fastly-resources.sh \
+  .github/workflows/ci.yml \
+  scripts/check-derivative-status-coverage.sh
+git commit -m "ops(status): add monitoring and recovery runbook"
+```
+
+---
+
+### Task 15: Production repair and staged rollout (explicit approval required)
+
+**Files:**
+- Read: `docs/runbooks/derivative-status-delivery.md`
+- Read: `docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md`
+- No source edits during rollout.
+
+- [ ] **Step 1: Obtain explicit production deployment approval**
+
+Stop if the user has not explicitly authorized production secret changes,
+resource provisioning, Cloud Run/Fastly deployments, traffic changes, and
+incident recovery mutations.
+
+- [ ] **Step 2: Repair the active P1 first**
+
+Follow the runbook to align the current legacy callback secret, verify live
+transcript/transcode callback success, and run audited artifact-backed
+metadata repair without retranscoding.
+
+Expected: fresh callback 2xx, rejected-callback rate reaches zero, repaired
+artifact/status counts reconcile.
+
+- [ ] **Step 3: Publish and verify the Fastly bridge floor**
+
+Run the reviewed Fastly resource provisioner first and require live proof that
+the operational control store, initial compatibility entries, service link,
+required secret entries, and Edge Rate Limiting entitlement exist. From a
+clean temporary worktree pinned
+to the Task 4 bridge commit (before Task 5 status routes), use only:
+
+```bash
+fastly compute publish --comment "derivative status CAS bridge"
+fastly purge --all --service-id pOvEEWykEbpnylqst1KTrR
+```
+
+Wait the declared propagation interval and run every mapping-route probe before
+freeze/migration. Record the exact bridge commit and active Fastly version as
+the rollback floor.
+
+- [ ] **Step 4: Freeze, drain, migrate, and resume**
+
+Deploy the fully verified processor image as a named
+`PROCESSOR_MODE=maintenance` revision with zero traffic and smoke its 503
+compute behavior before use. Set mapping writes paused, route Cloud Run 100%
+to that named maintenance revision, wait 1,800 seconds, require every
+zero/quiet signal for two minutes, run
+`derivative-status-admin mapping-migrate` to cursor exhaustion, verify
+legacy/v2 parity, canary unfreeze, and resume only the explicit pre-rollout
+legacy normal revision. Record both revision names; never route to implicit
+`latest`.
+
+- [ ] **Step 5: Publish status routes and provision durable delivery**
+
+From a separate clean worktree pinned to the fully verified Task 14 commit,
+publish/purge the Fastly package containing the versioned status routes and
+signed Fastly processor caller. Verify the status-auth non-mutating route,
+legacy compatibility controls, bounded ERL behavior, and bridge behavior. Only then
+provision the reviewed GCP render, deploy the private worker/reconciler, and
+verify IAM, queue overrides, task deadline, retry contract, and secret
+overlap.
+
+- [ ] **Step 6: Deploy dual-accept processor auth and every signed caller**
+
+Deploy a named queue-first processor revision with
+`PROCESSOR_AUTH_MODE=dual_accept` and controlled traffic. Deploy the signed
+`cloud-run-upload` revision and the full Fastly caller release, and install
+the reviewed admin CLI/backfill entrypoint. Exercise
+`/internal/processor-auth/v1/verify` through every real caller path with fresh
+nonce/request IDs. Invalid signed requests must fail even in dual-accept.
+Observe the unsigned-caller metric until every named caller is verified and
+the metric remains zero for the runbook interval.
+
+- [ ] **Step 7: Enforce processor auth and run the 24-hour canary**
+
+Deploy a new named queue-first processor revision with
+`PROCESSOR_AUTH_MODE=enforce`, canary traffic only after Step 6 is green, and
+prove unsigned calls are rejected. Run one synthetic transcript and transcode
+through the complete producer -> pending -> task -> worker -> Fastly path and
+observe the canary for 24 hours. Do not proceed unless the report proves all
+six blocking criteria:
+
+```text
+zero lost or dead events
+zero unauthorized delivery acceptance
+zero metadata regression
+zero duplicate failure increments
+p95 convergence < 30 seconds and >= 99.9% within five minutes
+queue and pending depth returned to baseline
+```
+
+Any missing/unavailable criterion or threshold failure pauses rollout and
+invokes the documented rollback for the faulty layer.
+
+- [ ] **Step 8: Queue-first cutover and observation**
+
+Repeat maintenance drain, switch 100% to the named queue-first revision, keep
+the legacy sender disabled, keep legacy endpoints during the bounded
+compatibility window, and observe the queue-first path.
+
+- [ ] **Step 9: Retire legacy behavior with reversible controls**
+
+Disable the legacy status endpoints after the required queue-first observation
+gate and observe seven more days. After fourteen total stable days and a scan
+proving every active mapping has v2 state, set
+`legacy_mapping_writes_enabled=false`. Do not delete source in this rollout;
+both changes are reversible Config Store controls and their before/after
+values are recorded.
+
+- [ ] **Step 10: Apply reviewed residual recovery**
+
+Run discover/intent, review, prepare, review exact bytes, apply, and verify.
+Never skip either digest review or use retranscoding for artifact-backed
+completion.
+
+- [ ] **Step 11: Final production evidence**
+
+Record:
+
+```text
+zero untracked/lost events
+zero unauthorized acceptance
+zero duplicate counter increments
+zero metadata regressions
+p95 convergence < 30 seconds
+>= 99.9% convergence within five minutes
+queue/pending return to baseline
+terminal corrupt media remains suppressed
+```
+
+Rollback only to the declared CAS-compatible bridge floor or newer.
+
+---
+
+### Task 16: Remove retired legacy code after the stability gate (future approval required)
+
+**Files:**
+- Modify: `cloud-run-transcoder/src/main.rs`
+- Modify: `src/main.rs`
+- Modify: `src/metadata.rs`
+- Modify: `src/subtitle_mapping.rs`
+- Modify: `docs/runbooks/derivative-status-delivery.md`
+
+- [ ] **Step 1: Verify the irreversible cleanup gate**
+
+Require Task 15 evidence for fourteen stable days, legacy endpoints disabled
+for seven days, every active mapping represented in v2, no legacy sender
+invocations, and explicit approval for a new cleanup PR. Stop on any missing
+evidence.
+
+- [ ] **Step 2: Write failing inventory tests**
+
+Inventory tests must reject legacy webhook dispatch calls, legacy status route
+registrations, and writes to `subtitle_hash:` while retaining the legacy read
+fallback required for old inactive records.
+
+- [ ] **Step 3: Remove dormant legacy implementations**
+
+Delete the disabled sender code, legacy status handlers/routes, and legacy
+mapping writes. Keep only the read fallback and documented rollback floor.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+cargo test --manifest-path cloud-run-transcoder/Cargo.toml --locked
+cargo test -p fastly-blossom --locked --lib
+cargo check --tests --locked
+git add cloud-run-transcoder/src/main.rs src/main.rs src/metadata.rs src/subtitle_mapping.rs docs/runbooks/derivative-status-delivery.md
+git commit -m "refactor(status): remove retired legacy delivery"
+```

--- a/docs/superpowers/plans/2026-07-24-perceptual-video-hashing-research-spike.md
+++ b/docs/superpowers/plans/2026-07-24-perceptual-video-hashing-research-spike.md
@@ -1,0 +1,1738 @@
+# Perceptual Video Hashing Research Spike Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the approved offline, sandboxed, reproducible vPDQ versus
+TMK+PDQF benchmark and verify it with synthetic media without changing any
+production service.
+
+**Architecture:** A standard-library Python package owns strict manifest
+validation, deterministic transforms and splits, native-tool adapters,
+threshold selection, metrics, reporting, and bounded run storage. A single
+`./benchmark` launcher builds or invokes a digest-pinned container containing
+the official ThreatExchange revision and FFmpeg. Quality evaluation is
+exhaustive; development thresholds are frozen into a content-addressed
+artifact before the held-out test phase.
+
+**Tech Stack:** Python 3.12 standard library, `unittest`, coverage.py 7.15.2,
+FFmpeg/FFprobe, Docker, CMake/C++14, official ThreatExchange vPDQ and
+TMK+PDQF at `baefb4ed67b6cdc1d4c82dbaef858d50866ac424`.
+
+**Status:** Approved by feasibility, completeness, and scope/alignment review.
+
+---
+
+## Scope and file map
+
+Create only the isolated experiment and documentation:
+
+- `experiments/perceptual-video-hashing/benchmark` — operator entry point.
+- `experiments/perceptual-video-hashing/Dockerfile` — pinned native toolchain.
+- `experiments/perceptual-video-hashing/requirements.lock` — test dependency.
+- `experiments/perceptual-video-hashing/README.md` — safe operating runbook.
+- `experiments/perceptual-video-hashing/config/defaults.json` — transforms,
+  split ratios, threshold grids, and budgets.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/model.py` —
+  immutable domain records and exit codes.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/manifest.py` —
+  strict schema, attestation, file and path validation.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/splits.py` —
+  deterministic group-preserving assignment.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/media.py` —
+  hostile-input probing, normalization, and resource limits.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/transforms.py` —
+  shell-free FFmpeg argument construction.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/adapters.py` —
+  bounded subprocess execution and official-tool parsers.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/metrics.py` —
+  exhaustive outcomes, operating-point selection, intervals, freeze digest.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/store.py` —
+  run ownership, atomic artifacts, safe cleanup.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/provenance.py` —
+  non-identifying build and run provenance.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/report.py` —
+  aggregate-only Markdown and JSON reports.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/pipeline.py` —
+  preflight, smoke, pilot, tune, test, report phases.
+- `experiments/perceptual-video-hashing/src/phash_benchmark/cli.py` — command
+  parsing and stable exit statuses.
+- `experiments/perceptual-video-hashing/tests/` — mirrored unit tests.
+- `experiments/perceptual-video-hashing/container/` — direct package lock and
+  deterministic SPDX generator.
+- `experiments/perceptual-video-hashing/fixtures/` — generated-media script
+  and safe example manifest only.
+- `.gitignore` — ignore experiment inputs, runs, generated media, hashes, and
+  coverage output.
+
+Do not modify edge, upload, transcoder, process-blob, moderation, deployment,
+or schema code.
+
+### Task 1: Scaffold the package and strict domain model
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/requirements.lock`
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/__init__.py`
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/model.py`
+- Create: `experiments/perceptual-video-hashing/tests/__init__.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_model.py`
+
+- [ ] **Step 1: Write the failing model tests**
+
+Define tests for exact enum values, immutable dataclasses, and stable exit
+codes:
+
+```python
+from dataclasses import FrozenInstanceError
+import unittest
+
+from phash_benchmark.model import (
+    Corpus,
+    ExitCode,
+    Item,
+    Role,
+    Split,
+    UseBasis,
+)
+
+
+class ModelTest(unittest.TestCase):
+    def test_protocol_values_are_stable(self):
+        self.assertEqual(Role.SOURCE.value, "source")
+        self.assertEqual(Role.DISTRACTOR.value, "distractor")
+        self.assertEqual(Split.TRAIN.value, "train")
+        self.assertEqual(Split.DEVELOPMENT.value, "development")
+        self.assertEqual(Split.TEST.value, "test")
+        self.assertEqual(Corpus.DIVINE_PUBLIC.value, "divine_public")
+        self.assertEqual(UseBasis.OWNED_OR_LICENSED.value, "owned_or_licensed")
+        self.assertEqual(ExitCode.OK, 0)
+        self.assertEqual(ExitCode.PREFLIGHT, 2)
+        self.assertEqual(ExitCode.INFRASTRUCTURE, 3)
+        self.assertEqual(ExitCode.PARTIAL, 4)
+
+    def test_items_are_immutable(self):
+        item = Item(
+            item_id="src_001",
+            relative_path="sources/src_001.mp4",
+            role=Role.SOURCE,
+            corpus=Corpus.DIVINE_PUBLIC,
+            use_basis=UseBasis.PUBLIC_LOCAL_RESEARCH,
+            visual_classes=("live_action",),
+            duplicate_group=None,
+        )
+        with self.assertRaises(FrozenInstanceError):
+            item.item_id = "changed"
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+cd experiments/perceptual-video-hashing
+PYTHONPATH=src python3 -m unittest tests.test_model -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'phash_benchmark'`.
+
+- [ ] **Step 3: Implement the exact model**
+
+Use `StrEnum`, `IntEnum`, and frozen dataclasses. Define:
+
+```python
+class ExitCode(IntEnum):
+    OK = 0
+    PREFLIGHT = 2
+    INFRASTRUCTURE = 3
+    PARTIAL = 4
+
+
+class Role(StrEnum):
+    SOURCE = "source"
+    DISTRACTOR = "distractor"
+
+
+class Split(StrEnum):
+    TRAIN = "train"
+    DEVELOPMENT = "development"
+    TEST = "test"
+
+
+class Corpus(StrEnum):
+    DIVINE_PUBLIC = "divine_public"
+    ARCHIVE_PUBLIC = "archive_public"
+    SYNTHETIC_GENERATED = "synthetic_generated"
+
+
+class UseBasis(StrEnum):
+    OWNED_OR_LICENSED = "owned_or_licensed"
+    PUBLIC_LOCAL_RESEARCH = "public_local_research"
+    ARCHIVE_LOCAL_RESEARCH = "archive_local_research"
+
+
+@dataclass(frozen=True, slots=True)
+class Item:
+    item_id: str
+    relative_path: str
+    role: Role
+    corpus: Corpus
+    use_basis: UseBasis
+    visual_classes: tuple[str, ...]
+    duplicate_group: str | None
+```
+
+Define these additional frozen, slotted records with the exact fields shown:
+
+```python
+@dataclass(frozen=True, slots=True)
+class RunRoles:
+    corpus_approver: str
+    benchmark_operator: str
+    safety_reviewer: str
+    decision_owner: str
+
+@dataclass(frozen=True, slots=True)
+class Manifest:
+    schema_version: int
+    corpus_id: str
+    roles: RunRoles
+    items: tuple[Item, ...]
+    digests: Mapping[str, str]
+    authorized_for_local_research: bool
+    non_sensitive: bool
+    perceptually_distinct_distractors_attested: bool
+    corpus_approver_human_attested: bool
+    decision_owner_human_attested: bool
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    executable: str
+    returncode: int
+    stdout: str
+    stderr: str
+    wall_seconds: float
+    child_cpu_seconds: float
+    timed_out: bool
+    output_limited: bool
+    file_size_limited: bool
+
+@dataclass(frozen=True, slots=True)
+class Limits:
+    wall_seconds: float
+    child_cpu_seconds: float
+    address_space_bytes: int
+    process_count: int
+    output_bytes: int
+    output_file_bytes: int
+
+@dataclass(frozen=True, slots=True)
+class MediaProbe:
+    item_id: str
+    demuxer: str
+    duration_seconds: float
+    width: int
+    height: int
+    frame_rate: str
+    file_bytes: int
+
+@dataclass(frozen=True, slots=True)
+class PairScore:
+    algorithm: str
+    split: Split
+    query_id: str
+    reference_id: str
+    parent_reference_id: str | None
+    transform_class: str
+    distance: int | None
+    quality: int | None
+    query_percent: float | None
+    reference_percent: float | None
+    level_one: float | None
+    level_two: float | None
+    query_wall_seconds: float
+    query_cpu_seconds: float
+
+@dataclass(frozen=True, slots=True)
+class HashMeasurement:
+    algorithm: str
+    item_id: str
+    split: Split
+    transform_class: str
+    input_seconds: float
+    wall_seconds: float
+    child_cpu_seconds: float
+    fingerprint_bytes: int
+
+@dataclass(frozen=True, slots=True)
+class OperatingPoint:
+    algorithm: str
+    distance: int | None
+    quality: int | None
+    reference_percent: float | None
+    query_percent: float | None
+    level_one: float | None
+    level_two: float | None
+
+@dataclass(frozen=True, slots=True)
+class ConfusionCounts:
+    true_positive: int
+    false_positive: int
+    false_negative: int
+    true_negative: int
+
+@dataclass(frozen=True, slots=True)
+class Failure:
+    phase: str
+    opaque_item_id: str | None
+    reason: str
+    limit_name: str | None
+
+@dataclass(frozen=True, slots=True)
+class BudgetState:
+    started_at_utc: str
+    cumulative_cpu_seconds: float
+    generated_bytes: int
+    engineering_time_budget_confirmed: bool
+
+@dataclass(frozen=True, slots=True)
+class RunPaths:
+    runs_root: Path
+    run_id: str
+    run_dir: Path
+    marker: Path
+    provenance: Path
+    normalized_manifest: Path
+    frozen_operating_points: Path
+    raw_results: Path
+    metrics: Path
+    failures: Path
+    report: Path
+    pilot_acceptance: Path
+    decision_acceptance: Path
+    media_dir: Path
+    hashes_dir: Path
+
+@dataclass(frozen=True, slots=True)
+class PreflightPlan:
+    run_id: str
+    source_count: int
+    distractor_count: int
+    expected_variant_count: int
+    estimated_cpu_seconds: float
+    estimated_wall_seconds: float
+    estimated_peak_memory_bytes: int
+    estimated_disk_bytes: int
+    free_disk_bytes: int
+
+@dataclass(frozen=True, slots=True)
+class PhaseResult:
+    phase: str
+    expected: int
+    attempted: int
+    succeeded: int
+    failed: int
+    exit_code: ExitCode
+
+@dataclass(frozen=True, slots=True)
+class Context:
+    manifest: Manifest
+    paths: RunPaths
+    seed: str
+    config_digest: str
+    image_digest: str
+    budget: BudgetState
+
+@dataclass(frozen=True, slots=True)
+class Summary:
+    conclusion: str
+    gate_results: Mapping[str, bool]
+    evaluations: tuple["Evaluation", ...]
+    failures: tuple[Failure, ...]
+    provenance: Mapping[str, object]
+    projections: Mapping[str, Mapping[str, float]]
+```
+
+`Evaluation` and `Observation` are defined in Task 6 beside the computations
+that construct them. Export `__version__ = "0.1.0"` from `__init__.py`. Pin
+`coverage==7.15.2` in `requirements.lock`; there are no runtime Python
+dependencies.
+
+- [ ] **Step 4: Run the model test and verify GREEN**
+
+Run the Step 2 command. Expected: two tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "feat(phash-spike): define benchmark domain model"
+```
+
+### Task 2: Validate manifests and hostile input paths
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/manifest.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_manifest.py`
+- Create: `experiments/perceptual-video-hashing/fixtures/example-manifest.json`
+
+- [ ] **Step 1: Write failing validation tests**
+
+Test:
+
+- the exact v1 example loads;
+- unknown top-level and item keys fail;
+- all five attestation booleans must be literal `true`, including
+  `perceptually_distinct_distractors`, `corpus_approver_human`, and
+  `decision_owner_human`;
+- attestation records opaque `corpus_approver_role`,
+  `benchmark_operator_role`, `safety_reviewer_role`, and
+  `decision_owner_role` aliases;
+- every role alias is nonempty, matches the opaque ID grammar, and the corpus
+  approver differs from the decision owner;
+- IDs, paths, paths after canonical resolution, enums, class allowlist,
+  duplicate IDs/paths/digests, symlinks, directories, FIFOs, and multi-link
+  files fail;
+- absolute paths, `..`, empty components, and NUL fail;
+- SHA-256 is computed by preflight and never accepted from JSON;
+- error messages contain opaque item IDs but not source paths.
+
+The main positive test must call:
+
+```python
+manifest = load_manifest(manifest_path, input_root)
+self.assertEqual(manifest.schema_version, 1)
+self.assertEqual(manifest.items[0].item_id, "src_001")
+self.assertEqual(
+    manifest.digests["src_001"],
+    hashlib.sha256(b"video").hexdigest(),
+)
+self.assertEqual(manifest.roles.corpus_approver, "corpus-approver")
+self.assertNotEqual(
+    manifest.roles.corpus_approver,
+    manifest.roles.decision_owner,
+)
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_manifest -v
+```
+
+Expected: import failure for `phash_benchmark.manifest`.
+
+- [ ] **Step 3: Implement strict validation**
+
+Implement:
+
+```python
+def load_manifest(path: Path, input_root: Path) -> Manifest
+def validate_relative_path(value: object) -> PurePosixPath
+def open_validated_regular_file(root: Path, relative: PurePosixPath) -> BinaryIO
+def sha256_stream(stream: BinaryIO) -> str
+```
+
+Use strict key equality, `json.loads`, `lstat`, `O_NOFOLLOW` where available,
+`fstat`, `stat.S_ISREG`, `st_nlink == 1`, and a post-open canonical containment
+check. Reject duplicate byte digests unless every duplicate has the same
+non-null `duplicate_group`. Never interpolate a path into an exception.
+
+The visual class enum is:
+
+```python
+VISUAL_CLASSES = frozenset({
+    "animation", "live_action", "text_heavy", "low_light",
+    "static_scene", "camera_motion", "fast_cuts",
+})
+```
+
+The accepted attestation shape is exactly:
+
+```json
+{
+  "authorized_for_local_research": true,
+  "non_sensitive": true,
+  "perceptually_distinct_distractors": true,
+  "corpus_approver_human": true,
+  "decision_owner_human": true,
+  "corpus_approver_role": "corpus-approver",
+  "benchmark_operator_role": "benchmark-operator",
+  "safety_reviewer_role": "safety-reviewer",
+  "decision_owner_role": "decision-owner"
+}
+```
+
+The example manifest contains one generated source and one generated
+distractor with opaque names, both attestations, and all four role aliases.
+`Manifest` includes a frozen `RunRoles` value; the provenance writer records
+all four aliases and never records personal identifiers.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the Step 2 command. Expected: all manifest tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "feat(phash-spike): validate benchmark manifests"
+```
+
+### Task 3: Implement deterministic split isolation
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/splits.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_splits.py`
+
+- [ ] **Step 1: Write failing split tests**
+
+Test deterministic output, different seeds, source 60/20/20 assignment,
+distractor 100-development/remainder-test assignment, duplicate groups staying
+together, every transform inheriting its parent's split, and pair construction
+rejecting any query/reference whose splits differ.
+
+Use 100 opaque source IDs and 400 distractors, and assert exact counts:
+
+```python
+self.assertEqual(Counter(source_splits.values()), {
+    Split.TRAIN: 60,
+    Split.DEVELOPMENT: 20,
+    Split.TEST: 20,
+})
+self.assertEqual(Counter(distractor_splits.values()), {
+    Split.DEVELOPMENT: 100,
+    Split.TEST: 300,
+})
+```
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_splits -v
+```
+
+Expected: import failure for `phash_benchmark.splits`.
+
+- [ ] **Step 3: Implement stable ranking**
+
+Implement:
+
+```python
+def stable_rank(seed: str, group_key: str) -> bytes:
+    return hashlib.sha256(f"{seed}\0{group_key}".encode()).digest()
+
+def assign_splits(
+    items: Sequence[Item],
+    seed: str,
+) -> dict[str, Split]:
+    ...
+```
+
+Group sources by `duplicate_group or item_id`, sort groups by `stable_rank`,
+and allocate counts with largest-remainder apportionment so 100 sources produce
+60/20/20. Allocate distractors by stable rank with the first 100 development
+and the rest test. Reject fewer than 400 distractors for a full run in
+preflight, not in this pure function.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the Step 2 command. Expected: all split tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "feat(phash-spike): isolate benchmark splits"
+```
+
+### Task 4: Probe hostile media and enforce supported local demuxers
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/media.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_media.py`
+
+- [ ] **Step 1: Write failing probe and limit tests**
+
+Test:
+
+- only `.mp4`, `.m4v`, `.mov`, `.webm`, and `.mkv` inputs reach FFprobe;
+- extensions map before parsing to explicit demuxers:
+  `.mp4/.m4v/.mov -> mov` and `.webm/.mkv -> matroska`;
+- explicit demuxer mapping accepts only `mov,mp4,m4a,3gp,3g2,mj2` as `mov`
+  and `matroska,webm` as `matroska`;
+- playlists, manifests, image sequences, concat files, and playlist/concat
+  content renamed with an allowed extension fail under the forced demuxer;
+  URLs, attached paths, unknown formats, multiple video streams,
+  zero/negative/over-budget duration, invalid dimensions, and non-finite
+  values fail;
+- FFprobe arguments include `-nostdin`, `-v error`,
+  `-protocol_whitelist file,pipe`, JSON output, and the revalidated path;
+- canonical containment, regular-file status, link count, inode, and device
+  are revalidated immediately before every FFprobe, FFmpeg, vPDQ, or TMK
+  subprocess;
+- child CPU, wall time, stdout/stderr, process count, and generated-file size
+  limits produce structured opaque failures;
+- normalization writes deterministic MP4 beneath the owned run and only that
+  generated media, never the caller file, reaches vPDQ or TMK;
+- native input paths use only generated opaque `[a-z0-9_-]` components, making
+  TMK's pinned internal `/bin/sh`/`popen()` invocation non-injectable;
+- malformed/undecodable files do not leak paths.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_media -v
+```
+
+Expected: import failure for `phash_benchmark.media`.
+
+- [ ] **Step 3: Implement the fail-closed media boundary**
+
+Implement:
+
+```python
+SUPPORTED_EXTENSIONS = frozenset({".mp4", ".m4v", ".mov", ".webm", ".mkv"})
+DEMUXER_BY_EXTENSION = {
+    ".mp4": "mov",
+    ".m4v": "mov",
+    ".mov": "mov",
+    ".webm": "matroska",
+    ".mkv": "matroska",
+}
+SUPPORTED_DEMUXERS = {
+    "mov,mp4,m4a,3gp,3g2,mj2": "mov",
+    "matroska,webm": "matroska",
+}
+
+def ffprobe_argv(path: Path, explicit_demuxer: str) -> tuple[str, ...]
+def parse_probe(item_id: str, stdout: str, file_bytes: int) -> MediaProbe
+def probe_media(item: Item, input_root: Path, limits: Limits) -> MediaProbe
+def normalize_argv(
+    input_path: Path,
+    output_path: Path,
+    explicit_demuxer: str,
+) -> tuple[str, ...]
+def revalidate_for_subprocess(
+    root: Path,
+    relative_path: PurePosixPath,
+    expected_device: int,
+    expected_inode: int,
+) -> Path
+```
+
+`probe_media` opens and validates the regular file, records device/inode,
+closes it, revalidates immediately before invoking FFprobe, parses one video
+stream, and returns the explicit preselected demuxer used for FFprobe and later
+as `-f mov` or `-f matroska`. `ffprobe_argv` includes that `-f` before `-i`;
+no playlist-capable or auto-selected demuxer reaches FFprobe or FFmpeg.
+The same sandboxed FFmpeg invocation normalizes accepted hostile input into a
+deterministic H.264/AAC MP4 below the owned run directory. All transformations
+operate on that normalized file, and vPDQ/TMK receive only normalized or
+benchmark-generated variants with validated opaque paths. Raw caller media is
+never passed to either upstream native hasher; this is required because pinned
+vPDQ opens through libav without protocol CLI controls and pinned TMK invokes
+FFmpeg through `popen()`.
+`Limits` contains wall seconds, CPU seconds, address-space bytes, process
+count, output bytes, and output-file bytes. `run_bounded` applies POSIX rlimits
+inside the container and classifies each limit separately.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the Step 2 command. Expected: all media-boundary tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "feat(phash-spike): constrain hostile media probing"
+```
+
+### Task 5: Generate deterministic transformation commands
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/config/defaults.json`
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/transforms.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_transforms.py`
+
+- [ ] **Step 1: Write failing transform tests**
+
+Table-test exact argument arrays for remux, CRF 23/32 re-encode, 480p/240p
+downscale, 15fps, overlay, letterbox, 5%/10% crop, hflip, 0.9x/1.1x speed,
+middle subsequence, and two-copy loop. Assert:
+
+- the first argument is `ffmpeg`;
+- `-nostdin`, `-protocol_whitelist file,pipe`, deterministic metadata removal,
+  bounded threads, and overwrite refusal are always present;
+- no argument contains a shell control operator;
+- outputs are derived from opaque IDs below the run transform directory;
+- the same input/config returns identical arrays and transform IDs.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_transforms -v
+```
+
+Expected: import failure for `phash_benchmark.transforms`.
+
+- [ ] **Step 3: Implement argument construction**
+
+Define a frozen `TransformSpec(name, variant, video_filter, audio_filter,
+duration_mode)` and:
+
+```python
+def default_transform_specs() -> tuple[TransformSpec, ...]
+def transform_id(parent_id: str, spec: TransformSpec) -> str
+def build_ffmpeg_command(
+    input_path: Path,
+    output_path: Path,
+    spec: TransformSpec,
+    duration_seconds: float,
+) -> tuple[str, ...]
+```
+
+Use argument arrays only. Use `drawtext=text=DIVINE_TEST` with a checked-in
+DejaVu font path from the container, `setpts`/`atempo` for speed, deterministic
+`-map_metadata -1`, `-fflags +bitexact`, `-flags:v +bitexact`, H.264
+`libx264`, AAC where audio exists, and no timestamps derived from wall time.
+Validate every configured transformation name against a closed enum.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the Step 2 command. Expected: all transform tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "feat(phash-spike): define deterministic video transforms"
+```
+
+### Task 6: Add bounded native-tool adapters and parsers
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/adapters.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_adapters.py`
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Test exact vPDQ hash arguments:
+
+```text
+vpdq-hash-video -i INPUT -o OUTPUT -r 1.0 -s 160 -t 1
+```
+
+Test exact vPDQ comparison arguments:
+
+```text
+match-hashes-brute QUERY REFERENCE D F
+```
+
+Parse:
+
+```text
+67.76 Percentage Query Video match
+80.85 Percentage Target Video match
+```
+
+into query `67.76` and reference `80.85`.
+
+Test TMK hash arguments and parse:
+
+```text
+tmk-hash-video -f /usr/bin/ffmpeg -i INPUT -o OUTPUT
+```
+
+Test TMK raw-score arguments and parse:
+
+```text
+tmk-two-level-score --c1 -1 --c2 0 QUERY.tmk REFERENCE.tmk
+0.952329 0.961902 QUERY.tmk REFERENCE.tmk
+```
+
+into level-one and level-two scores. Test malformed, duplicate, non-finite,
+out-of-range, timeout, nonzero-exit, oversized-output, and path-leak
+redaction behavior.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_adapters -v
+```
+
+Expected: import failure for `phash_benchmark.adapters`.
+
+- [ ] **Step 3: Implement adapters**
+
+Implement:
+
+```python
+def run_bounded(
+    argv: Sequence[str],
+    *,
+    timeout_seconds: float,
+    max_output_bytes: int,
+    env: Mapping[str, str],
+) -> CommandResult
+
+def vpdq_hash_argv(input_path: Path, output_path: Path) -> tuple[str, ...]
+def vpdq_compare_argv(
+    query_hash: Path, reference_hash: Path, distance: int, quality: int
+) -> tuple[str, ...]
+def parse_vpdq_scores(stdout: str) -> tuple[float, float]
+def tmk_hash_argv(input_path: Path, output_path: Path) -> tuple[str, ...]
+def tmk_score_argv(query_hash: Path, reference_hash: Path) -> tuple[str, ...]
+def parse_tmk_scores(stdout: str) -> tuple[float, float]
+```
+
+Run with `shell=False`, `stdin=DEVNULL`, `start_new_session=True`, a minimal
+environment containing only `PATH`, `LANG=C.UTF-8`, and `TZ=UTC`, byte-mode
+capturing, timeout-driven process-group termination, and bounded stdout/stderr.
+Measure wall time with `time.monotonic_ns()` and child user+system CPU deltas
+with `resource.getrusage(resource.RUSAGE_CHILDREN)` around each nonparallel
+subprocess. After a successful hash, combine the command measurement with the
+probed duration and `stat().st_size` into `HashMeasurement`; record each
+comparison's wall/CPU time in `PairScore`. Tests use a real short-lived child
+process to verify nonnegative units and a fake clock/resource reader for exact
+normalization.
+Return structured failures containing command basename and opaque item ID only.
+TMK raw scoring uses `tmk-two-level-score --c1 -1 --c2 0 HASH_A HASH_B`.
+The pinned tool accepts `--c2` but does not use it to suppress its printed
+pair output; the adapter always collects raw scores and Python applies the
+selected `c1` and `c2` thresholds. Native paths must first pass the generated
+opaque-path validator because pinned TMK constructs an internal shell command.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the Step 2 command. Expected: all adapter tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "feat(phash-spike): wrap perceptual hashing tools"
+```
+
+### Task 7: Calculate exhaustive metrics and freeze operating points
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/metrics.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_metrics.py`
+
+- [ ] **Step 1: Write failing metric tests**
+
+Cover:
+
+- parent hits, wrong-reference false positives, missing parents, and all
+  negative-pair true negatives;
+- a query producing both a true positive and a wrong-reference false positive;
+- zero denominators;
+- query-level distractor matches;
+- exact vPDQ Cartesian grid `D=(16,24,31,40)`,
+  `F=(0,25,50,75)`, `Pc=(0,25,50,80,100)`, and
+  `Pq=(0,25,50,80,100)`, with asymmetric reference/query percentages;
+- exact TMK Cartesian grid `c1=(0.70,0.80,0.90,0.95)` and
+  `c2=(0.70,0.80,0.90,0.95)`;
+- rejection of values outside the official ranges and any combination absent
+  from the checked-in configuration;
+- lexicographic development selection: pair precision >= 0.99, then recall,
+  then lower compute only when the paired source-bootstrap recall-difference
+  interval includes zero;
+- no passing point selecting highest precision for diagnosis;
+- deterministic source-cluster bootstrap and exact one-sided zero-event upper
+  bound `1 - 0.05 ** (1 / n)`;
+- exhaustive aggregation across every algorithm × configured threshold ×
+  split × transform, including expected/attempted/succeeded/failed
+  denominators and per-reason failures;
+- hash wall/CPU seconds per input second, query wall/CPU seconds per exhaustive
+  pair, fingerprint bytes per input second and normalized six-second video,
+  and supported-input completion;
+- canonical JSON freeze bytes, SHA-256 filename, digest verification, and
+  mutation rejection.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_metrics -v
+```
+
+Expected: import failure for `phash_benchmark.metrics`.
+
+- [ ] **Step 3: Implement metrics**
+
+Implement pure functions:
+
+```python
+@dataclass(frozen=True, slots=True)
+class Observation:
+    cluster_id: str
+    expected_match: bool
+    returned_parent: bool
+    returned_wrong_reference: bool
+
+@dataclass(frozen=True, slots=True)
+class Evaluation:
+    point: OperatingPoint
+    split: Split
+    transform_class: str
+    counts: ConfusionCounts
+    expected: int
+    attempted: int
+    succeeded: int
+    failed: int
+    precision: float
+    recall: float
+    f1: float
+    false_positive_rate: float
+    precision_interval: tuple[float, float]
+    recall_interval: tuple[float, float]
+    distractor_false_match_upper_bound: float
+    correct_parent_query_recall: float
+    distractor_query_matches: int
+    transform_recall: Mapping[str, float]
+    completion_rate: float
+    hash_wall_per_input_second: float
+    hash_cpu_per_input_second: float
+    query_wall_seconds_per_pair: float
+    query_cpu_seconds_per_pair: float
+    fingerprint_bytes_per_input_second: float
+    fingerprint_bytes_per_six_seconds: float
+    observations: tuple[Observation, ...]
+
+def evaluate_pairs(
+    scores: Sequence[PairScore],
+    parent_by_query: Mapping[str, str | None],
+    point: OperatingPoint,
+) -> Evaluation
+
+def choose_operating_point(
+    evaluations: Sequence[Evaluation],
+) -> Evaluation
+
+def aggregate_evaluations(
+    scores: Sequence[PairScore],
+    hashes: Sequence[HashMeasurement],
+    failures: Sequence[Failure],
+    points: Sequence[OperatingPoint],
+) -> tuple[Evaluation, ...]
+
+def bootstrap_interval(
+    observations: Sequence[Observation],
+    statistic: Callable[[Sequence[Observation]], float],
+    *,
+    seed: int,
+    iterations: int = 10_000,
+) -> tuple[float, float]
+
+def zero_event_upper_bound(sample_size: int, alpha: float = 0.05) -> float
+def write_freeze(path: Path, selections: Mapping[str, Evaluation]) -> Path
+def load_freeze(path: Path, expected_digest: str) -> Mapping[str, object]
+```
+
+`aggregate_evaluations` emits one row for every algorithm, configured
+operating point, split, and concrete transform plus an explicit
+`transform_class="__overall__"` row. Every row carries both fingerprint bytes
+per input second and normalized six-second bytes, so `Summary.evaluations`
+serializes the complete `metrics.json` matrix without implicit dimensions.
+
+For vPDQ, match when distance/quality were used to generate the raw score and
+`reference_percent >= Pc` and `query_percent >= Pq`. For TMK, match when
+`level_one >= c1` and `level_two >= c2`. Serialize with sorted keys, compact
+separators, UTF-8, and no NaN. `choose_operating_point` first filters
+development evaluations below 0.99 pair precision, selects maximum
+correct-parent recall, and uses lower measured compute only when the
+deterministic paired source-bootstrap interval of the recall difference
+includes zero. It never reads held-out test observations.
+
+The canonical freeze object has exactly:
+
+```json
+{
+  "schema_version": 1,
+  "orientation": "reference=canonical,query=variant_or_distractor",
+  "seconds_per_hash": 1.0,
+  "tool_version": "0.1.0",
+  "threatexchange_commit": "baefb4ed67b6cdc1d4c82dbaef858d50866ac424",
+  "development_result_digest": "<sha256>",
+  "configuration_digest": "<sha256>",
+  "selections": {
+    "vpdq": {
+      "distance": 31,
+      "quality": 50,
+      "reference_percent": 80.0,
+      "query_percent": 0.0
+    },
+    "tmk": {
+      "level_one": 0.9,
+      "level_two": 0.9
+    }
+  }
+}
+```
+
+The angle-bracket digest strings describe test fixtures; real serialization
+requires lowercase 64-hex values. Mutation tests alter each field
+independently and require digest verification to fail.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the Step 2 command. Expected: all metric tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "feat(phash-spike): select frozen hashing thresholds"
+```
+
+### Artifact schema contract
+
+Tasks 6–8 serialize only schema-versioned JSON with strict key validation and
+round-trip tests:
+
+- `provenance.json` (`schema_version`, four `roles`, `tool_version`,
+  `threatexchange_commit`, `container_image_digest`, `base_image_digest`,
+  `installed_packages`, `ffmpeg_version`, `binary_sha256`, `sbom_sha256`,
+  `host_os`, `host_architecture`, `host_cpu`, `command`, `started_at_utc`,
+  `manifest_digest`, `config_digest`, `seed`, and `budget`);
+- `normalized-manifest.json` (`schema_version`, `corpus_id`, `roles`, opaque
+  item IDs, roles/corpora/use bases/classes/groups, SHA-256, and assigned
+  splits; local paths are excluded);
+- `raw-results.jsonl` (one exact `PairScore` object per line);
+- `metrics.json` (`schema_version`, expected/attempted/succeeded/failed counts,
+  per-algorithm/per-threshold/per-split/per-transform confusion counts,
+  pair/query metrics, confidence intervals, timing, bytes, completion rates,
+  gate results, projections, and the machine-readable conclusion);
+- `failures.jsonl` (one exact `Failure` object per line);
+- `frozen-operating-points.json` (`schema_version`, canonical orientation
+  `reference=canonical,query=variant_or_distractor`, cadence, tool version,
+  ThreatExchange commit, development-result digest, configuration digest, and
+  complete selected vPDQ or TMK fields from `OperatingPoint`);
+- `report.md`, derived only from aggregate `metrics.json` and
+  `provenance.json`;
+- `pilot-acceptance.json` (pilot metrics digest, safety-reviewer role alias,
+  boolean acceptance, and UTC acceptance time);
+- `decision-acceptance.json` (report digest, one permitted conclusion, safety
+  reviewer role alias, distinct decision owner role alias, boolean acceptance,
+  and UTC acceptance time).
+
+`normalized-manifest.json`, raw results, failures, native hashes, media, and
+exact digests are restricted run data and removed by successful cleanup.
+Aggregate metrics, aggregate report, and non-identifying provenance are
+retained. Diagnostic failures and raw results expire after seven days.
+Round-trip tests reject unknown keys, missing keys, NaN/infinity, wrong schema
+versions, and type changes in every JSON/JSONL artifact.
+
+### Task 8: Add owned run storage and aggregate reporting
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/store.py`
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/report.py`
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/provenance.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_store.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_report.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_provenance.py`
+
+- [ ] **Step 1: Write failing store and report tests**
+
+Store tests require:
+
+- run IDs matching `^[a-z0-9][a-z0-9_-]{2,63}$`;
+- atomic create with mode `0700`;
+- a random ownership nonce in `.phash-benchmark-owned.json`;
+- canonical runs-root containment on create, every open, and cleanup;
+- cleanup refusal for missing/mismatched markers, symlinks, root itself, and
+  caller inputs;
+- success cleanup removing media, hashes, and raw pairs while retaining
+  aggregate report/provenance;
+- success cleanup refusing a valid report until a matching atomic
+  `decision-acceptance.json` exists;
+- atomic pilot/final acceptance rejecting wrong role aliases, changed metric
+  or report digests, unknown conclusions, every recognized conclusion that
+  differs from the current machine-readable `metrics.json` conclusion, and
+  duplicate mutation;
+- diagnostic cleanup retaining bounded failures for no more than seven days.
+
+Report tests require the first heading to be the conclusion, then a gate table,
+transform metrics, failures, confidence intervals, provenance, limitations,
+and 10k/100k/1m projections. Assert reports contain no paths, URLs, 64-hex
+digests, frame hashes, usernames, or non-aggregate item IDs.
+
+Table-test the decision engine for:
+
+- `NO DECISION` on partial/incomplete/invalid runs;
+- no adoption when neither standalone candidate passes;
+- the sole passing candidate;
+- vPDQ and TMK quality wins when paired recall advantage is at least five
+  percentage points, its 95% interval excludes zero, and no required transform
+  regresses by more than two points;
+- lower hash CPU when quality is indistinguishable;
+- lower fingerprint bytes when CPU is within 10%;
+- TMK's fixed-length model when both CPU and bytes are within 10%.
+
+Each passing candidate must have pair precision >= 0.99, zero held-out
+distractor-query matches, an exact upper bound, recall >= 0.90 for remux,
+reencode, downscale, and watermark, completion >= 0.99, hash CPU/input second
+<= 0.1, and fingerprint bytes/six-second video <= 10 KiB. Crop, padding,
+speed, subsequence, and remix must be present separately but have no hard
+recall floor.
+
+Projection tests use:
+
+```text
+daily_cpu_seconds = daily_uploads * measured_cpu_seconds_per_six_second_video
+daily_storage_bytes = daily_uploads * measured_fingerprint_bytes_per_six_seconds
+daily_review_upper = daily_uploads * false_match_upper_bound
+```
+
+for daily uploads 10,000, 100,000, and 1,000,000.
+
+Provenance tests inject platform/clock/command readers and require every field
+in the artifact contract, exact sorted installed-package versions, FFmpeg
+version, image/base digests, binary and SBOM checksums, host OS/architecture/CPU,
+UTC start time, manifest/config digests, seed, budget, and all four role
+aliases. Environment variables, home paths, usernames, media paths, and
+credentials must never be captured.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest \
+  tests.test_store tests.test_report tests.test_provenance -v
+```
+
+Expected: import failures for `store` and `report`.
+
+- [ ] **Step 3: Implement owned storage and reports**
+
+Implement:
+
+```python
+def create_run(runs_root: Path, run_id: str) -> RunPaths
+def open_owned_run(runs_root: Path, run_id: str) -> RunPaths
+def atomic_json(path: Path, value: object) -> None
+def cleanup_run(paths: RunPaths, *, diagnostic: bool) -> None
+def cleanup_expired(runs_root: Path, *, now: datetime) -> tuple[str, ...]
+def accept_pilot(paths: RunPaths, reviewer_role: str, *, now: datetime) -> None
+def accept_decision(
+    paths: RunPaths,
+    conclusion: str,
+    reviewer_role: str,
+    decision_owner_role: str,
+    *,
+    now: datetime,
+) -> None
+def collect_provenance(context: Context, command: Sequence[str]) -> Mapping[str, object]
+def candidate_gates(evaluation: Evaluation) -> Mapping[str, bool]
+def choose_conclusion(
+    vpdq: Evaluation,
+    tmk: Evaluation,
+    *,
+    partial: bool,
+) -> str
+def project_shadow_load(
+    evaluation: Evaluation,
+    false_match_upper_bound: float,
+) -> Mapping[str, Mapping[str, float]]
+def render_report(summary: Summary) -> str
+def sanitized_report(report: str) -> None
+```
+
+Use `os.open` exclusive creation, `fsync`, `os.replace`, non-following
+directory traversal, explicit known child names, and no recursive deletion of
+an unresolved path. `sanitized_report` fails closed on forbidden patterns.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the Step 2 command. Expected: all store/report tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "feat(phash-spike): secure run artifacts and reports"
+```
+
+### Task 9: Orchestrate preflight, staged execution, and stable CLI
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/pipeline.py`
+- Create: `experiments/perceptual-video-hashing/src/phash_benchmark/cli.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_pipeline.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_cli.py`
+- Create: `experiments/perceptual-video-hashing/benchmark`
+
+- [ ] **Step 1: Write failing phase and CLI tests**
+
+Use fake adapters with real temporary files. Verify:
+
+- `preflight` is read-only and checks attestation, exactly 50
+  `divine_public` sources, exactly 50 `archive_public` sources, no other real
+  source corpus, at least 400 distractors, all four recorded role aliases,
+  corpus-approver/decision-owner separation, representation minima, disk +25%,
+  estimated CPU, wall time, peak memory, disk, and sandbox runtime;
+- `smoke` generates safe media and requires exact/re-encode positives plus an
+  unrelated negative for both algorithms;
+- `pilot` uses exactly five sources per real corpus and 20 distractors;
+- per-item failures continue but produce exit 4 and `NO DECISION`;
+- containment, freeze, ground-truth, or isolation errors abort;
+- budget guards stop before an operation would exceed 720,000 cumulative CPU
+  seconds or 268,435,456,000 generated bytes, and stop a resumed run seven
+  days after `started_at_utc`;
+- full real-media execution requires the human-recorded
+  `engineering_time_budget_confirmed` flag for the five-engineering-day cap;
+- stage 1 stops when either official candidate fails build, regression, or any
+  required synthetic smoke assertion;
+- stage 2 stops on two occurrences of the same sandbox-limit failure, any
+  transform class below 80% successful generation in the pilot, or a projected
+  full run above the remaining CPU/disk budget;
+- tune only uses train/development and emits the freeze;
+- test requires and verifies the freeze and never calls selection;
+- every query/reference pair is scored;
+- `full` hands one explicit runs root/run ID through every phase;
+- `full` allocates when `--run` is absent, pauses real media after pilot with
+  `pilot_acceptance_required`, and resumes the same explicit run only after
+  immutable pilot acceptance;
+- `smoke` allocates and prints a run ID when `--run` is omitted and opens that
+  explicit owned run when it is supplied;
+- `pilot` accepts manifest/input/runs root, allocates and prints a run ID when
+  omitted, and may explicitly reopen only the same manifest-digest run;
+- `accept-pilot`, `tune`, `test`, `report`, `accept`, and `cleanup` require
+  both `--runs-root` and `--run`;
+- `tune` refuses a real-media run without immutable pilot acceptance;
+- exit statuses are exactly 0, 2, 3, and 4.
+- success cleanup removes restricted artifacts after report acceptance;
+  handled failure cleanup removes generated media/hashes immediately, retains
+  bounded diagnostics with expiry metadata, and returns exit 4; expired-run
+  cleanup returns exit 0 only when every selected owned run was removed.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest \
+  tests.test_pipeline tests.test_cli -v
+```
+
+Expected: import failures for `pipeline` and `cli`.
+
+- [ ] **Step 3: Implement phases and CLI**
+
+Implement:
+
+```python
+def preflight(
+    manifest_path: Path,
+    input_root: Path,
+    runs_root: Path,
+) -> PreflightPlan
+def smoke(context: Context) -> PhaseResult
+def pilot(context: Context) -> PhaseResult
+def tune(context: Context) -> PhaseResult
+def test_frozen(context: Context, freeze_path: Path) -> PhaseResult
+def report(context: Context) -> PhaseResult
+def full(
+    manifest_path: Path,
+    input_root: Path,
+    runs_root: Path,
+    run_id: str | None = None,
+) -> ExitCode
+def main(argv: Sequence[str] | None = None) -> int
+```
+
+Every phase records expected/attempted/succeeded/failed counts. For automated
+synthetic fixtures, `full` executes preflight, smoke, pilot, tune, frozen test,
+and report. For real media it pauses after pilot until `accept-pilot`; the
+operator resumes with the same `full ... --run <id>` or uses individual
+tune/test/report commands. The resumed path ends in `pending_acceptance`; it
+never performs success cleanup before human decision acceptance. It
+applies pure `check_stage_one`, `check_stage_two`, and `check_budget`
+predicates with the exact limits above before advancing. The launcher sets
+`PYTHONPATH` relative to its real directory and executes
+`python3 -m phash_benchmark.cli "$@"` without `eval`.
+
+The exact lifecycle is:
+
+| Command | Allocates run | Required location arguments |
+|---|---:|---|
+| `build` | no | none |
+| `preflight` | no | `--manifest --input-root --runs-root` |
+| `smoke` | yes unless reopening | `--runs-root [--run]` |
+| `pilot` | yes unless reopening | `--manifest --input-root --runs-root [--run]` |
+| `accept-pilot` | no | `--runs-root --run --safety-reviewer-role` |
+| `tune` | no | `--runs-root --run` |
+| `test` | no | `--runs-root --run --freeze` |
+| `report` | no | `--runs-root --run` |
+| `accept` | no | `--runs-root --run --conclusion --safety-reviewer-role --decision-owner-role` |
+| `cleanup` | no | `--runs-root --run` |
+| `full` | yes unless reopening | `--manifest --input-root --runs-root [--run]` |
+
+Allocated IDs are printed on stdout as `run_id=<opaque-id>`. Reopening verifies
+the ownership marker, manifest digest, configuration digest, and immutable
+completed-phase artifacts before resuming.
+`accept-pilot` and `accept` call the atomic validated store APIs from Task 8.
+`accept` reads the strict current metrics artifact and requires its conclusion
+to equal the supplied recognized conclusion before it hashes the report and
+writes acceptance.
+`cleanup` refuses success cleanup until `accept` exists and matches the current
+report digest; handled partial runs use diagnostic cleanup without acceptance.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the Step 2 command, then:
+
+```bash
+./benchmark --help
+```
+
+Expected: tests pass and help lists `build`, `preflight`, `smoke`, `pilot`,
+`accept-pilot`, `tune`, `test`, `report`, `accept`, `cleanup`, and `full`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "feat(phash-spike): orchestrate benchmark phases"
+```
+
+### Task 10: Build the pinned, non-root native container
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/Dockerfile`
+- Create: `experiments/perceptual-video-hashing/container/apt-packages.lock`
+- Create: `experiments/perceptual-video-hashing/container/spdx_from_dpkg.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_container_contract.py`
+- Modify: `experiments/perceptual-video-hashing/benchmark`
+
+- [ ] **Step 1: Write failing container-contract tests**
+
+Parse the Dockerfile and launcher as text and require:
+
+- base `ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90`;
+- exact ThreatExchange commit;
+- Ubuntu snapshot `20260610T000000Z` and exact direct package lock;
+- release CMake build and nonparallel TMK build;
+- upstream vPDQ/TMK regression invocations;
+- copied binary checksums and an SPDX JSON SBOM;
+- final runtime contains `/bin/sh` for pinned TMK's internal `popen()` and
+  DejaVu Sans from the pinned font package;
+- numeric non-root user and read-only work paths;
+- runtime command flags `--network none`, `--read-only`, `--cap-drop ALL`,
+  `--security-opt no-new-privileges`, PID/memory/CPU limits, tmpfs, read-only
+  input mount, writable run mount, and an environment allowlist;
+- no home, cloud, SSH agent, Docker socket, or host-root mount.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_container_contract -v
+```
+
+Expected: missing Dockerfile contract.
+
+- [ ] **Step 3: Implement the container contract**
+
+Use a multi-stage Dockerfile:
+
+```dockerfile
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS build
+ARG THREATEXCHANGE_COMMIT=baefb4ed67b6cdc1d4c82dbaef858d50866ac424
+ARG UBUNTU_SNAPSHOT=20260610T000000Z
+```
+
+Rewrite both Ubuntu archive and security sources to the fixed snapshot.
+`apt-packages.lock` pins these direct packages:
+
+```text
+build-essential=12.10ubuntu1
+ca-certificates=20240203
+cmake=3.28.3-1build7
+ffmpeg=7:6.1.1-3ubuntu5
+fonts-dejavu-core=2.37-8
+git=1:2.43.0-1ubuntu7.3
+libavcodec-dev=7:6.1.1-3ubuntu5
+libavdevice-dev=7:6.1.1-3ubuntu5
+libavfilter-dev=7:6.1.1-3ubuntu5
+libavformat-dev=7:6.1.1-3ubuntu5
+libavutil-dev=7:6.1.1-3ubuntu5
+libgomp1=14.2.0-4ubuntu2~24.04.1
+libswresample-dev=7:6.1.1-3ubuntu5
+libswscale-dev=7:6.1.1-3ubuntu5
+make=4.3-4.1build2
+pkg-config=1.8.1-2build1
+python3=3.12.3-0ubuntu2.1
+python3-venv=3.12.3-0ubuntu2.1
+```
+
+Install the lock with `--no-install-recommends`, clone without credentials,
+verify
+`HEAD`, build vPDQ with `-DCMAKE_BUILD_TYPE=Release`, build TMK without FAISS,
+run upstream regression vectors, generate binary SHA-256 files and an SPDX
+2.3 JSON SBOM using the checked-in standard-library
+`spdx_from_dpkg.py` over `dpkg-query`, and copy only runtime
+libraries/binaries plus the Python package into a non-root final stage. The
+SBOM generator itself has unit tests for deterministic namespace, package
+records, checksums, and invalid dpkg input. The launcher has separate `build`
+and safe `docker run` paths; `full` builds first, then runs offline with the
+mandatory isolation flags and explicit mounts. The container contract asserts
+`test -x /bin/sh`, the exact font file, and the recorded versions.
+
+- [ ] **Step 4: Run contract test and attempt the build**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_container_contract -v
+./benchmark build
+```
+
+Expected: contract test passes. The build passes when a Docker daemon and
+network are available; otherwise record the exact infrastructure failure
+without weakening the Dockerfile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "build(phash-spike): pin native hashing toolchain"
+```
+
+### Task 11: Generate synthetic fixtures and prove both algorithms end to end
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/fixtures/generate.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_synthetic_fixture.py`
+- Create: `experiments/perceptual-video-hashing/tests/test_native_smoke.py`
+
+- [ ] **Step 1: Write failing fixture tests**
+
+Require argument-array generation for three six-second MP4s:
+
+- source: moving test pattern plus 440 Hz tone;
+- re-encode: same visual content at CRF 32;
+- unrelated: different generated pattern plus 880 Hz tone.
+
+Assert deterministic metadata, output containment, no shell, and a generated
+manifest with opaque IDs and attestations. Gate the native smoke test behind
+`PHASH_NATIVE_SMOKE=1`; when enabled it must hash all three with both tools and
+assert source/re-encode matches while unrelated does not at documented smoke
+thresholds: vPDQ `D=31,F=50,Pc=80,Pq=0` and TMK
+`c1=0.70,c2=0.70`.
+
+Also generate a truncated MP4 and a text file with an `.mp4` suffix; native
+integration must classify both as bounded `unsupported_media` or
+`decode_failed`, emit no source path, and continue to the next item. Run the
+same generated manifest twice with the same seed in separate owned run roots
+and assert byte-identical split assignments, metric JSON, and frozen operating
+points after removing permitted provenance timestamps/run IDs.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest \
+  tests.test_synthetic_fixture tests.test_native_smoke -v
+```
+
+Expected: fixture import failure.
+
+- [ ] **Step 3: Implement safe generation**
+
+Implement `generate(output_root: Path) -> Path` using direct FFmpeg argument
+arrays and return the manifest path. The native smoke invokes only container
+binaries and records exact scores; it never substitutes a mock when enabled.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+```bash
+PYTHONPATH=src python3 -m unittest \
+  tests.test_synthetic_fixture tests.test_native_smoke -v
+PHASH_NATIVE_SMOKE=1 PYTHONPATH=src python3 -m unittest \
+  tests.test_native_smoke -v
+PHASH_NATIVE_SMOKE=1 ./benchmark smoke --runs-root /tmp/divine-phash-smoke
+```
+
+Expected: unit tests pass. Native smoke is a required completion gate; if
+Docker is unavailable or either official tool fails, Task 11 and the overall
+spike remain incomplete with the exact infrastructure error recorded.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add experiments/perceptual-video-hashing
+git commit -m "test(phash-spike): add native synthetic smoke"
+```
+
+### Task 12: Document operation, retention, and limitations
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/README.md`
+- Modify: `.gitignore`
+- Create: `experiments/perceptual-video-hashing/tests/test_documentation.py`
+
+- [ ] **Step 1: Write failing documentation tests**
+
+Require the README to contain:
+
+- every command and stable exit code;
+- exact manifest schema/example;
+- corpus approver, operator, safety reviewer, and decision owner roles;
+- Docker daemon prerequisite and safe command preview;
+- 5-day/200-CPU-hour/250-GiB/seven-day caps;
+- cleanup success/failure behavior and statement that originals are never
+  deleted;
+- no-enforcement and benign-proxy limitations;
+- aggregate report order and decision rule;
+- explicit instruction that a passing result authorizes only a separate
+  shadow-pilot design.
+
+Require `.gitignore` entries for input media, `runs/`, generated variants,
+`.vpdq`, `.tmk`, hash text, `.coverage`, and HTML coverage.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_documentation -v
+```
+
+Expected: missing README requirements.
+
+- [ ] **Step 3: Write the runbook and ignore rules**
+
+Document copy-paste commands for build, preflight, full, each follow-up phase,
+report review, exact-run cleanup, and expired-run cleanup. Include no real
+source URLs, IDs, fingerprints, or credentials. Add only experiment-scoped
+ignore rules without changing existing user entries.
+
+- [ ] **Step 4: Run and verify GREEN**
+
+Run the Step 2 command. Expected: documentation tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .gitignore experiments/perceptual-video-hashing
+git commit -m "docs(phash-spike): document safe benchmark operation"
+```
+
+### Task 13: Enforce 100% coverage and final verification
+
+**Files:**
+
+- Create: `experiments/perceptual-video-hashing/.coveragerc`
+- Create: `experiments/perceptual-video-hashing/tests/test_config_contract.py`
+
+- [ ] **Step 1: Write the failing coverage/config contract test**
+
+Require `.coveragerc` to enable branch coverage, measure
+`src/phash_benchmark`, `fixtures/generate.py`, and
+`container/spdx_from_dpkg.py`, omit no Divine source files, and fail under 100.
+Require `requirements.lock` to pin coverage exactly.
+
+- [ ] **Step 2: Run and verify RED**
+
+```bash
+PYTHONPATH=src python3 -m unittest tests.test_config_contract -v
+```
+
+Expected: `.coveragerc` missing.
+
+- [ ] **Step 3: Add exact coverage configuration**
+
+```ini
+[run]
+branch = True
+source =
+    src/phash_benchmark
+    fixtures
+    container
+
+[report]
+fail_under = 100
+show_missing = True
+skip_covered = False
+```
+
+- [ ] **Step 4: Run full fresh verification**
+
+Create a temporary venv outside the repository, install
+`requirements.lock`, then run:
+
+```bash
+python -m coverage erase
+PYTHONPATH=src python -m coverage run --branch -m unittest discover -s tests -v
+python -m coverage report --fail-under=100
+./benchmark --help
+git diff --check
+git status --short
+```
+
+Expected: every test passes, line and branch coverage are 100%, help succeeds,
+the diff has no whitespace errors, and only planned files are staged or
+committed.
+
+Native verification is mandatory:
+
+```bash
+./benchmark build
+PHASH_NATIVE_SMOKE=1 PYTHONPATH=src python -m unittest \
+  tests.test_native_smoke -v
+PHASH_NATIVE_SMOKE=1 ./benchmark smoke --runs-root /tmp/divine-phash-smoke
+```
+
+If Docker is unavailable or either command fails, record the exact
+infrastructure failure and leave the task and spike incomplete. Do not commit
+the final verification step or claim the harness complete until both commands
+pass.
+
+- [ ] **Step 5: Request code review and commit verification config**
+
+Apply `superpowers:requesting-code-review`, address blocking findings, rerun
+Step 4, then:
+
+```bash
+git add experiments/perceptual-video-hashing/.coveragerc \
+  experiments/perceptual-video-hashing/tests/test_config_contract.py
+git commit -m "test(phash-spike): enforce complete harness coverage"
+```
+
+### Task 14: Execute the authorized corpus and accept the decision
+
+**External inputs (not committed):**
+
+- Authorized manifest implementing the exact v1 contract.
+- Read-only input root containing exactly 50 `divine_public` sources, exactly
+  50 `archive_public` sources, and at least 400 attested distinct distractors.
+- Operator-selected runs root with at least the preflight disk requirement.
+- Task-specific run ID, freeze path, selected conclusion, safety-reviewer role,
+  and decision-owner role values copied exactly from validated command output
+  and manifest provenance as their `PHASH_*` variables are needed.
+
+- [ ] **Step 1: Verify external authorization and preflight**
+
+The operator supplies explicit absolute paths through task-specific variables:
+
+```bash
+test -f "$PHASH_CORPUS_MANIFEST"
+test -d "$PHASH_INPUT_ROOT"
+test -d "$PHASH_RUNS_ROOT"
+./benchmark preflight \
+  --manifest "$PHASH_CORPUS_MANIFEST" \
+  --input-root "$PHASH_INPUT_ROOT" \
+  --runs-root "$PHASH_RUNS_ROOT"
+```
+
+Expected: exit 0 with exact 50/50/400+ counts, technical-class representation
+counts, all four role aliases, authorization/non-sensitive/distinctness
+attestations, resource estimates, and 25% disk headroom. If these external
+inputs are absent or invalid, this task and the research spike remain blocked;
+do not substitute downloaded or synthetic media.
+
+- [ ] **Step 2: Run and review the bounded pilot**
+
+```bash
+./benchmark pilot \
+  --manifest "$PHASH_CORPUS_MANIFEST" \
+  --input-root "$PHASH_INPUT_ROOT" \
+  --runs-root "$PHASH_RUNS_ROOT"
+```
+
+Expected: exit 0, a printed run ID, five sources from each real corpus, 20
+distractors, every transform represented, no repeated sandbox exhaustion, and
+resource projections within the remaining caps. The safety reviewer records
+the aggregate pilot acceptance before full execution:
+
+```bash
+./benchmark accept-pilot \
+  --runs-root "$PHASH_RUNS_ROOT" \
+  --run "$PHASH_RUN_ID" \
+  --safety-reviewer-role "$PHASH_SAFETY_REVIEWER_ROLE"
+```
+
+- [ ] **Step 3: Execute tune, immutable freeze, and held-out test**
+
+Use the pilot-approved run ID:
+
+```bash
+./benchmark tune --runs-root "$PHASH_RUNS_ROOT" --run "$PHASH_RUN_ID"
+./benchmark test \
+  --runs-root "$PHASH_RUNS_ROOT" \
+  --run "$PHASH_RUN_ID" \
+  --freeze "$PHASH_FREEZE_PATH"
+./benchmark report --runs-root "$PHASH_RUNS_ROOT" --run "$PHASH_RUN_ID"
+```
+
+`tune` first generates and hashes the full authorized corpus, then consumes
+only train/development data for threshold selection. `test` verifies the
+content-addressed freeze and has no tuning path; report is aggregate-only and
+selects exactly vPDQ, TMK+PDQF, or no adoption. Exit 4 means `NO DECISION` and
+the spike remains incomplete.
+
+- [ ] **Step 4: Record human review and decision-owner acceptance**
+
+After the safety reviewer confirms omissions, failure denominators,
+confidence bounds, and sanitization, invoke:
+
+```bash
+./benchmark accept \
+  --runs-root "$PHASH_RUNS_ROOT" \
+  --run "$PHASH_RUN_ID" \
+  --conclusion "$PHASH_CONCLUSION" \
+  --safety-reviewer-role "$PHASH_SAFETY_REVIEWER_ROLE" \
+  --decision-owner-role "$PHASH_DECISION_OWNER_ROLE"
+```
+
+The command atomically writes an owned `decision-acceptance.json` containing
+exactly:
+
+```json
+{
+  "schema_version": 1,
+  "report_sha256": "<lowercase-64-hex>",
+  "conclusion": "vpdq|tmk|no_adoption",
+  "safety_reviewer_role": "<opaque-role-alias>",
+  "decision_owner_role": "<different-opaque-role-alias>",
+  "accepted": true,
+  "accepted_at_utc": "<RFC3339>"
+}
+```
+
+The CLI validates aliases against provenance and rejects personal identifiers,
+unknown fields, a changed report digest, or an unrecognized conclusion.
+
+- [ ] **Step 5: Clean restricted data and verify retained evidence**
+
+```bash
+./benchmark cleanup --runs-root "$PHASH_RUNS_ROOT" --run "$PHASH_RUN_ID"
+```
+
+Expected: caller originals remain untouched; normalized media, variants,
+native hashes, raw pairs, exact digests, and restricted failure details are
+removed; aggregate metrics, sanitized report, non-identifying provenance,
+freeze, and decision acceptance remain. Only after this verification is the
+research spike complete.
+
+## Implementation constraints
+
+- Follow RED → verify failure → GREEN for every production behavior.
+- Never stage or modify unrelated dirty-worktree files.
+- Use a clean feature worktree created with
+  `superpowers:using-git-worktrees` before Task 1.
+- Do not fetch, select, or commit the real 100-source/400-distractor corpus.
+  Task 14 runs only when the authorized operator-provided manifest and files
+  exist.
+- Do not weaken sandbox flags or tests because Docker Desktop is unavailable.
+- Do not add a production integration, external hash list, FAISS path,
+  moderation call, or automatic action.
+- The actual held-out benchmark and research spike remain incomplete until
+  Task 14 produces and accepts a valid frozen decision.

--- a/docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md
@@ -2,395 +2,733 @@
 
 **Date:** 2026-07-24
 **Issue:** divine-funnelcake#686
-**Status:** Approved for implementation planning
+**Status:** Design review, revision 2
 
-## Problem
+## Problem and baseline
 
-The Cloud Run transcoder currently sends transcript and HLS status updates to
+The Cloud Run transcoder sends transcript and transcode status updates to
 Fastly as fire-and-forget HTTP requests. A non-2xx response is logged, but the
 job continues and the update is permanently lost.
 
-On 2026-07-22 and 2026-07-23, Fastly rejected these callbacks with
-`403 Invalid webhook secret`. Transcript and HLS artifacts continued to be
-written to GCS, but Fastly KV metadata remained stale. Terminal invalid-media
-failures were also lost, causing the same corrupt source to be retried and
-reported repeatedly.
+During the current incident, transcript and HLS artifacts continued to be
+written to GCS while Fastly rejected callbacks with `403 Invalid webhook
+secret`. In one 24-hour investigation window, 2,360 callbacks for 444 hashes
+were rejected. At the same time, Parakeet returned 337 successful responses
+and 242 distinct VTT artifacts were uploaded. Lost terminal invalid-media
+updates also caused one corrupt source to be processed and reported
+repeatedly.
 
-The reliability boundary must therefore be the status event itself, not the
-duration of one Cloud Run request.
+The reliability boundary must be the status event itself, not the lifetime of
+one Cloud Run request.
+
+## People and use cases
+
+### Creator
+
+WHO finishes an upload, WANTS completed transcript and transcode derivatives
+to become discoverable, SO THAT the video is playable and captioned without
+uploading again, WHEN Fastly or callback authentication is temporarily
+unavailable.
+
+WHO uploads invalid media, WANTS one stable terminal result, SO THAT the same
+source is not processed indefinitely, WHEN terminal-status delivery is
+temporarily unavailable.
+
+### Viewer
+
+WHO opens processed media, WANTS playback and subtitle availability to reflect
+the artifacts that exist, SO THAT completed derivatives do not appear missing,
+WHEN status events are delayed, duplicated, or delivered out of order.
+
+### On-call operator
+
+WHO repairs an outage or credential mismatch, WANTS pending status events to
+drain automatically, SO THAT affected users recover without retranscoding,
+WHEN delivery resumes.
+
+WHO receives a dead-letter alert, WANTS a dry-run and replay workflow, SO THAT
+a permanently malformed or rejected event can be corrected without editing
+production storage by hand.
 
 ## Goals
 
-- Deliver every transcript and HLS status update eventually.
-- Survive temporary network, Fastly, credential, and Cloud Tasks failures.
-- Make duplicate and out-of-order deliveries harmless.
-- Allow webhook-secret rotation without redeploying the delivery service.
-- Make a stuck delivery backlog visible within five minutes.
-- Recover existing or future orphaned events without retranscoding media.
-- Keep the solution specific to derivative status delivery rather than
-  introducing a general event platform.
+- Persist every transcript and transcode status event before acknowledging
+  publication.
+- Survive temporary network, Fastly, credential, Cloud Tasks, and task-create
+  failures.
+- Make duplicate and out-of-order delivery harmless across every durable side
+  effect.
+- Rotate a route-scoped delivery credential without deploying the delivery
+  worker.
+- Detect a stuck backlog within five minutes.
+- Recover incident-window artifacts and explicitly identified terminal
+  failures without retranscoding.
+- Prevent public callers from using processor routes to amplify compute,
+  outbox, or queue cost.
+- Keep this specific to derivative status delivery.
 
 ## Non-goals
 
 - Replacing Fastly KV as the public metadata store.
-- Replacing the existing transcription or HLS processing pipelines.
-- Building a reusable company-wide event bus.
-- Providing strict FIFO ordering from Cloud Tasks.
-- Deploying or rotating production secrets as part of the code change.
+- Replacing transcription or HLS generation.
+- Strict FIFO ordering from Cloud Tasks.
+- Building a reusable company-wide event platform.
+- Automatically inferring historical terminal failures from unstructured
+  error text.
+
+## MVP and deferred work
+
+The MVP includes:
+
+- route-authenticated processor entry points;
+- a typed, durable GCS outbox;
+- one Cloud Tasks queue with enforced routing and authentication;
+- one private delivery service;
+- one private scheduled reconciliation job;
+- versioned Fastly status endpoints with generation-matched writes;
+- incident recovery tooling;
+- metrics, alerts, and a checked-in runbook.
+
+There is no direct-webhook fallback after queue-first publishing is enabled.
+An unordered direct path would bypass the delivery guarantees. A later project
+may consolidate this pattern with other Divine outboxes after production
+evidence exists.
 
 ## Architecture
 
-The transcoder image will support two service modes:
+Build three small Rust binaries from shared modules:
 
-- `processor` (default): the existing public `divine-transcoder` service.
-- `delivery`: a private `divine-status-delivery` Cloud Run service exposing
-  only health, task delivery, and reconciliation routes.
-
-The services use the same image and Rust event types. They are separate Cloud
-Run services because the existing transcoder is publicly invokable. Keeping
-the delivery service private lets Cloud Run IAM authenticate Cloud Tasks and
-Cloud Scheduler OIDC tokens without bespoke JWT validation in application
-code.
+- `divine-transcoder`: the existing processor, with authenticated entry points
+  and queue-first status publication.
+- `divine-status-delivery`: a lightweight private Cloud Run service with no
+  CUDA or FFmpeg runtime.
+- `divine-status-reconciler`: a lightweight Cloud Run Job using the delivery
+  library but without the delivery credential.
 
 ```text
-Transcript or HLS processor
-  -> write immutable pending event to GCS
+Authenticated processor
+  -> create typed event
+  -> immutable create in private GCS outbox
   -> create deterministic Cloud Task
-  -> finish the processing request
+  -> finish processing request
 
-Cloud Tasks (OIDC)
-  -> private divine-status-delivery service
-  -> load pending event from GCS
-  -> read the current webhook secret from a mounted secret volume
-  -> POST the existing payload to Fastly
-  -> on Fastly 2xx, delete the pending event and acknowledge the task
-  -> otherwise retain the event and retry or dead-letter it
+Cloud Tasks, queue-level OIDC and route override
+  -> private delivery service
+  -> load and validate pending event
+  -> read current HMAC secret from mounted volume
+  -> sign and POST full event to versioned Fastly route
+  -> Fastly applies each durable effect with KV generation-match
+  -> worker deletes pending event only after Fastly reports durable acceptance
 
-Cloud Scheduler (OIDC, once per minute)
-  -> reconciliation route
-  -> find old pending events
+Cloud Scheduler
+  -> private Cloud Run reconciliation job
+  -> resume paginated outbox scan from durable cursor
   -> recreate missing deterministic tasks
 ```
 
-## Components
+## Repository boundaries
 
-### Shared status-delivery module
+Shared status types and pure decisions live in a library module that does not
+depend on Axum, GCS, Cloud Tasks, or Fastly:
 
-Create a focused module under `cloud-run-transcoder/src/` that owns:
+- `StatusEvent` and derivative-specific update types;
+- validation;
+- total ordering;
+- retry/dead-letter classification;
+- Fastly apply decisions.
 
-- the versioned `StatusEvent` wire type;
-- event validation;
-- deterministic GCS object and Cloud Task names;
-- outbox persistence;
-- Cloud Tasks creation;
-- delivery response classification;
-- reconciliation decisions.
+Runtime adapters implement narrow interfaces:
 
-Provider transcription retries and derivative status-delivery retries remain
-separate concerns.
+- `OutboxStore`
+- `TaskQueue`
+- `WebhookClient`
+- `SecretProvider`
+- `Clock`
+- `IdGenerator`
 
-### GCS outbox
+Router construction accepts these interfaces so service tests do not start the
+GPU processor or require live cloud services.
 
-Use the existing media bucket with dedicated internal prefixes:
+Deployment scripts and configuration for the queue, private service,
+reconciliation job, IAM bindings, log-based metrics, and alert policies are
+owned in this repository under `cloud-run-transcoder/`. They require project,
+region, bucket, service-account, and notification-channel inputs; they do not
+embed credentials.
 
-- `status-outbox/pending/<event_id>.json`
-- `status-outbox/dead/<event_id>.json`
+## Authentication boundaries
 
-An event is written to `pending` before task creation. If Cloud Tasks creation
-fails, the processing request does not lose the event; the reconciler can
-create the task later.
+### Processor routes
 
-Pending records remain until Fastly accepts them. Permanently malformed events
-move to `dead` with the delivery classification and timestamp. Dead records
-are retained for operator inspection and alerting and must not contain
-secrets.
+The public Cloud Run service remains reachable because Fastly invokes it, but
+all non-health routes require a dedicated `processor_request_secret` HMAC:
 
-GCS is already a required dependency of the processor and is strongly
-consistent for object reads and listings. The outbox adds no new datastore.
+- `/transcode`
+- `/transcribe`
+- `/backfill-fmp4`
+- `/audio/extract`
+- any future route that can start work or write an outbox event
 
-### Cloud Tasks queue
+Fastly and the upload service sign the raw request body using a timestamped
+HMAC. The processor checks the signature in constant time, enforces a
+five-minute timestamp window, and rejects unsigned requests before parsing the
+body or allocating expensive work. CORS is limited to the required production
+origin and does not substitute for authentication.
 
-Provision one regional queue, `derivative-status-delivery`, in the same region
-as the delivery service.
+Existing per-hash transcript locking remains. Transcode receives the same
+idempotent in-progress lock to suppress trusted duplicate work.
 
-Initial queue policy:
+### Fastly status routes
 
-- minimum retry backoff: 5 seconds;
-- maximum retry backoff: 15 minutes;
-- exponential backoff;
-- no small maximum-attempt cutoff;
-- dispatch deadline: 30 seconds;
-- maximum concurrent dispatches: 10;
-- maximum dispatch rate: 20 per second.
+Add dedicated routes:
 
-Cloud Tasks invokes the private delivery service using a dedicated service
-account with only `roles/run.invoker` on that service. The processor service
-account receives only the permission needed to create tasks in this queue.
+- `POST /internal/derivative-status/v1/transcript`
+- `POST /internal/derivative-status/v1/transcode`
 
-A task body contains only `event_id`. Task names are derived from the event ID,
-so a producer or reconciler may safely repeat task creation. `AlreadyExists`
-is treated as success.
+They accept only a new `derivative_status_secret` HMAC. This credential is not
+accepted by admin, moderation, delete, restore, dashboard, or legacy webhook
+routes. The current `webhook_secret` is never mounted in the delivery service.
 
-### Private delivery service
+The delivery worker signs:
 
-The delivery service exposes:
+```text
+v1
+<unix timestamp seconds>
+<raw request body bytes>
+```
 
-- `GET /health`
-- `POST /internal/status-events/deliver`
-- `POST /internal/status-events/reconcile`
+It sends the timestamp and lowercase hex HMAC-SHA256 signature in dedicated
+headers. Fastly verifies the signature in constant time and allows at most five
+minutes of clock skew.
 
-The service is not granted `allUsers` invocation. Cloud Run IAM rejects
-unauthenticated requests before application code runs.
+The worker pins the exact HTTPS origin and route in configuration, disables
+redirects, uses a 3-second connect timeout and 10-second total timeout, and
+reads at most 16 KiB of an upstream response.
 
-The webhook secret is mounted from Secret Manager as a `latest` version file
-and read for each delivery. Cloud Run secret volumes fetch the latest value
-when read, so secret rotation does not require a new revision. The secret is
-never copied into a Cloud Task or GCS event.
+### Secret rotation
 
-The delivery service sends the existing bearer-authenticated payload to one of
-the two existing Fastly routes:
+Fastly accepts `derivative_status_secret_primary` and, during rotation only,
+`derivative_status_secret_secondary`. GCP exposes the current secret to the
+delivery service as a mounted `latest` secret file, which is read for each
+attempt.
 
-- `/admin/transcode-status`
-- `/admin/transcript-status`
+Rotation order:
 
-It returns 2xx to Cloud Tasks only after Fastly accepts the event or the event
-has been safely dead-lettered.
+1. Place the new value in Fastly's secondary slot.
+2. Add a new GCP secret version and make it latest.
+3. Deliver a signed smoke event and confirm the new credential is accepted.
+4. Promote the new Fastly value to primary.
+5. Remove the old secondary value within one hour.
+6. Alert on any use of the retiring credential after promotion.
 
-### Reconciler
+The processor HMAC credential uses the same overlap procedure but remains a
+separate secret.
 
-Cloud Scheduler invokes reconciliation once per minute using a second service
-account with `roles/run.invoker` on the private delivery service.
+## IAM and identity matrix
 
-The reconciler lists pending records older than two minutes and recreates
-their deterministic tasks. It processes a bounded page per invocation and
-logs the continuation state. Duplicate task creation and duplicate delivery
-are safe.
+All service accounts are keyless.
 
-This is recovery for the producer-to-queue gap and task expiry; it is not a
-second primary delivery mechanism.
+| Identity | Allowed operations |
+| --- | --- |
+| Processor runtime | Create pending outbox objects; create tasks in the one status queue |
+| Delivery runtime | Read/delete pending objects; create dead objects; access only `derivative_status_secret` |
+| Reconciler runtime | List/read pending objects; create tasks; read/write reconciliation cursor |
+| Cloud Tasks OIDC identity | Invoke only `divine-status-delivery` |
+| Scheduler identity | Execute only `divine-status-reconciler` |
+| Cloud Tasks service agent | Mint tokens for the task OIDC identity as required by Google |
+| Deployment identity | Manage declared resources and `actAs` only the identities needed during deployment |
+
+The queue uses queue-level `ALWAYS` overrides for HTTPS scheme, delivery host,
+delivery path, POST method, OIDC service account, and audience. Producers
+cannot choose a target or authentication identity. Only the deployment
+identity needs `iam.serviceAccounts.actAs` while configuring that override;
+task creators receive no impersonation role.
+
+## Private outbox
+
+Use a dedicated private bucket with public-access prevention and uniform
+bucket-level access. It contains no media:
+
+- `pending/<event_id>.json`
+- `dead/<event_id>.json`
+- `control/reconcile-cursor.json`
+
+Pending objects have no expiration lifecycle. Dead objects expire after 30
+days. Access is granted according to the IAM matrix rather than by relying on a
+textual prefix in the media bucket.
+
+Pending creation uses `ifGenerationMatch=0`. If the same event already exists,
+the producer verifies that its bytes match; a mismatch is an integrity error.
+
+Successful cleanup deletes the exact generation read by the worker. Dead
+movement creates the dead object with `ifGenerationMatch=0` before deleting
+the matching pending generation. A crash at any boundary leaves at least one
+recoverable copy.
 
 ## Event contract
+
+Fastly receives the full event envelope. Cloud Tasks receives only the event
+ID.
 
 ```json
 {
   "schema_version": 1,
-  "event_id": "uuid",
-  "derivative": "transcript",
+  "event_id": "018f6e33-c5af-7d82-a7b2-30f02e8f7e10",
   "sha256": "64 lowercase hex characters",
-  "operation_id": "uuid",
+  "operation_id": "018f6e33-c5af-7b11-a2f7-7cf63d8a68ac",
   "operation_started_at_ms": 1784847000000,
   "sequence": 2,
   "created_at_ms": 1784847001234,
-  "status": "complete",
-  "payload": {
-    "sha256": "64 lowercase hex characters",
-    "status": "complete"
+  "attempt_number": 1,
+  "derivative": "transcript",
+  "update": {
+    "status": "complete",
+    "job_id": "optional",
+    "language": "en",
+    "duration_ms": 6100,
+    "cue_count": 3,
+    "confidence": "high",
+    "last_attempt_at_ms": 1784847001200
   }
 }
 ```
 
-`derivative` is `transcript` or `transcode`. The payload retains all existing
-fields, including transcript `job_id`, language, duration, cue count, error
-details, retry timing, dimensions, and terminal status.
+The Rust type is a tagged enum:
 
-Each processor invocation creates a unique `operation_id` and increasing
-sequence numbers for its status events. `job_id` remains a product-facing
-subtitle-job identifier and is not reused as a delivery identifier.
+- `DerivativeUpdate::Transcript(TranscriptUpdate)`
+- `DerivativeUpdate::Transcode(TranscodeUpdate)`
 
-Events contain no media bytes, transcript text, owner keys, credentials, or
-other secrets.
+Shared validation:
 
-## Idempotency and ordering
+- body and outbox object at most 32 KiB;
+- schema version exactly 1;
+- canonical UUIDv7 event and operation IDs;
+- SHA-256 exactly 64 lowercase hex characters;
+- operation timestamp agrees with the UUIDv7 timestamp within one second;
+- created time is not before operation start or more than ten minutes in the
+  future;
+- sequence is `1..=32`;
+- attempt number is `1..=100`;
+- status is one of the derivative's declared enum values;
+- error code is at most 64 ASCII identifier characters;
+- error message is sanitized and at most 2,048 bytes;
+- job ID is at most 128 bytes;
+- language is at most 35 ASCII characters;
+- cue count, duration, dimensions, size, and absolute retry time use bounded
+  unsigned integers;
+- fields forbidden for a given derivative or status are rejected.
 
-Cloud Tasks provides at-least-once delivery, not strict FIFO ordering. Fastly
-therefore stores a delivery watermark independently for transcript and
-transcode metadata:
+Status timestamps and retry times are absolute event values. Fastly does not
+replace them with delivery receipt time. Events contain no transcript text,
+media bytes, owner key, signed URL, filesystem path, authorization value, or
+other credential.
 
-- last operation start time;
-- last operation ID;
-- last accepted sequence;
+The delivery task request is:
+
+```json
+{"event_id":"canonical UUIDv7"}
+```
+
+with `Content-Type: application/json` and a maximum body of 128 bytes.
+
+Unknown schema versions are retained and alerted as deployment skew rather
+than automatically dead-lettered.
+
+## Total order
+
+An operation is one processor invocation, including all status transitions it
+emits. An explicit retry creates a new operation.
+
+Events are totally ordered by:
+
+1. `operation_started_at_ms`;
+2. `operation_id` as a canonical byte sequence;
+3. `sequence`.
+
+The UUID tie-breaker handles operations started in the same millisecond. The
+trusted producer timestamp, UUID agreement check, future-skew bound, and HMAC
+prevent future-dated replay poisoning.
+
+Replaying the same event preserves its event ID and ordering coordinates. A
+human corrective action creates a new recovery operation so it intentionally
+supersedes prior state.
+
+## Fastly durable-apply protocol
+
+### Exact response contract
+
+The versioned endpoints return 200 only after every required durable effect
+has succeeded:
+
+```json
+{
+  "event_id": "uuid",
+  "outcome": "applied|duplicate|stale",
+  "blob_effect": "applied|already_applied",
+  "job_effect": "not_required|applied|already_applied"
+}
+```
+
+Missing blob metadata returns `409 metadata_not_ready`, not 202. If a transcript
+event names a subtitle job that does not yet exist, it returns
+`409 job_not_ready`. Both are retryable.
+
+Invalid bodies or signatures return minimal generic errors without parser,
+storage, secret, or upstream details.
+
+### Generation-matched writes
+
+Add an optional serde-defaulted delivery watermark to both `BlobMetadata` and
+`SubtitleJob`:
+
+- operation ordering fields;
+- last sequence;
 - last event ID.
 
-Fastly applies an event when:
+Webhook paths bypass the five-minute POP-local metadata cache. They read the KV
+value and generation marker, run the pure transition decision, then write with
+`if_generation_match`. A precondition failure reloads and retries up to five
+times before returning a retryable conflict.
 
-- its operation start time is newer than the stored operation; or
-- it belongs to the stored operation and has a higher sequence.
+Every existing writer of transcript or transcode status is routed through the
+same generation-aware helper or explicitly creates a newer operation. No
+status writer may perform an unconditional full-record overwrite.
 
-Fastly acknowledges without mutation when:
+### Multi-effect retries
 
-- the event ID is a duplicate;
-- the operation is older; or
-- the sequence has already been applied.
+Blob and subtitle-job effects have independent watermarks in their respective
+records.
 
-This check happens before changing status, incrementing attempt counts,
-updating subtitle jobs, or purging caches. Consequently:
+For every attempt, Fastly:
 
-- duplicate failures increment attempt counters once;
-- delayed `processing` events cannot regress a completed operation;
-- a later explicit retry operation may advance a previous terminal state.
+1. Applies or confirms the blob effect with CAS.
+2. Applies or confirms the subtitle-job effect with CAS when required.
+3. Refreshes the hash-to-job mapping idempotently.
+4. Issues the required cache purges.
+5. Returns the structured 200 response.
 
-The handler returns 200 for duplicate and stale events so Cloud Tasks stops
-retrying them.
+A duplicate blob effect does not short-circuit later effects. Therefore a
+retry after a partial failure can finish the subtitle job and purges without
+incrementing attempt counters or regressing blob state.
 
-## Failure classification
+Failure counters are changed inside the CAS transition only when that record's
+watermark has not already accepted the event. Completion and failure updates
+are absolute assignments derived from the typed event; retrying them is
+idempotent.
 
-Delivery results are handled as follows:
+Legacy status endpoints remain only until the new edge route and worker are
+verified. They do not accept the new route-scoped credential. Queue-first
+producers are enabled only after the versioned endpoints are active, and the
+legacy routes are then disabled before full rollout.
 
-| Result | Action |
+## Cloud Tasks queue
+
+Provision one `derivative-status-delivery` queue in the delivery region:
+
+- minimum backoff: 5 seconds;
+- maximum backoff: 15 minutes;
+- exponential backoff;
+- maximum retry duration: 30 days;
+- dispatch deadline: 20 seconds;
+- maximum concurrent dispatches: 10;
+- maximum dispatch rate: 20 per second;
+- queue-level routing and OIDC overrides enforced with mode `ALWAYS`.
+
+Task names derive from event IDs. Cloud Tasks may retain a deleted task name
+for up to 24 hours; `AlreadyExists` means "currently queued or still
+tombstoned", not proof of delivery. The GCS pending object remains the source
+of truth and the reconciler retries after the tombstone window if necessary.
+
+## Delivery state machine
+
+The worker handles:
+
+| Condition | Task response and outbox action |
 | --- | --- |
-| Fastly 2xx | Delete pending record and acknowledge task |
-| Network error | Retain pending record and retry |
-| 401, 403 | Retain, alert as credential failure, and retry |
-| 404 | Retain and retry because metadata creation can race delivery |
-| 408, 409, 425, 429 | Retain and retry |
-| 5xx | Retain and retry |
-| Structurally invalid event before dispatch | Move to `dead` and alert |
-| Other permanent Fastly 4xx | Move to `dead` and alert with sanitized response metadata |
+| Pending missing, dead missing | 204; already delivered/cleaned |
+| Dead exists | 204; already classified |
+| Pending read or secret read failure | 503; retain and retry |
+| Unknown schema version | 503; retain and alert deployment skew |
+| Structurally corrupt known-version event | Create dead, delete pending generation, 204 |
+| Fastly applied/duplicate/stale response | Delete pending generation, 204 |
+| Fastly 401/403 | 503; retain, high-severity credential alert |
+| Fastly 409/408/425/429/5xx or network error | 503; retain and retry |
+| Other Fastly 4xx | Create dead, delete pending generation, 204 |
+| Fastly success followed by cleanup failure | 503; retry safely |
 
-The delivery service maps retryable upstream results to a non-2xx task-handler
-response. It records the actual upstream status in structured logs and
-metrics.
+Dead records contain the original sanitized event, classification, upstream
+status code when present, first/last attempt timestamps, and no response body
+or credential.
 
-If deleting the pending event fails after Fastly accepted it, the task is
-retried. Fastly idempotency makes the duplicate harmless, and the next attempt
-can finish cleanup.
+The service reuses one HTTP client. Liveness proves the process is running.
+Readiness verifies outbox access, secret-file readability, fixed target
+configuration, and service mode without calling Fastly.
 
-## Producer behavior
+## Reconciliation job
 
-Replace both direct webhook functions with a shared queue-first publisher.
+Cloud Scheduler starts a Cloud Run Job once per minute. Cloud Run permits only
+one concurrent execution.
 
-For every status transition:
+The job stores the next GCS page token and cycle start time in
+`control/reconcile-cursor.json` using a generation-match update. It advances
+the cursor after every scanned page even when records on that page already
+have tasks or are temporarily failing. At end-of-list it records cycle
+completion and resets the cursor.
 
-1. Build and validate the status event.
-2. Persist the pending GCS record.
-3. Attempt deterministic task creation with short bounded client retries.
-4. Return success once either task creation succeeds or the durable pending
-   record is confirmed.
+Each execution stops after eight minutes or 5,000 records, whichever comes
+first. The next execution resumes from the persisted cursor. Tests cover a
+backlog larger than one page, a permanently failing first page, cursor CAS
+conflicts, a crash before and after cursor advancement, and full-cycle reset.
 
-The media operation does not wait for Fastly delivery.
+For every pending object older than two minutes, it creates the deterministic
+task. `AlreadyExists` is recorded and scanning continues.
 
-If the pending record itself cannot be persisted, return an error and capture
-a focused Sentry event. A retried media request remains cheap after successful
-artifact creation because existing GCS artifact checks emit `complete`
-without recomputing the derivative.
+## Incident recovery tool
 
-## Observability
+Provide a checked-in admin CLI with `discover`, `plan`, and `apply` phases.
 
-Structured logs and metrics include:
+`discover`:
 
-- event ID, derivative, hash, operation ID, and sequence;
-- enqueue outcome and latency;
-- delivery attempt count and latency;
-- sanitized Fastly response status;
-- pending outbox age and count;
-- dead-letter count;
-- reconciliation scanned, recreated, skipped, and failed counts.
+- lists `*/vtt/main.vtt` and `*/hls/master.m3u8` in the media bucket;
+- emits a local manifest of artifact-backed `complete` candidates;
+- accepts an explicit operator-supplied manifest of terminal failures derived
+  from structured logs/Sentry evidence;
+- does not mutate cloud state.
 
-Never log authorization headers, secret values, transcript content, media
-bytes, or full external response bodies.
+`plan`:
 
-Create alerts for:
+- validates every hash and current Fastly metadata response;
+- excludes absent, deleted, or otherwise ineligible blob metadata;
+- shows counts by derivative and desired status;
+- creates deterministic event IDs within one recovery run.
 
-- oldest pending event greater than five minutes;
-- any sustained 401/403 delivery response;
-- any dead-letter event;
-- task creation failures;
-- reconciler failures;
-- queue depth growing for fifteen minutes.
+`apply`:
 
-Sentry fingerprints must identify the service and failure class rather than
-grouping all provider and delivery errors together.
+- requires the reviewed manifest and an explicit confirmation flag;
+- creates new recovery operations using the normal typed outbox publisher;
+- never calls the processor or retranscodes media;
+- is idempotent when rerun with the same manifest.
 
-## Testing
+Verification reports artifact count, planned count, applied count, remaining
+stale count, and terminal retry suppression. The current incident's known
+invalid-media hash is supplied through the reviewed manifest, not hardcoded.
 
-### Native unit tests
+## Deployment order
 
-- Event serialization and validation for both derivative types.
-- Deterministic event object and task naming.
-- Retryable versus permanent response classification.
-- Operation/sequence watermark comparisons.
-- Duplicate failures do not increment attempt counts.
-- Newer operations may advance terminal state.
-- Older and duplicate events return success without mutation.
+1. Add native CAS helpers, optional watermarks, versioned Fastly endpoints,
+   HMAC verification, and tests.
+2. Publish Fastly with `fastly compute publish`, purge the service, and verify
+   legacy behavior plus the new routes.
+3. Provision the private outbox bucket, queue with enforced overrides,
+   identities/IAM, private worker, reconciliation job, metrics, and alerts.
+4. Deploy the delivery worker and test unauthenticated rejection, task OIDC,
+   HMAC overlap, retry, dead-letter, CAS conflict, and secret rotation.
+5. Add processor HMAC verification and update both trusted callers before
+   rejecting unsigned requests.
+6. Deploy queue-first producer support disabled, then enable it for a 10%
+   deterministic hash canary for 24 hours.
+7. Enable all transcript and transcode status events if canary criteria pass.
+8. Disable legacy status endpoints and observe for seven days.
+9. Run incident recovery in dry-run, review its manifest, apply it, and verify
+   convergence.
+10. Remove old shared status-sender code after fourteen stable days.
 
-### Service tests
+Rollback pauses producer publication but does not delete pending/dead objects.
+The worker and reconciler continue until pending is empty. If the new Fastly
+route is the fault, pause queue dispatch, roll back Fastly atomically, correct
+the route, and resume; never switch queued producers to unordered direct
+delivery.
 
-Use a local HTTP test server and injected outbox/task/webhook clients to prove:
+## Observability and alerts
 
-- pending persistence happens before task creation;
-- task-creation failure leaves a recoverable pending event;
-- Fastly 403 retains the event and returns a retryable task response;
-- Fastly 200 deletes the pending event;
-- cleanup failure causes a safe duplicate retry;
-- malformed events move to the dead prefix;
-- reconciliation recreates deterministic missing tasks;
-- `AlreadyExists` is successful reconciliation.
+Cloud Monitoring and Cloud Tasks built-in metrics are authoritative. Use
+structured logs to create the missing outbox/dead-letter metrics.
 
-### Integration and deployment validation
+Low-cardinality metric labels:
 
-- Run the transcoder test suite and clippy.
-- Deploy the private delivery service before enabling producers.
-- Submit a synthetic non-media status event against a controlled test
-  metadata record.
-- Verify OIDC invocation succeeds and unauthenticated invocation is rejected.
-- Verify a deliberately rejected callback remains pending and retries.
-- Correct the test credential and verify the queued event drains without
-  recreation.
-- Enable queue-first publishing for a small canary, then for all status events.
+- service;
+- derivative;
+- status/outcome;
+- failure class.
 
-## Rollout and recovery
+Hashes, event IDs, operation IDs, and job IDs appear only in access-controlled
+structured logs, not metric labels.
 
-1. Provision the queue, service accounts, IAM, secret volume, Scheduler job,
-   dashboards, and alerts.
-2. Deploy the same image in private `delivery` mode.
-3. Run authentication, retry, and secret-rotation smoke tests.
-4. Deploy processor support with queue publishing disabled.
-5. Enable queue-first publishing for transcript and transcode events.
-6. Confirm pending age remains below five minutes and Fastly metadata reaches
-   terminal states.
-7. Reconcile existing VTT artifacts and terminal invalid-media failures from
-   the incident window.
+Measure:
 
-The initial release may retain the direct sender behind an emergency
-configuration switch, marked `TODO(#686)` and disabled by default. Remove the
-switch after the queued path has completed a stable observation period.
+- enqueue success/failure and latency;
+- delivery outcome, attempt count, and latency;
+- Fastly response class;
+- queue depth and oldest task age;
+- pending age and count;
+- dead count;
+- reconciliation scan/recreate/failure/cycle duration;
+- CAS conflict and exhaustion counts;
+- artifact-to-terminal-metadata convergence latency;
+- duplicate processor suppression.
 
-Rollback disables new queue publishing but does not delete pending or dead
-records. The delivery service and reconciler remain active until the backlog
-is empty.
+Alert policies:
 
-## Operational runbook requirements
+- pending or oldest-task age reaches four minutes, evaluated every minute;
+- any sustained 401/403 for two minutes;
+- any dead event;
+- enqueue or reconciliation failures;
+- queue depth grows for fifteen minutes;
+- CAS retries exhaust;
+- unsigned processor-route attempts exceed a conservative threshold;
+- processor cost or request rate deviates materially from baseline.
 
-Document:
+Sentry fingerprints include service, derivative, and failure class so provider,
+FFmpeg, delivery, and user-invalid-media events cannot collapse into one
+group.
 
-- how to inspect queue depth and oldest pending-event age;
-- how to identify 401/403 delivery failures without reading secrets;
-- how to synchronize or rotate the GCP and Fastly webhook secret safely;
-- how to replay pending and dead events;
-- how to pause and resume queue dispatch;
-- how to validate one transcript and one HLS transition end to end;
-- how to reconcile artifacts after a prolonged outage.
+## User-facing success and rollout gates
 
-## Security
+Normal operation:
 
-- The delivery service is private and OIDC-authenticated by Cloud Run IAM.
-- Producer, task-invoker, and scheduler service accounts have separate,
-  least-privilege roles.
-- The Fastly secret exists only in Secret Manager, its mounted volume, and the
-  outbound authorization header.
-- Outbox events are operational metadata only and use bucket IAM already
-  restricted to service identities.
-- Logs and alerts use IDs and status codes, never credentials or user media.
+- p95 artifact-to-terminal-metadata convergence is below 30 seconds;
+- at least 99.9% converges within five minutes;
+- permanent untracked event loss is zero;
+- a duplicate event changes no counter or terminal state;
+- a delivered terminal invalid-media result suppresses repeated processing.
+
+Canary passes after 24 hours only if:
+
+- no lost or dead events;
+- no unauthorized delivery acceptance;
+- no metadata regression;
+- no duplicate failure increment;
+- p95 and five-minute objectives are met;
+- queue and pending depth return to baseline.
+
+Full rollout remains under observation for seven days. Legacy sender code is
+removed only after fourteen stable days.
+
+Pause rollout or roll back the faulty layer if:
+
+- any accepted event becomes untracked;
+- more than 0.1% of artifact-backed derivatives remain stale after five
+  minutes while dependencies are healthy;
+- any queued event regresses terminal metadata;
+- any duplicate increments an attempt counter;
+- a dead event occurs;
+- credential failures persist for five minutes;
+- oldest pending age exceeds fifteen minutes while Fastly is healthy.
+
+During a prolonged dependency outage, artifacts may be directly retrievable
+while metadata remains pending. The pending event remains durable, the
+operator is alerted, and recovery occurs automatically after service returns.
+
+## Testing strategy
+
+Every implementation slice begins with a failing native test.
+
+### Pure domain tests
+
+- typed transcript/transcode serialization and field allowlists;
+- size, UUID, hash, timestamp, sequence, attempt, and error bounds;
+- total-order same-millisecond UUID tie-break;
+- retry/dead/unknown-version classification;
+- transition decisions for applied, duplicate, stale, and newer operation.
+
+### Fastly metadata tests
+
+Introduce an injected KV adapter exposing value plus generation and
+generation-matched writes.
+
+- uncached webhook lookup;
+- CAS success and conflict reload;
+- conflict exhaustion;
+- duplicate failure does not increment;
+- partial blob success followed by job failure completes on retry;
+- missing blob/job returns retryable 409;
+- cache purge is retried after durable effects;
+- every existing derivative-status writer uses the generation-aware path.
+
+### Processor and publisher tests
+
+- unsigned, stale, malformed, and wrong-secret processor requests are rejected
+  before work;
+- current and overlap secrets are accepted;
+- pending persistence precedes task creation;
+- pending create conflict requires byte equality;
+- task-create failure leaves a recoverable pending event;
+- existing artifact makes a retried processor request publish completion
+  without recomputation;
+- duplicate transcode request is suppressed by its GCS lock.
+
+### Delivery service tests
+
+Use injected in-memory outbox/secret providers and a local HTTP server.
+
+- all state-machine rows above;
+- redirects are rejected;
+- response and timeout bounds;
+- HMAC current/secondary rotation;
+- success plus cleanup failure retries safely;
+- dead create-before-delete generation ordering;
+- missing pending is acknowledged;
+- unknown schema remains pending.
+
+### Reconciler and recovery tests
+
+- multi-page backlog cannot starve later pages;
+- durable cursor recovery at every crash boundary;
+- overlapping execution prevention;
+- task-name tombstone and `AlreadyExists` behavior;
+- dry-run recovery never mutates;
+- same manifest applies idempotently;
+- recovery excludes ineligible metadata and never invokes processors.
+
+### Deployment smoke tests
+
+- private worker rejects unauthenticated invocation;
+- queue-level host/path/method/OIDC overrides cannot be bypassed by task input;
+- runtime identities cannot invoke or read outside their matrix;
+- delivery HMAC cannot authenticate any admin route;
+- processor HMAC cannot authenticate a status or admin route;
+- a deliberate Fastly 403 stays pending and drains after credential repair;
+- secret rotation succeeds without a worker revision;
+- one transcript and one transcode reach terminal metadata end to end.
+
+## Runbook
+
+Create `docs/runbooks/derivative-status-delivery.md` containing exact,
+non-secret commands and expected output for:
+
+- health/readiness;
+- queue depth and pending age;
+- identifying credential failures safely;
+- pausing/resuming dispatch and consequences;
+- dual-secret rotation;
+- pending and dead inspection;
+- dead revalidation and replay as a new corrective operation;
+- reconciliation cursor inspection/reset with safety checks;
+- incident recovery dry-run/apply/verification;
+- transcript and transcode end-to-end validation;
+- rollback and backlog drain.
+
+## Design-review sources
+
+- Fastly KV generation markers support conditional writes and prevent lost
+  updates: <https://www.fastly.com/documentation/reference/api/services/resources/kv-store-item/>
+- The Fastly Rust insert builder exposes `if_generation_match`:
+  <https://docs.rs/fastly/latest/src/fastly/kv_store.rs.html>
+- Cloud Tasks treats non-2xx handler responses as failed attempts:
+  <https://docs.cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks>
+- Queue-level `ALWAYS` routing and OIDC overrides apply to all tasks:
+  <https://docs.cloud.google.com/tasks/docs/configuring-queues>
+- Cloud Run mounted secret volumes read the latest secret version:
+  <https://docs.cloud.google.com/run/docs/configuring/services/secrets>
 
 ## Success criteria
 
-- A five-minute Fastly or credential outage loses zero status events.
-- Restoring Fastly or the credential drains the backlog without
-  retranscoding.
-- Duplicate or out-of-order task delivery cannot regress metadata or multiply
-  attempt counters.
-- Secret rotation is observed by the delivery service without a new revision.
-- A task-creation outage is recovered by the GCS outbox reconciler.
-- Operators receive an alert within five minutes of a stuck backlog.
-- Direct `.vtt`/HLS artifact availability and Fastly metadata converge after
-  recovery.
+- A five-minute Fastly or credential outage loses zero events.
+- Repair drains the backlog without retranscoding.
+- Duplicate, concurrent, partial, and out-of-order delivery cannot regress
+  metadata or multiply counters.
+- Credential compromise is scoped to derivative status, not administration.
+- Secret rotation requires no worker deployment.
+- Task-creation failure is recovered by the outbox reconciler.
+- Operators receive a backlog signal within five minutes.
+- Incident-window artifacts and reviewed terminal failures converge through
+  the same normal event path.

--- a/docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-24
 **Issue:** divine-funnelcake#686
-**Status:** Design review, revision 2
+**Status:** Design review, revision 3
 
 ## Problem and baseline
 
@@ -169,10 +169,49 @@ all non-health routes require a dedicated `processor_request_secret` HMAC:
 - any future route that can start work or write an outbox event
 
 Fastly and the upload service sign the raw request body using a timestamped
-HMAC. The processor checks the signature in constant time, enforces a
-five-minute timestamp window, and rejects unsigned requests before parsing the
-body or allocating expensive work. CORS is limited to the required production
-origin and does not substitute for authentication.
+HMAC. The canonical preimage is:
+
+```text
+v1
+<uppercase HTTP method>
+<exact normalized path, with no query string>
+<unix timestamp seconds>
+<canonical UUIDv7 request ID>
+<lowercase hex SHA-256 of the raw body>
+```
+
+Callers send exactly one value for each of:
+
+- `X-Divine-Auth-Version: v1`
+- `X-Divine-Timestamp`
+- `X-Divine-Request-Id`
+- `X-Divine-Signature: <lowercase hex HMAC-SHA256>`
+
+Each route rejects query strings, duplicate auth headers, non-canonical
+encodings, timestamps outside five minutes, and signatures that fail a
+constant-time comparison. HMAC keys contain at least 256 random bits; missing,
+empty, short, or invalid keys fail readiness.
+
+Before buffering or parsing JSON, route-specific body limits apply:
+
+- `/transcode` and `/transcribe`: 8 KiB;
+- `/backfill-fmp4`: 8 KiB;
+- `/audio/extract`: 4 KiB.
+
+After authentication, the processor creates
+`processor-requests/<request_id>` in the private outbox bucket with
+`ifGenerationMatch=0` and a 24-hour lifecycle. The marker contains the method,
+path, body digest, and operation ID but no request body or credential. A
+pre-existing marker returns `409 replay_detected` without starting work.
+Trusted callers regenerate the timestamp, request ID, and signature for an
+intentional retry; they never retry a 409 with the same signed request.
+Because the signed digest binds the body, a captured request ID cannot
+authorize a different payload or route. The replay marker is created before
+expensive work or outbox publication.
+
+The processor checks the signature in constant time and rejects unsigned
+requests before parsing the body or allocating expensive work. CORS is limited
+to the required production origin and does not substitute for authentication.
 
 Existing per-hash transcript locking remains. Transcode receives the same
 idempotent in-progress lock to suppress trusted duplicate work.
@@ -181,6 +220,7 @@ idempotent in-progress lock to suppress trusted duplicate work.
 
 Add dedicated routes:
 
+- `POST /internal/derivative-status/v1/verify`
 - `POST /internal/derivative-status/v1/transcript`
 - `POST /internal/derivative-status/v1/transcode`
 
@@ -188,17 +228,31 @@ They accept only a new `derivative_status_secret` HMAC. This credential is not
 accepted by admin, moderation, delete, restore, dashboard, or legacy webhook
 routes. The current `webhook_secret` is never mounted in the delivery service.
 
+The verify route accepts a signed, bounded nonce body and performs no metadata
+mutation. It exists only for credential-rotation and deployment smoke tests
+and uses the same signature verifier and rate limit as the status routes.
+
 The delivery worker signs:
 
 ```text
 v1
+POST
+<exact normalized versioned path>
 <unix timestamp seconds>
-<raw request body bytes>
+<lowercase hex SHA-256 of raw request body bytes>
 ```
 
 It sends the timestamp and lowercase hex HMAC-SHA256 signature in dedicated
-headers. Fastly verifies the signature in constant time and allows at most five
-minutes of clock skew.
+headers:
+
+- `X-Divine-Auth-Version: v1`
+- `X-Divine-Timestamp: <unix seconds>`
+- `X-Divine-Signature: <lowercase hex HMAC-SHA256>`
+- `Content-Type: application/json`
+
+Fastly rejects query strings, duplicate auth headers, a derivative that does
+not match the selected route, and invalid encodings. It verifies the signature
+in constant time and allows at most five minutes of clock skew.
 
 The worker pins the exact HTTPS origin and route in configuration, disables
 redirects, uses a 3-second connect timeout and 10-second total timeout, and
@@ -215,7 +269,8 @@ Rotation order:
 
 1. Place the new value in Fastly's secondary slot.
 2. Add a new GCP secret version and make it latest.
-3. Deliver a signed smoke event and confirm the new credential is accepted.
+3. Call the non-mutating signed verify route and confirm the new credential is
+   accepted.
 4. Promote the new Fastly value to primary.
 5. Remove the old secondary value within one hour.
 6. Alert on any use of the retiring credential after promotion.
@@ -229,12 +284,13 @@ All service accounts are keyless.
 
 | Identity | Allowed operations |
 | --- | --- |
-| Processor runtime | Create pending outbox objects; create tasks in the one status queue |
-| Delivery runtime | Read/delete pending objects; create dead objects; access only `derivative_status_secret` |
+| Processor runtime | Create/read pending objects; create replay markers; create tasks in the one status queue; no list/delete |
+| Delivery runtime | Read/delete pending objects; create/read dead objects; access only `derivative_status_secret`; no list/task-create |
 | Reconciler runtime | List/read pending objects; create tasks; read/write reconciliation cursor |
 | Cloud Tasks OIDC identity | Invoke only `divine-status-delivery` |
 | Scheduler identity | Execute only `divine-status-reconciler` |
 | Cloud Tasks service agent | Mint tokens for the task OIDC identity as required by Google |
+| Recovery CLI identity | Read media artifact metadata and Fastly derivative status; create/read outbox events and tasks; no media-body read or delete |
 | Deployment identity | Manage declared resources and `actAs` only the identities needed during deployment |
 
 The queue uses queue-level `ALWAYS` overrides for HTTPS scheme, delivery host,
@@ -243,6 +299,12 @@ cannot choose a target or authentication identity. Only the deployment
 identity needs `iam.serviceAccounts.actAs` while configuring that override;
 task creators receive no impersonation role.
 
+These permissions are implemented as bucket/queue/service-scoped custom roles
+where predefined roles are broader than the table. Bucket access is reviewed
+quarterly. Structured operational logs are retained for 30 days; Sentry uses
+the project's restricted operational retention policy and stores only the
+sanitized fields defined here.
+
 ## Private outbox
 
 Use a dedicated private bucket with public-access prevention and uniform
@@ -250,19 +312,63 @@ bucket-level access. It contains no media:
 
 - `pending/<event_id>.json`
 - `dead/<event_id>.json`
+- `processor-requests/<request_id>`
 - `control/reconcile-cursor.json`
+- `control/reconcile-lease.json`
 
 Pending objects have no expiration lifecycle. Dead objects expire after 30
-days. Access is granted according to the IAM matrix rather than by relying on a
-textual prefix in the media bucket.
+days, and processor request markers expire after 24 hours. Unknown-schema and
+credential-failure pending objects remain until code/configuration is repaired
+or an operator explicitly classifies them. Access is granted according to the
+IAM matrix rather than by relying on a textual prefix in the media bucket.
 
 Pending creation uses `ifGenerationMatch=0`. If the same event already exists,
-the producer verifies that its bytes match; a mismatch is an integrity error.
+the producer uses its narrow read permission to verify that its canonical
+bytes match; a mismatch is an integrity error that fails publication and
+alerts.
 
 Successful cleanup deletes the exact generation read by the worker. Dead
 movement creates the dead object with `ifGenerationMatch=0` before deleting
 the matching pending generation. A crash at any boundary leaves at least one
 recoverable copy.
+
+## Producer publication state machine
+
+Every status transition uses the same steps:
+
+1. Construct and fully validate the canonical typed event.
+2. Create the immutable pending object.
+3. Create its deterministic Cloud Task with bounded client retries.
+4. Return publication success once the pending object is durable, even if task
+   creation failed; the reconciler owns the producer-to-queue gap.
+
+For the initial `processing` transition, failure to persist pending returns 503
+and the processor does not start expensive work. For `complete` or `failed`,
+failure to persist pending returns 503 even if compute or artifact upload
+already occurred; it is never converted to job success.
+
+An intentional caller retry uses a new signed request ID. Existing-artifact
+checks then publish `complete` without recomputation. Existing transcript and
+transcode locks prevent overlapping compute. A terminal failure that already
+has a durable pending event is not recreated within that operation; its
+deterministic event ID makes repeat publication idempotent.
+
+Outcomes:
+
+| Condition | Processor behavior |
+| --- | --- |
+| Event validation fails | Internal error; no pending/task; alert |
+| Pending create succeeds | Attempt task creation |
+| Matching pending object already exists | Treat pending as durable and attempt task creation |
+| Existing pending bytes differ | Integrity error; no work/success; alert |
+| Task creation succeeds or returns `AlreadyExists` | Continue/return normal processor result |
+| Task creation fails after bounded retries | Continue/return normal result because pending is durable; alert and reconcile |
+| Pending persistence fails before work | Return 503; do not start work |
+| Pending persistence fails after artifact/terminal result | Return 503; caller retries with a new signed request |
+
+The processor response distinguishes media result from delivery state with
+`status_delivery: queued|pending_reconciliation`. It never claims a status
+event was delivered to Fastly synchronously.
 
 ## Event contract
 
@@ -272,7 +378,7 @@ ID.
 ```json
 {
   "schema_version": 1,
-  "event_id": "018f6e33-c5af-7d82-a7b2-30f02e8f7e10",
+  "event_id": "018f6e33-c5af-5d82-a7b2-30f02e8f7e10",
   "sha256": "64 lowercase hex characters",
   "operation_id": "018f6e33-c5af-7b11-a2f7-7cf63d8a68ac",
   "operation_started_at_ms": 1784847000000,
@@ -286,7 +392,12 @@ ID.
     "language": "en",
     "duration_ms": 6100,
     "cue_count": 3,
-    "confidence": "high",
+    "transcript_confidence": {
+      "average_token_confidence": 0.91,
+      "average_logprob": -0.09,
+      "low_confidence_token_ratio": 0.02,
+      "token_count": 47
+    },
     "last_attempt_at_ms": 1784847001200
   }
 }
@@ -297,11 +408,89 @@ The Rust type is a tagged enum:
 - `DerivativeUpdate::Transcript(TranscriptUpdate)`
 - `DerivativeUpdate::Transcode(TranscodeUpdate)`
 
+The JSON uses `derivative` as the enum tag and `update` as its content.
+Unknown fields are rejected.
+
+### Transcript update
+
+`status` is exactly `pending`, `processing`, `complete`, or `failed`.
+
+| Field | Type and bound | Pending | Processing | Complete | Failed |
+| --- | --- | --- | --- | --- | --- |
+| `status` | enum | required | required | required | required |
+| `job_id` | string, 1–128 bytes | optional | optional | optional | optional |
+| `language` | ASCII BCP-47-shaped string, 1–35 bytes | optional | optional | optional | optional |
+| `duration_ms` | `u64`, max 86,400,000 | forbidden | forbidden | optional | forbidden |
+| `cue_count` | `u32`, max 1,000,000 | forbidden | forbidden | optional | forbidden |
+| `transcript_confidence` | object below | forbidden | forbidden | optional | forbidden |
+| `error_code` | safe identifier, 1–64 bytes | forbidden | forbidden | forbidden | required |
+| `error_message` | safe template text, max 2,048 bytes | forbidden | forbidden | forbidden | optional |
+| `retry_at_ms` | absolute Unix milliseconds | forbidden | forbidden | forbidden | optional |
+| `terminal` | boolean | forbidden | forbidden | forbidden | required |
+| `last_attempt_at_ms` | absolute Unix milliseconds | required | required | required | required |
+
+`transcript_confidence` contains exactly:
+
+- `average_token_confidence`: finite `f64` in `0.0..=1.0`;
+- `average_logprob`: finite `f64` in `-100.0..=0.0`;
+- `low_confidence_token_ratio`: finite `f64` in `0.0..=1.0`;
+- `token_count`: `u32` in `1..=10_000_000`.
+
+Blob assignments are:
+
+- pending/processing: assign status and event timestamps; do not change the
+  attempt counter;
+- complete: assign status, clear errors/retry/terminal, and reset the blob
+  transcript attempt counter to zero;
+- failed: assign status/error/retry/terminal and set the blob transcript
+  attempt counter to `max(current, attempt_number)`.
+
+When `job_id` is present, the subtitle-job effect is required. Complete assigns
+`Ready`, the stable VTT URL, and supplied language/duration/cue values, clears
+error/retry fields, and preserves the job's attempt count. Failed assigns
+`Failed`, safe error/retry fields, and sets the job attempt count to
+`max(current, attempt_number)`. Pending and processing assign only their
+corresponding job status and update timestamp.
+
+When `job_id` is absent, no subtitle-job or hash-to-job effect is attempted.
+The handler never guesses a job through the hash mapping.
+
+### Transcode update
+
+`status` is exactly `pending`, `processing`, `complete`, or `failed`.
+
+| Field | Type and bound | Pending | Processing | Complete | Failed |
+| --- | --- | --- | --- | --- | --- |
+| `status` | enum | required | required | required | required |
+| `new_size` | `u64`, max 53,687,091,200 | forbidden | forbidden | optional | forbidden |
+| `display_width` | `u32`, 1–16,384; paired with height | forbidden | forbidden | optional | forbidden |
+| `display_height` | `u32`, 1–16,384; paired with width | forbidden | forbidden | optional | forbidden |
+| `error_code` | safe identifier, 1–64 bytes | forbidden | forbidden | forbidden | required |
+| `error_message` | safe template text, max 2,048 bytes | forbidden | forbidden | forbidden | optional |
+| `retry_at_ms` | absolute Unix milliseconds | forbidden | forbidden | forbidden | optional |
+| `terminal` | boolean | forbidden | forbidden | forbidden | required |
+| `last_attempt_at_ms` | absolute Unix milliseconds | required | required | required | required |
+
+Assignments mirror transcript blob assignments: pending/processing preserve
+the counter, complete clears failure state and resets the transcode attempt
+counter to zero, and failed sets the counter to
+`max(current, attempt_number)`. Width and height are either both absent or
+both present; when present Fastly stores the canonical `WIDTHxHEIGHT` value.
+
+### Safe errors
+
+`error_message` is produced only by an allowlisted `error_code` → user-safe
+template mapping. Raw provider bodies, FFmpeg stderr, signed URLs, filesystem
+paths, user-controlled text, and exception chains are never persisted in
+events, public metadata, structured logs, Sentry, or dead records. Diagnostic
+telemetry records bounded error class, provider status, and timeout flags
+instead.
+
 Shared validation:
 
 - body and outbox object at most 32 KiB;
 - schema version exactly 1;
-- canonical UUIDv7 event and operation IDs;
+- canonical deterministic UUIDv5 event ID and UUIDv7 operation ID;
 - SHA-256 exactly 64 lowercase hex characters;
 - operation timestamp agrees with the UUIDv7 timestamp within one second;
 - created time is not before operation start or more than ten minutes in the
@@ -315,6 +504,9 @@ Shared validation:
 - language is at most 35 ASCII characters;
 - cue count, duration, dimensions, size, and absolute retry time use bounded
   unsigned integers;
+- `last_attempt_at_ms` falls between operation start and event creation;
+- `retry_at_ms`, when present, falls between event creation and seven days
+  after event creation;
 - fields forbidden for a given derivative or status are rejected.
 
 Status timestamps and retry times are absolute event values. Fastly does not
@@ -325,7 +517,7 @@ other credential.
 The delivery task request is:
 
 ```json
-{"event_id":"canonical UUIDv7"}
+{"event_id":"canonical UUIDv5"}
 ```
 
 with `Content-Type: application/json` and a maximum body of 128 bytes.
@@ -348,9 +540,16 @@ The UUID tie-breaker handles operations started in the same millisecond. The
 trusted producer timestamp, UUID agreement check, future-skew bound, and HMAC
 prevent future-dated replay poisoning.
 
-Replaying the same event preserves its event ID and ordering coordinates. A
-human corrective action creates a new recovery operation so it intentionally
-supersedes prior state.
+For identical operation ordering fields and sequence:
+
+- the same event ID plus the same canonical event digest is a duplicate;
+- a different event ID or different digest is `integrity_conflict`, causes no
+  mutation, returns 409, and raises a high-severity alert.
+
+The producer derives one deterministic event ID from operation ID and sequence,
+so a correct producer cannot create this conflict. Replaying the same event
+preserves its event ID and ordering coordinates. A human corrective action
+creates a new recovery operation so it intentionally supersedes prior state.
 
 ## Fastly durable-apply protocol
 
@@ -364,7 +563,8 @@ has succeeded:
   "event_id": "uuid",
   "outcome": "applied|duplicate|stale",
   "blob_effect": "applied|already_applied",
-  "job_effect": "not_required|applied|already_applied"
+  "job_effect": "not_required|applied|already_applied",
+  "mapping_effect": "not_required|applied|already_applied"
 }
 ```
 
@@ -372,13 +572,23 @@ Missing blob metadata returns `409 metadata_not_ready`, not 202. If a transcript
 event names a subtitle job that does not yet exist, it returns
 `409 job_not_ready`. Both are retryable.
 
+Errors use one bounded response type:
+
+```json
+{"error":"metadata_not_ready|job_not_ready|validation_failed|integrity_conflict|conflict_exhausted|internal"}
+```
+
 Invalid bodies or signatures return minimal generic errors without parser,
-storage, secret, or upstream details.
+storage, secret, or upstream details. A mixed result aggregates as `applied`
+when any required record applied the event, `duplicate` when every required
+record already applied it, and `stale` when every required record is stale.
+Conflicting mixed ordering is an integrity error rather than success.
 
 ### Generation-matched writes
 
-Add an optional serde-defaulted delivery watermark to both `BlobMetadata` and
-`SubtitleJob`:
+Add separate optional serde-defaulted transcript and transcode watermarks to
+`BlobMetadata`, plus a transcript watermark to `SubtitleJob` and the typed
+hash-to-job mapping record. Each watermark contains:
 
 - operation ordering fields;
 - last sequence;
@@ -387,11 +597,20 @@ Add an optional serde-defaulted delivery watermark to both `BlobMetadata` and
 Webhook paths bypass the five-minute POP-local metadata cache. They read the KV
 value and generation marker, run the pure transition decision, then write with
 `if_generation_match`. A precondition failure reloads and retries up to five
-times before returning a retryable conflict.
+times before returning `409 conflict_exhausted`.
 
-Every existing writer of transcript or transcode status is routed through the
-same generation-aware helper or explicitly creates a newer operation. No
-status writer may perform an unconditional full-record overwrite.
+Because BlobMetadata and SubtitleJob are full-record KV values, **every**
+mutation of an existing record—not only derivative status—moves to a shared
+generation-aware read/modify/write helper with bounded conflict retries. This
+includes upload completion, moderation, delete/restore, backfill, repair,
+manual transcript controls, subtitle dispatch, and admin paths. Unconditional
+full-record writes remain available only for create-with-no-existing-record
+using add semantics. Compile-visible APIs and an inventory test prevent a
+caller from bypassing the helper.
+
+Concurrency tests race delivery against moderation, deletion, upload repair,
+backfill, forced subtitle jobs, and subtitle dispatch to prove unrelated fields
+and watermarks are preserved.
 
 ### Multi-effect retries
 
@@ -402,13 +621,20 @@ For every attempt, Fastly:
 
 1. Applies or confirms the blob effect with CAS.
 2. Applies or confirms the subtitle-job effect with CAS when required.
-3. Refreshes the hash-to-job mapping idempotently.
+3. When `job_id` is present, applies or confirms a typed hash-to-job mapping
+   record with its own transcript watermark and generation-matched write.
 4. Issues the required cache purges.
 5. Returns the structured 200 response.
 
 A duplicate blob effect does not short-circuit later effects. Therefore a
 retry after a partial failure can finish the subtitle job and purges without
 incrementing attempt counters or regressing blob state.
+
+The event's explicit `job_id` is authoritative. A stale event cannot repoint
+the hash mapping because the mapping applies the same total-order decision.
+Forced replacement with a newer operation wins; a late completion for the old
+job is stale for the mapping while remaining independently classifiable for
+that old job record.
 
 Failure counters are changed inside the CAS transition only when that record's
 watermark has not already accepted the event. Completion and failure updates
@@ -433,6 +659,14 @@ Provision one `derivative-status-delivery` queue in the delivery region:
 - maximum dispatch rate: 20 per second;
 - queue-level routing and OIDC overrides enforced with mode `ALWAYS`.
 
+The queue overrides scheme, host, path, empty query, POST method,
+`Content-Type: application/json`, OIDC service account, and audience.
+Task creators supply only the deterministic name and bounded body—no URL,
+query, authentication, or caller-selected headers. The delivery service
+rejects a non-empty query, unexpected content type, oversized body, duplicate
+content-type, or unknown JSON field. Cloud Tasks informational headers are
+logged only as bounded delivery metadata and are never treated as identity.
+
 Task names derive from event IDs. Cloud Tasks may retain a deleted task name
 for up to 24 hours; `AlreadyExists` means "currently queued or still
 tombstoned", not proof of delivery. The GCS pending object remains the source
@@ -445,11 +679,14 @@ The worker handles:
 | Condition | Task response and outbox action |
 | --- | --- |
 | Pending missing, dead missing | 204; already delivered/cleaned |
-| Dead exists | 204; already classified |
+| Dead exists, pending missing | Verify dead event ID/digest, then 204 |
+| Matching dead and pending both exist | Delete exact pending generation, then 204 |
+| Dead/pending event ID or digest mismatch | 503; mutate neither; integrity alert |
 | Pending read or secret read failure | 503; retain and retry |
 | Unknown schema version | 503; retain and alert deployment skew |
 | Structurally corrupt known-version event | Create dead, delete pending generation, 204 |
-| Fastly applied/duplicate/stale response | Delete pending generation, 204 |
+| Valid Fastly applied/duplicate/stale response | Delete pending generation, 204 |
+| Malformed, oversized, mismatched, or unexpected Fastly 2xx | 503; retain and alert |
 | Fastly 401/403 | 503; retain, high-severity credential alert |
 | Fastly 409/408/425/429/5xx or network error | 503; retain and retry |
 | Other Fastly 4xx | Create dead, delete pending generation, 204 |
@@ -459,14 +696,23 @@ Dead records contain the original sanitized event, classification, upstream
 status code when present, first/last attempt timestamps, and no response body
 or credential.
 
+Before deletion, the worker parses the bounded Fastly response, verifies the
+exact schema, echoed event ID, aggregate outcome, and every required effect.
+It retains the pending record on any mismatch. A dead-object create conflict
+also requires matching event ID and canonical digest before pending cleanup.
+
 The service reuses one HTTP client. Liveness proves the process is running.
 Readiness verifies outbox access, secret-file readability, fixed target
 configuration, and service mode without calling Fastly.
 
 ## Reconciliation job
 
-Cloud Scheduler starts a Cloud Run Job once per minute. Cloud Run permits only
-one concurrent execution.
+Cloud Scheduler requests a Cloud Run Job once per minute. The job first
+acquires `control/reconcile-lease.json` with a generation-matched write. The
+lease records execution ID and expiry; a live lease makes a duplicate
+Scheduler invocation exit successfully without scanning. A crashed execution
+can be reclaimed after ten minutes using generation match. Correctness does
+not depend on Cloud Run preventing overlapping executions.
 
 The job stores the next GCS page token and cycle start time in
 `control/reconcile-cursor.json` using a generation-match update. It advances
@@ -474,17 +720,27 @@ the cursor after every scanned page even when records on that page already
 have tasks or are temporarily failing. At end-of-list it records cycle
 completion and resets the cursor.
 
+An invalid or expired GCS page token is recorded, then the cursor is reset with
+generation match and a new full cycle starts. A per-record task-create failure
+does not pin the page: the job logs it, advances, and the next full cycle
+retries that pending object.
+
 Each execution stops after eight minutes or 5,000 records, whichever comes
 first. The next execution resumes from the persisted cursor. Tests cover a
 backlog larger than one page, a permanently failing first page, cursor CAS
-conflicts, a crash before and after cursor advancement, and full-cycle reset.
+conflicts, lease contention/expiry, invalid cursor recovery, a crash before
+and after cursor advancement, and full-cycle reset.
 
 For every pending object older than two minutes, it creates the deterministic
 task. `AlreadyExists` is recorded and scanning continues.
 
 ## Incident recovery tool
 
-Provide a checked-in admin CLI with `discover`, `plan`, and `apply` phases.
+Provide a checked-in admin CLI using the recovery identity from the IAM table.
+It emits canonical JSON with `schema_version`, `recovery_run_id`, creation
+time, source evidence, ordered entries, and a SHA-256 manifest digest.
+
+Artifact recovery has `discover`, `plan`, `apply`, and `verify` phases.
 
 `discover`:
 
@@ -499,18 +755,35 @@ Provide a checked-in admin CLI with `discover`, `plan`, and `apply` phases.
 - validates every hash and current Fastly metadata response;
 - excludes absent, deleted, or otherwise ineligible blob metadata;
 - shows counts by derivative and desired status;
-- creates deterministic event IDs within one recovery run.
+- creates one UUIDv7 recovery operation and deterministic UUIDv5 event IDs;
+- writes a plan containing the source-manifest digest.
 
 `apply`:
 
 - requires the reviewed manifest and an explicit confirmation flag;
+- refuses a plan whose source digest or canonical bytes changed after review;
 - creates new recovery operations using the normal typed outbox publisher;
 - never calls the processor or retranscodes media;
 - is idempotent when rerun with the same manifest.
 
-Verification reports artifact count, planned count, applied count, remaining
+`verify` reports artifact count, planned count, applied count, remaining
 stale count, and terminal retry suppression. The current incident's known
 invalid-media hash is supplied through the reviewed manifest, not hardcoded.
+
+Dead-letter operations are separate:
+
+- `dead list` shows bounded IDs, classifications, ages, and derivatives;
+- `dead inspect <event_id>` validates and prints a redacted canonical record;
+- `dead plan-replay <event_id>` requires an operator-supplied correction and
+  creates a new recovery operation rather than changing the immutable event;
+- `dead apply-replay <reviewed-plan> --confirm` binds to the plan digest,
+  publishes the corrective event, and leaves the original dead record for its
+  30-day audit retention;
+- `dead verify-replay` confirms the corrective event reached Fastly.
+
+CLI output is machine-readable JSON by default. Mutation commands require the
+dedicated recovery identity, explicit project/bucket inputs, a reviewed plan
+digest, and `--confirm`; discovery and planning never mutate cloud state.
 
 ## Deployment order
 
@@ -522,21 +795,32 @@ invalid-media hash is supplied through the reviewed manifest, not hardcoded.
    identities/IAM, private worker, reconciliation job, metrics, and alerts.
 4. Deploy the delivery worker and test unauthenticated rejection, task OIDC,
    HMAC overlap, retry, dead-letter, CAS conflict, and secret rotation.
-5. Add processor HMAC verification and update both trusted callers before
-   rejecting unsigned requests.
-6. Deploy queue-first producer support disabled, then enable it for a 10%
-   deterministic hash canary for 24 hours.
-7. Enable all transcript and transcode status events if canary criteria pass.
+5. Add processor HMAC verification in dual-accept mode. Inventory and update
+   every caller before rejection becomes mandatory: Fastly on-demand
+   transcript/transcode paths, `cloud-run-upload`, `backfill.sh`,
+   `backfill-prioritized.sh`, incident recovery tooling, and any documented
+   operator command. Verify each caller, then reject unsigned requests.
+6. Deploy queue-first producer support disabled and run controlled synthetic
+   transcript/transcode canaries through the complete production queue and
+   Fastly path for 24 hours.
+7. Enable queue-first publication atomically for all real transcript and
+   transcode status events if canary criteria pass.
 8. Disable legacy status endpoints and observe for seven days.
 9. Run incident recovery in dry-run, review its manifest, apply it, and verify
    convergence.
 10. Remove old shared status-sender code after fourteen stable days.
 
-Rollback pauses producer publication but does not delete pending/dead objects.
-The worker and reconciler continue until pending is empty. If the new Fastly
-route is the fault, pause queue dispatch, roll back Fastly atomically, correct
-the route, and resume; never switch queued producers to unordered direct
-delivery.
+Rollback never disables immutable outbox persistence while processors accept
+work. Depending on the faulty layer it either:
+
+- pauses processor admissions and lets in-flight operations persist their
+  final events; or
+- keeps processor publication active while pausing only queue dispatch.
+
+Pending/dead objects are never deleted by rollback. If the new Fastly route is
+the fault, pause queue dispatch, keep outbox publication active, roll back
+Fastly atomically, correct the route, and resume. Never switch queued
+producers to unordered direct delivery.
 
 ## Observability and alerts
 
@@ -566,6 +850,13 @@ Measure:
 - artifact-to-terminal-metadata convergence latency;
 - duplicate processor suppression.
 
+The rollout baseline is the previous seven complete days at the same
+five-minute interval. For a new queue with no history, baseline means zero
+pending events older than two minutes and queue depth returning to zero between
+normal bursts. "Dependencies healthy" means worker readiness passes, the
+non-mutating Fastly verify route succeeds, GCS/Cloud Tasks API error rate is
+below 1%, and no platform incident is declared.
+
 Alert policies:
 
 - pending or oldest-task age reaches four minutes, evaluated every minute;
@@ -574,8 +865,9 @@ Alert policies:
 - enqueue or reconciliation failures;
 - queue depth grows for fifteen minutes;
 - CAS retries exhaust;
-- unsigned processor-route attempts exceed a conservative threshold;
-- processor cost or request rate deviates materially from baseline.
+- unsigned processor-route attempts exceed 10 per minute for five minutes;
+- processor request rate or cost exceeds 2× the same-interval seven-day
+  baseline for fifteen minutes.
 
 Sentry fingerprints include service, derivative, and failure class so provider,
 FFmpeg, delivery, and user-invalid-media events cannot collapse into one
@@ -618,6 +910,42 @@ During a prolonged dependency outage, artifacts may be directly retrievable
 while metadata remains pending. The pending event remains durable, the
 operator is alerted, and recovery occurs automatically after service returns.
 
+## Coverage gate
+
+The scaffolded root coverage command does not include
+`cloud-run-transcoder`, which is excluded from the root workspace. Before the
+first implementation commit, replace it with a checked-in
+`scripts/check-derivative-status-coverage.sh` and point
+`.coverage-thresholds.json` plus CI at that script.
+
+Put all new domain behavior in a native `derivative-status-core` crate shared
+by Fastly and Cloud Run. Put publisher, worker, reconciler, router, and adapter
+orchestration in a `cloud-run-transcoder/status-delivery` library crate; its
+delivery and reconciliation binaries are thin entry points. The existing
+processor calls the covered publisher API.
+
+The script runs:
+
+```bash
+cargo llvm-cov \
+  --manifest-path derivative-status-core/Cargo.toml \
+  --all-targets --all-features \
+  --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100
+
+cargo llvm-cov \
+  --manifest-path cloud-run-transcoder/status-delivery/Cargo.toml \
+  --all-targets --all-features \
+  --fail-under-lines 100 --fail-under-functions 100 --fail-under-regions 100
+```
+
+The first command covers event validation, ordering, transition, response, and
+CAS-retry decisions. The second covers every publisher, delivery, outbox,
+queue, reconciliation, HTTP, and binary branch through injected adapters.
+Thin Fastly and processor wiring is additionally exercised by their existing
+crate tests and deployment contract tests. CI installs the pinned
+`cargo-llvm-cov` version and treats either command or any integration test
+failure as blocking.
+
 ## Testing strategy
 
 Every implementation slice begins with a failing native test.
@@ -642,12 +970,19 @@ generation-matched writes.
 - partial blob success followed by job failure completes on retry;
 - missing blob/job returns retryable 409;
 - cache purge is retried after durable effects;
-- every existing derivative-status writer uses the generation-aware path.
+- transcript and transcode use independent blob watermarks;
+- forced hash-to-job replacement rejects a late old-job event;
+- moderation/delete/upload/backfill/subtitle-dispatch races preserve all
+  unrelated fields and delivery watermarks;
+- every existing full-record writer uses the generation-aware path.
 
 ### Processor and publisher tests
 
 - unsigned, stale, malformed, and wrong-secret processor requests are rejected
   before work;
+- captured signatures cannot replay across method/path/body/request ID;
+- replay markers reject repeated expensive work and expire after 24 hours;
+- pre-authentication body limits reject oversized requests;
 - current and overlap secrets are accepted;
 - pending persistence precedes task creation;
 - pending create conflict requires byte equality;
@@ -663,9 +998,11 @@ Use injected in-memory outbox/secret providers and a local HTTP server.
 - all state-machine rows above;
 - redirects are rejected;
 - response and timeout bounds;
+- mismatched or malformed successful responses retain pending;
 - HMAC current/secondary rotation;
 - success plus cleanup failure retries safely;
 - dead create-before-delete generation ordering;
+- both-present dead/pending cleanup and mismatch protection;
 - missing pending is acknowledged;
 - unknown schema remains pending.
 

--- a/docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md
@@ -1,0 +1,396 @@
+# Durable Derivative Status Delivery Design
+
+**Date:** 2026-07-24
+**Issue:** divine-funnelcake#686
+**Status:** Approved for implementation planning
+
+## Problem
+
+The Cloud Run transcoder currently sends transcript and HLS status updates to
+Fastly as fire-and-forget HTTP requests. A non-2xx response is logged, but the
+job continues and the update is permanently lost.
+
+On 2026-07-22 and 2026-07-23, Fastly rejected these callbacks with
+`403 Invalid webhook secret`. Transcript and HLS artifacts continued to be
+written to GCS, but Fastly KV metadata remained stale. Terminal invalid-media
+failures were also lost, causing the same corrupt source to be retried and
+reported repeatedly.
+
+The reliability boundary must therefore be the status event itself, not the
+duration of one Cloud Run request.
+
+## Goals
+
+- Deliver every transcript and HLS status update eventually.
+- Survive temporary network, Fastly, credential, and Cloud Tasks failures.
+- Make duplicate and out-of-order deliveries harmless.
+- Allow webhook-secret rotation without redeploying the delivery service.
+- Make a stuck delivery backlog visible within five minutes.
+- Recover existing or future orphaned events without retranscoding media.
+- Keep the solution specific to derivative status delivery rather than
+  introducing a general event platform.
+
+## Non-goals
+
+- Replacing Fastly KV as the public metadata store.
+- Replacing the existing transcription or HLS processing pipelines.
+- Building a reusable company-wide event bus.
+- Providing strict FIFO ordering from Cloud Tasks.
+- Deploying or rotating production secrets as part of the code change.
+
+## Architecture
+
+The transcoder image will support two service modes:
+
+- `processor` (default): the existing public `divine-transcoder` service.
+- `delivery`: a private `divine-status-delivery` Cloud Run service exposing
+  only health, task delivery, and reconciliation routes.
+
+The services use the same image and Rust event types. They are separate Cloud
+Run services because the existing transcoder is publicly invokable. Keeping
+the delivery service private lets Cloud Run IAM authenticate Cloud Tasks and
+Cloud Scheduler OIDC tokens without bespoke JWT validation in application
+code.
+
+```text
+Transcript or HLS processor
+  -> write immutable pending event to GCS
+  -> create deterministic Cloud Task
+  -> finish the processing request
+
+Cloud Tasks (OIDC)
+  -> private divine-status-delivery service
+  -> load pending event from GCS
+  -> read the current webhook secret from a mounted secret volume
+  -> POST the existing payload to Fastly
+  -> on Fastly 2xx, delete the pending event and acknowledge the task
+  -> otherwise retain the event and retry or dead-letter it
+
+Cloud Scheduler (OIDC, once per minute)
+  -> reconciliation route
+  -> find old pending events
+  -> recreate missing deterministic tasks
+```
+
+## Components
+
+### Shared status-delivery module
+
+Create a focused module under `cloud-run-transcoder/src/` that owns:
+
+- the versioned `StatusEvent` wire type;
+- event validation;
+- deterministic GCS object and Cloud Task names;
+- outbox persistence;
+- Cloud Tasks creation;
+- delivery response classification;
+- reconciliation decisions.
+
+Provider transcription retries and derivative status-delivery retries remain
+separate concerns.
+
+### GCS outbox
+
+Use the existing media bucket with dedicated internal prefixes:
+
+- `status-outbox/pending/<event_id>.json`
+- `status-outbox/dead/<event_id>.json`
+
+An event is written to `pending` before task creation. If Cloud Tasks creation
+fails, the processing request does not lose the event; the reconciler can
+create the task later.
+
+Pending records remain until Fastly accepts them. Permanently malformed events
+move to `dead` with the delivery classification and timestamp. Dead records
+are retained for operator inspection and alerting and must not contain
+secrets.
+
+GCS is already a required dependency of the processor and is strongly
+consistent for object reads and listings. The outbox adds no new datastore.
+
+### Cloud Tasks queue
+
+Provision one regional queue, `derivative-status-delivery`, in the same region
+as the delivery service.
+
+Initial queue policy:
+
+- minimum retry backoff: 5 seconds;
+- maximum retry backoff: 15 minutes;
+- exponential backoff;
+- no small maximum-attempt cutoff;
+- dispatch deadline: 30 seconds;
+- maximum concurrent dispatches: 10;
+- maximum dispatch rate: 20 per second.
+
+Cloud Tasks invokes the private delivery service using a dedicated service
+account with only `roles/run.invoker` on that service. The processor service
+account receives only the permission needed to create tasks in this queue.
+
+A task body contains only `event_id`. Task names are derived from the event ID,
+so a producer or reconciler may safely repeat task creation. `AlreadyExists`
+is treated as success.
+
+### Private delivery service
+
+The delivery service exposes:
+
+- `GET /health`
+- `POST /internal/status-events/deliver`
+- `POST /internal/status-events/reconcile`
+
+The service is not granted `allUsers` invocation. Cloud Run IAM rejects
+unauthenticated requests before application code runs.
+
+The webhook secret is mounted from Secret Manager as a `latest` version file
+and read for each delivery. Cloud Run secret volumes fetch the latest value
+when read, so secret rotation does not require a new revision. The secret is
+never copied into a Cloud Task or GCS event.
+
+The delivery service sends the existing bearer-authenticated payload to one of
+the two existing Fastly routes:
+
+- `/admin/transcode-status`
+- `/admin/transcript-status`
+
+It returns 2xx to Cloud Tasks only after Fastly accepts the event or the event
+has been safely dead-lettered.
+
+### Reconciler
+
+Cloud Scheduler invokes reconciliation once per minute using a second service
+account with `roles/run.invoker` on the private delivery service.
+
+The reconciler lists pending records older than two minutes and recreates
+their deterministic tasks. It processes a bounded page per invocation and
+logs the continuation state. Duplicate task creation and duplicate delivery
+are safe.
+
+This is recovery for the producer-to-queue gap and task expiry; it is not a
+second primary delivery mechanism.
+
+## Event contract
+
+```json
+{
+  "schema_version": 1,
+  "event_id": "uuid",
+  "derivative": "transcript",
+  "sha256": "64 lowercase hex characters",
+  "operation_id": "uuid",
+  "operation_started_at_ms": 1784847000000,
+  "sequence": 2,
+  "created_at_ms": 1784847001234,
+  "status": "complete",
+  "payload": {
+    "sha256": "64 lowercase hex characters",
+    "status": "complete"
+  }
+}
+```
+
+`derivative` is `transcript` or `transcode`. The payload retains all existing
+fields, including transcript `job_id`, language, duration, cue count, error
+details, retry timing, dimensions, and terminal status.
+
+Each processor invocation creates a unique `operation_id` and increasing
+sequence numbers for its status events. `job_id` remains a product-facing
+subtitle-job identifier and is not reused as a delivery identifier.
+
+Events contain no media bytes, transcript text, owner keys, credentials, or
+other secrets.
+
+## Idempotency and ordering
+
+Cloud Tasks provides at-least-once delivery, not strict FIFO ordering. Fastly
+therefore stores a delivery watermark independently for transcript and
+transcode metadata:
+
+- last operation start time;
+- last operation ID;
+- last accepted sequence;
+- last event ID.
+
+Fastly applies an event when:
+
+- its operation start time is newer than the stored operation; or
+- it belongs to the stored operation and has a higher sequence.
+
+Fastly acknowledges without mutation when:
+
+- the event ID is a duplicate;
+- the operation is older; or
+- the sequence has already been applied.
+
+This check happens before changing status, incrementing attempt counts,
+updating subtitle jobs, or purging caches. Consequently:
+
+- duplicate failures increment attempt counters once;
+- delayed `processing` events cannot regress a completed operation;
+- a later explicit retry operation may advance a previous terminal state.
+
+The handler returns 200 for duplicate and stale events so Cloud Tasks stops
+retrying them.
+
+## Failure classification
+
+Delivery results are handled as follows:
+
+| Result | Action |
+| --- | --- |
+| Fastly 2xx | Delete pending record and acknowledge task |
+| Network error | Retain pending record and retry |
+| 401, 403 | Retain, alert as credential failure, and retry |
+| 404 | Retain and retry because metadata creation can race delivery |
+| 408, 409, 425, 429 | Retain and retry |
+| 5xx | Retain and retry |
+| Structurally invalid event before dispatch | Move to `dead` and alert |
+| Other permanent Fastly 4xx | Move to `dead` and alert with sanitized response metadata |
+
+The delivery service maps retryable upstream results to a non-2xx task-handler
+response. It records the actual upstream status in structured logs and
+metrics.
+
+If deleting the pending event fails after Fastly accepted it, the task is
+retried. Fastly idempotency makes the duplicate harmless, and the next attempt
+can finish cleanup.
+
+## Producer behavior
+
+Replace both direct webhook functions with a shared queue-first publisher.
+
+For every status transition:
+
+1. Build and validate the status event.
+2. Persist the pending GCS record.
+3. Attempt deterministic task creation with short bounded client retries.
+4. Return success once either task creation succeeds or the durable pending
+   record is confirmed.
+
+The media operation does not wait for Fastly delivery.
+
+If the pending record itself cannot be persisted, return an error and capture
+a focused Sentry event. A retried media request remains cheap after successful
+artifact creation because existing GCS artifact checks emit `complete`
+without recomputing the derivative.
+
+## Observability
+
+Structured logs and metrics include:
+
+- event ID, derivative, hash, operation ID, and sequence;
+- enqueue outcome and latency;
+- delivery attempt count and latency;
+- sanitized Fastly response status;
+- pending outbox age and count;
+- dead-letter count;
+- reconciliation scanned, recreated, skipped, and failed counts.
+
+Never log authorization headers, secret values, transcript content, media
+bytes, or full external response bodies.
+
+Create alerts for:
+
+- oldest pending event greater than five minutes;
+- any sustained 401/403 delivery response;
+- any dead-letter event;
+- task creation failures;
+- reconciler failures;
+- queue depth growing for fifteen minutes.
+
+Sentry fingerprints must identify the service and failure class rather than
+grouping all provider and delivery errors together.
+
+## Testing
+
+### Native unit tests
+
+- Event serialization and validation for both derivative types.
+- Deterministic event object and task naming.
+- Retryable versus permanent response classification.
+- Operation/sequence watermark comparisons.
+- Duplicate failures do not increment attempt counts.
+- Newer operations may advance terminal state.
+- Older and duplicate events return success without mutation.
+
+### Service tests
+
+Use a local HTTP test server and injected outbox/task/webhook clients to prove:
+
+- pending persistence happens before task creation;
+- task-creation failure leaves a recoverable pending event;
+- Fastly 403 retains the event and returns a retryable task response;
+- Fastly 200 deletes the pending event;
+- cleanup failure causes a safe duplicate retry;
+- malformed events move to the dead prefix;
+- reconciliation recreates deterministic missing tasks;
+- `AlreadyExists` is successful reconciliation.
+
+### Integration and deployment validation
+
+- Run the transcoder test suite and clippy.
+- Deploy the private delivery service before enabling producers.
+- Submit a synthetic non-media status event against a controlled test
+  metadata record.
+- Verify OIDC invocation succeeds and unauthenticated invocation is rejected.
+- Verify a deliberately rejected callback remains pending and retries.
+- Correct the test credential and verify the queued event drains without
+  recreation.
+- Enable queue-first publishing for a small canary, then for all status events.
+
+## Rollout and recovery
+
+1. Provision the queue, service accounts, IAM, secret volume, Scheduler job,
+   dashboards, and alerts.
+2. Deploy the same image in private `delivery` mode.
+3. Run authentication, retry, and secret-rotation smoke tests.
+4. Deploy processor support with queue publishing disabled.
+5. Enable queue-first publishing for transcript and transcode events.
+6. Confirm pending age remains below five minutes and Fastly metadata reaches
+   terminal states.
+7. Reconcile existing VTT artifacts and terminal invalid-media failures from
+   the incident window.
+
+The initial release may retain the direct sender behind an emergency
+configuration switch, marked `TODO(#686)` and disabled by default. Remove the
+switch after the queued path has completed a stable observation period.
+
+Rollback disables new queue publishing but does not delete pending or dead
+records. The delivery service and reconciler remain active until the backlog
+is empty.
+
+## Operational runbook requirements
+
+Document:
+
+- how to inspect queue depth and oldest pending-event age;
+- how to identify 401/403 delivery failures without reading secrets;
+- how to synchronize or rotate the GCP and Fastly webhook secret safely;
+- how to replay pending and dead events;
+- how to pause and resume queue dispatch;
+- how to validate one transcript and one HLS transition end to end;
+- how to reconcile artifacts after a prolonged outage.
+
+## Security
+
+- The delivery service is private and OIDC-authenticated by Cloud Run IAM.
+- Producer, task-invoker, and scheduler service accounts have separate,
+  least-privilege roles.
+- The Fastly secret exists only in Secret Manager, its mounted volume, and the
+  outbound authorization header.
+- Outbox events are operational metadata only and use bucket IAM already
+  restricted to service identities.
+- Logs and alerts use IDs and status codes, never credentials or user media.
+
+## Success criteria
+
+- A five-minute Fastly or credential outage loses zero status events.
+- Restoring Fastly or the credential drains the backlog without
+  retranscoding.
+- Duplicate or out-of-order task delivery cannot regress metadata or multiply
+  attempt counters.
+- Secret rotation is observed by the delivery service without a new revision.
+- A task-creation outage is recovered by the GCS outbox reconciler.
+- Operators receive an alert within five minutes of a stuck backlog.
+- Direct `.vtt`/HLS artifact availability and Fastly metadata converge after
+  recovery.

--- a/docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md
+++ b/docs/superpowers/specs/2026-07-24-durable-derivative-status-delivery-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-24
 **Issue:** divine-funnelcake#686
-**Status:** Design review, revision 3
+**Status:** Approved
 
 ## Problem and baseline
 
@@ -198,10 +198,10 @@ Before buffering or parsing JSON, route-specific body limits apply:
 - `/backfill-fmp4`: 8 KiB;
 - `/audio/extract`: 4 KiB.
 
-After authentication, the processor creates
-`processor-requests/<request_id>` in the private outbox bucket with
-`ifGenerationMatch=0` and a 24-hour lifecycle. The marker contains the method,
-path, body digest, and operation ID but no request body or credential. A
+After authentication, the processor creates `<request_id>` in the private
+processor-replay bucket with `ifGenerationMatch=0` and a 24-hour lifecycle.
+The marker contains the method, path, body digest, and operation ID but no
+request body or credential. A
 pre-existing marker returns `409 replay_detected` without starting work.
 Trusted callers regenerate the timestamp, request ID, and signature for an
 intentional retry; they never retry a 409 with the same signed request.
@@ -213,8 +213,86 @@ The processor checks the signature in constant time and rejects unsigned
 requests before parsing the body or allocating expensive work. CORS is limited
 to the required production origin and does not substitute for authentication.
 
+The processor also exposes
+`POST /internal/processor-auth/v1/verify`. It applies the same route-bound HMAC
+protocol and dual-secret verifier but performs no replay-marker, outbox,
+attempt, lock, artifact, or compute mutation. The raw body is at most 256 bytes
+and has exactly `{"nonce":"<16-64 lowercase base64url characters>"}`. A valid
+request returns exactly:
+
+```json
+{
+  "authenticated": true,
+  "auth_version": "v1",
+  "request_id": "<echoed canonical UUIDv7>"
+}
+```
+
+Invalid auth remains a minimal 401/403. The route rejects unknown fields and
+is rate-limited per caller. Rotation succeeds only when each signer sends a
+fresh nonce/request ID and receives the exact 200 schema through its real
+production call path; it never uses a compute route as a probe.
+
 Existing per-hash transcript locking remains. Transcode receives the same
 idempotent in-progress lock to suppress trusted duplicate work.
+
+Before acquiring a compute lock, the processor reads the derivative/hash
+record in the immutable terminal-suppression bucket. If that record exists,
+the request repairs pending/task state if needed and returns the stable bounded
+terminal result without starting compute or publishing a newer processing
+event. If not suppressed, it acquires the per-hash lock, re-reads suppression
+to close the preflight race, then creates the operation ID and allocates its
+ordinal in Firestore before work. Suppression is set
+when a durable terminal-failure event is published with an allowlisted
+permanent-input classification:
+
+- `invalid_media`;
+- `unsupported_media`;
+- `no_audio_track`;
+- `corrupt_media`.
+
+Provider unavailability, authentication/configuration failures, timeouts, and
+retry exhaustion are never permanent-input classifications. The enum and its
+safe client messages are checked in and exhaustively tested.
+
+Only the dedicated operator identity can clear suppression, through a
+dry-run/confirm command that records reason, actor, prior terminal event ID,
+and reviewed plan digest, then starts a new attempt epoch. Normal signed
+processor callers cannot set an override flag. Clearing suppression does not
+delete the prior event or audit record.
+
+### Admission pause and drain
+
+Every processor image supports two startup modes. `normal` serves the signed
+compute routes. `maintenance` serves health/readiness and both non-mutating
+verification routes, but every compute-capable route returns:
+
+```json
+{"error":"processor_admissions_paused","retryable":true}
+```
+
+with HTTP 503 and `Retry-After: 30`. The maintenance router never initializes
+GPU/FFmpeg work or status publishers. Deployment keeps a tested named
+maintenance revision at zero traffic. Pausing is a Cloud Run traffic change to
+100% maintenance, followed by a describe check that fails the runbook if any
+traffic remains on a normal revision. Resuming is a traffic change to 100% of
+the explicitly named, verified normal revision; it never uses `latest`.
+
+The deployed Cloud Run request timeout is the maximum operation timeout:
+900 seconds, matching `cloud-run-transcoder/deploy.sh`. After pause, the drain
+gate waits 1,800 seconds and also requires all of the following continuously
+for two minutes:
+
+- the per-revision `active_derivative_operations` gauge is zero;
+- no transcript/transcode processing or terminal log originates from the old
+  revision;
+- no in-progress per-hash lock has an unexpired 900-second lease;
+- Cloud Run reports zero active requests on the old revision.
+
+Any nonzero or unavailable signal keeps admissions paused and pages the
+processor owner; it never guesses that drain completed. The runbook records
+the old/new revision names, pause time, signal evidence, traffic describe
+output, and resume verification.
 
 ### Fastly status routes
 
@@ -258,6 +336,24 @@ The worker pins the exact HTTPS origin and route in configuration, disables
 redirects, uses a 3-second connect timeout and 10-second total timeout, and
 reads at most 16 KiB of an upstream response.
 
+### Canonical signature bytes
+
+Both HMAC protocols use UTF-8/ASCII fields joined by one byte `0x0a` (LF),
+with no leading or trailing LF. Decimal timestamps contain ASCII digits only,
+have no sign or leading zero, and UUIDs are lowercase canonical hyphenated
+text. The body digest is lowercase hex over the exact received body bytes;
+JSON is never reparsed or reserialized before verification. Paths are the
+literal allowlisted ASCII route constants above. Percent-encoding, duplicate
+slashes, a trailing slash, dot segments, or a query string are rejected rather
+than normalized into a signed route.
+
+Check in byte-level fixtures containing protocol name, hex key, raw body hex,
+preimage hex, and expected signature hex. The same fixtures run unchanged in
+Fastly, processor, upload, operator CLI, and delivery tests. Fixtures include
+an empty body, a body ending in LF, non-ASCII JSON bytes, a leading-zero
+timestamp rejection, uppercase UUID rejection, and each exact route, so
+language/library differences cannot silently fork the protocol.
+
 ### Secret rotation
 
 Fastly accepts `derivative_status_secret_primary` and, during rotation only,
@@ -275,8 +371,37 @@ Rotation order:
 5. Remove the old secondary value within one hour.
 6. Alert on any use of the retiring credential after promotion.
 
-The processor HMAC credential uses the same overlap procedure but remains a
-separate secret.
+The processor verifier mounts
+`processor_request_secret_primary` and, during rotation only,
+`processor_request_secret_secondary`. The GCP processor runtime identity can
+access those two secrets and no other application secret. The same logical
+credential is copied into distinct signer stores:
+
+- Fastly Secret Store for Fastly processor callers;
+- Secret Manager access for the `cloud-run-upload` runtime identity;
+- Secret Manager access for a dedicated, impersonated
+  `derivative-processor-operator` identity used by approved backfill and
+  operator commands.
+
+No human user receives a long-lived service-account key or prints a secret.
+Operator commands obtain short-lived identity credentials, read the one
+processor signing secret in memory, and redact auth headers from output.
+Neither upload nor operator identities can access `derivative_status_secret`
+or the legacy `webhook_secret`.
+
+Processor-secret rotation is verifier-first:
+
+1. Put the new value in the processor verifier's secondary slot and deploy or
+   refresh the verifier mount.
+2. Update the Fastly, upload-runtime, and operator signer stores one at a time.
+3. Prove each caller with a signed, non-compute verification request and
+   confirm that old and new signatures are accepted during the overlap.
+4. Promote the new value to verifier primary.
+5. Remove the old value from every signer store.
+6. Remove verifier secondary within one hour and alert on use of the retired
+   credential.
+
+The delivery and processor rotations are separate procedures and credentials.
 
 ## IAM and identity matrix
 
@@ -284,13 +409,17 @@ All service accounts are keyless.
 
 | Identity | Allowed operations |
 | --- | --- |
-| Processor runtime | Create/read pending objects; create replay markers; create tasks in the one status queue; no list/delete |
-| Delivery runtime | Read/delete pending objects; create/read dead objects; access only `derivative_status_secret`; no list/task-create |
-| Reconciler runtime | List/read pending objects; create tasks; read/write reconciliation cursor |
+| Processor runtime | Create/read pending objects; create replay markers; create/read immutable suppression objects; transactionally get/create/update Firestore attempt records; create tasks in the one status queue; access only processor verifier primary/secondary secrets; no list/delete |
+| Upload runtime | Access only the active `processor_request_secret` signer value; no status-delivery secret or outbox access |
+| Fastly processor caller | Read only the Fastly Secret Store entry for the active processor signer; no status-delivery or admin credential |
+| Operator/backfill signer | Impersonated dedicated identity; access only the active `processor_request_secret`; no status-delivery secret or outbox access |
+| Delivery runtime | Read/delete pending objects; create/read dead objects; access only `derivative_status_secret`; no list/task-create/dead-delete |
+| Reconciler runtime | List/read pending objects; create tasks; read/create/update/delete reconciliation cursor and lease objects |
 | Cloud Tasks OIDC identity | Invoke only `divine-status-delivery` |
 | Scheduler identity | Execute only `divine-status-reconciler` |
 | Cloud Tasks service agent | Mint tokens for the task OIDC identity as required by Google |
-| Recovery CLI identity | Read media artifact metadata and Fastly derivative status; create/read outbox events and tasks; no media-body read or delete |
+| Recovery CLI identity | List media-bucket object metadata without `storage.objects.get`; read Fastly derivative status; list/read/create pending records; list/read dead records; create/read immutable suppression objects; transactionally get/create/update Firestore attempt records; create tasks; no media-body read and no delete |
+| Suppression operator identity | Read/delete exact suppression objects and get/update Firestore attempt records only through the reviewed clear command; no create/list or pending/dead/media access |
 | Deployment identity | Manage declared resources and `actAs` only the identities needed during deployment |
 
 The queue uses queue-level `ALWAYS` overrides for HTTPS scheme, delivery host,
@@ -299,28 +428,55 @@ cannot choose a target or authentication identity. Only the deployment
 identity needs `iam.serviceAccounts.actAs` while configuring that override;
 task creators receive no impersonation role.
 
-These permissions are implemented as bucket/queue/service-scoped custom roles
-where predefined roles are broader than the table. Bucket access is reviewed
-quarterly. Structured operational logs are retained for 30 days; Sentry uses
-the project's restricted operational retention policy and stores only the
-sanitized fields defined here.
+These permissions are implemented as resource-scoped custom roles where
+predefined roles are broader than the table. Deployment contract tests inspect
+the effective policy and prove each allowed and denied operation, including
+Cloud Run invocation, job execution, queue task creation, Secret Manager
+access, service-agent token minting, and every object operation.
+
+Object namespaces are isolated with separate buckets rather than relying on
+prefix-scoped prose or conditional delete permissions:
+
+- pending-event bucket: producer create/read, delivery read/delete,
+  reconciler list/read, recovery list/read/create;
+- dead-event bucket: delivery create/read, recovery list/read; only the
+  lifecycle service deletes;
+- processor-replay bucket: processor create only;
+- terminal-suppression bucket: processor/recovery create/read; suppression
+  operator read/delete; no runtime list/update;
+- reconciliation-control bucket: reconciler read/create/update/delete only.
+
+`storage.objects.list` is bucket-wide. It is granted only on the pending bucket
+to reconciler/recovery, on the dead bucket to recovery, and on the media bucket
+to recovery for artifact discovery. Media listing exposes object metadata but
+the recovery identity is explicitly denied `storage.objects.get`, so it cannot
+read media bodies. No runtime has list access to the replay, suppression, or
+control bucket. Bucket access is reviewed quarterly. Structured operational
+logs are retained for 30 days; Sentry uses the project's restricted
+operational retention policy and stores only the sanitized fields defined
+here.
+
+Attempt state uses a dedicated Firestore database with database-scoped custom
+IAM permissions for entity get/create/update and transactions. Runtime roles
+omit entity list and delete. Deployment tests prove an identity that can
+allocate or update an attempt cannot delete a document, enumerate the
+database, or access any other Firestore database.
 
 ## Private outbox
 
-Use a dedicated private bucket with public-access prevention and uniform
-bucket-level access. It contains no media:
+Use five dedicated private buckets with public-access prevention and uniform
+bucket-level access. They contain no media:
 
-- `pending/<event_id>.json`
-- `dead/<event_id>.json`
-- `processor-requests/<request_id>`
-- `control/reconcile-cursor.json`
-- `control/reconcile-lease.json`
+- pending-event bucket: `<event_id>.json`;
+- dead-event bucket: `<event_id>.json`;
+- processor-replay bucket: `<request_id>`;
+- terminal-suppression bucket: `<derivative>/<sha256>.json`;
+- reconciliation-control bucket: `cursor.json` and `lease.json`.
 
 Pending objects have no expiration lifecycle. Dead objects expire after 30
 days, and processor request markers expire after 24 hours. Unknown-schema and
 credential-failure pending objects remain until code/configuration is repaired
-or an operator explicitly classifies them. Access is granted according to the
-IAM matrix rather than by relying on a textual prefix in the media bucket.
+or an operator explicitly classifies them.
 
 Pending creation uses `ifGenerationMatch=0`. If the same event already exists,
 the producer uses its narrow read permission to verify that its canonical
@@ -332,15 +488,90 @@ movement creates the dead object with `ifGenerationMatch=0` before deleting
 the matching pending generation. A crash at any boundary leaves at least one
 recoverable copy.
 
+## Attempt allocation and terminal suppression
+
+One Firestore attempt-state document exists per derivative/hash at
+`derivative_attempts/<derivative>:<sha256>`:
+
+```json
+{
+  "schema_version": 1,
+  "attempt_epoch": "uuid",
+  "next_attempt_number": 4,
+  "allocations": {
+    "<operation_id>": 1,
+    "<operation_id>": 2,
+    "<operation_id>": 3
+  }
+}
+```
+
+The processor creates its UUIDv7 operation ID, then uses one Firestore
+transaction on this document to allocate the next ordinal. Retrying allocation
+for the same operation ID returns the stored ordinal; a new operation receives
+and stores the next value. The map is bounded by the maximum 100 attempts per
+epoch, so the document is bounded and requires no cross-record transaction. An
+ordinal is an admitted processing attempt: a process crash after allocation
+still counts as an attempt when a later failure reports a higher ordinal.
+
+Every event in the operation carries the allocated `attempt_epoch` and
+`attempt_number`. Fastly assigns failure counters with
+`max(current, attempt_number)` for the matching epoch. Consequently failure 2
+delivered before failure 1 still records two admitted attempts, while
+redelivery changes nothing. A stale failure from the same epoch may advance
+the counter to its ordinal only when the current derivative state is not a
+newer `complete` or terminal failure. It never changes status fields. A stale
+event from an older epoch changes nothing.
+
+`complete` resets the public failure counter to zero but retains its epoch
+watermark and terminal status, so late failures from that epoch are ignored.
+Completed artifacts use the existing-artifact fast path rather than
+recomputation; permanent-input failures use terminal suppression. The
+operator-only clear command first transactionally replaces the attempt record
+fields with a new UUID epoch, `next_attempt_number=1`, and an empty allocation
+map. It then deletes the exact suppression-object generation named by the
+reviewed plan.
+
+The first event in that new epoch is ordered after the reviewed override;
+Fastly resets its epoch-local counter before applying the new operation.
+
+Terminal publication first creates, with `ifGenerationMatch=0`, an immutable
+suppression object containing the bounded canonical failure event, digest,
+safe client result, and operation ordering fields. If it already exists, only
+byte-identical content is accepted. The publisher then creates the immutable
+pending event from those exact bytes and creates the task. A crash after
+suppression but before pending creation is safe: the next processor preflight
+sees suppression, recreates or verifies the deterministic pending event and
+task, then returns the stable terminal result without compute. If suppression
+storage is unavailable, preflight and terminal publication fail closed with
+503.
+
+The processor and recovery identities cannot update or delete suppression
+objects. The operator clear order is epoch-rotation first, exact-generation
+suppression delete second. A crash before delete remains safely suppressed and
+the reviewed command can resume; after delete the new epoch is already
+durable. Thus a Fastly/task outage or partial override cannot reopen the
+corrupt-input compute loop.
+
+Allocation number 100 blocks further normal operations with
+`409 attempt_epoch_exhausted` and pages the processor owner before any compute.
+The operator inspects the failure history and either leaves terminal
+suppression in place or uses the same reviewed epoch-rotation command. Epoch
+rotation is never automatic.
+
 ## Producer publication state machine
 
-Every status transition uses the same steps:
+Every non-suppressed status transition uses the same steps:
 
 1. Construct and fully validate the canonical typed event.
 2. Create the immutable pending object.
 3. Create its deterministic Cloud Task with bounded client retries.
 4. Return publication success once the pending object is durable, even if task
    creation failed; the reconciler owns the producer-to-queue gap.
+
+A permanent-input terminal failure uses the suppression-first protocol above:
+persist the canonical event in attempt state, then run steps 2–4 from those
+stored bytes. Preflight repair runs the same steps without compute.
 
 For the initial `processing` transition, failure to persist pending returns 503
 and the processor does not start expensive work. For `complete` or `failed`,
@@ -365,6 +596,7 @@ Outcomes:
 | Task creation fails after bounded retries | Continue/return normal result because pending is durable; alert and reconcile |
 | Pending persistence fails before work | Return 503; do not start work |
 | Pending persistence fails after artifact/terminal result | Return 503; caller retries with a new signed request |
+| Terminal suppression exists but pending/task is missing | Recreate/verify it from stored canonical bytes; return stable terminal result without compute |
 
 The processor response distinguishes media result from delivery state with
 `status_delivery: queued|pending_reconciliation`. It never claims a status
@@ -384,6 +616,7 @@ ID.
   "operation_started_at_ms": 1784847000000,
   "sequence": 2,
   "created_at_ms": 1784847001234,
+  "attempt_epoch": "018f6e33-c5af-7d22-a7b2-30f02e8f7e11",
   "attempt_number": 1,
   "derivative": "transcript",
   "update": {
@@ -443,14 +676,15 @@ Blob assignments are:
 - complete: assign status, clear errors/retry/terminal, and reset the blob
   transcript attempt counter to zero;
 - failed: assign status/error/retry/terminal and set the blob transcript
-  attempt counter to `max(current, attempt_number)`.
+  attempt epoch/counter to the event epoch and
+  `max(current_for_epoch, attempt_number)`.
 
 When `job_id` is present, the subtitle-job effect is required. Complete assigns
 `Ready`, the stable VTT URL, and supplied language/duration/cue values, clears
 error/retry fields, and preserves the job's attempt count. Failed assigns
-`Failed`, safe error/retry fields, and sets the job attempt count to
-`max(current, attempt_number)`. Pending and processing assign only their
-corresponding job status and update timestamp.
+`Failed`, safe error/retry fields, and sets the job attempt epoch/counter to
+the event epoch and `max(current_for_epoch, attempt_number)`. Pending and
+processing assign only their corresponding job status and update timestamp.
 
 When `job_id` is absent, no subtitle-job or hash-to-job effect is attempted.
 The handler never guesses a job through the hash mapping.
@@ -473,9 +707,9 @@ The handler never guesses a job through the hash mapping.
 
 Assignments mirror transcript blob assignments: pending/processing preserve
 the counter, complete clears failure state and resets the transcode attempt
-counter to zero, and failed sets the counter to
-`max(current, attempt_number)`. Width and height are either both absent or
-both present; when present Fastly stores the canonical `WIDTHxHEIGHT` value.
+counter to zero, and failed assigns the matching-epoch maximum attempt number.
+Width and height are either both absent or both present; when present Fastly
+stores the canonical `WIDTHxHEIGHT` value.
 
 ### Safe errors
 
@@ -496,7 +730,7 @@ Shared validation:
 - created time is not before operation start or more than ten minutes in the
   future;
 - sequence is `1..=32`;
-- attempt number is `1..=100`;
+- attempt epoch is a canonical UUID and attempt number is `1..=100`;
 - status is one of the derivative's declared enum values;
 - error code is at most 64 ASCII identifier characters;
 - error message is sanitized and at most 2,048 bytes;
@@ -513,6 +747,13 @@ Status timestamps and retry times are absolute event values. Fastly does not
 replace them with delivery receipt time. Events contain no transcript text,
 media bytes, owner key, signed URL, filesystem path, authorization value, or
 other credential.
+
+The attempt epoch/number must match the allocation stored for the event's
+operation ID. The processor and recovery publisher reject a mismatch before
+pending persistence. Fastly enforces ordered epoch transitions and trusts only
+the route-authenticated typed publisher contract; it does not read GCS attempt
+state. Existing-artifact completion carries its allocated ordinal but resets
+the relevant public failure counter and never increments it.
 
 The delivery task request is:
 
@@ -562,9 +803,9 @@ has succeeded:
 {
   "event_id": "uuid",
   "outcome": "applied|duplicate|stale",
-  "blob_effect": "applied|already_applied",
-  "job_effect": "not_required|applied|already_applied",
-  "mapping_effect": "not_required|applied|already_applied"
+  "blob_effect": "applied|already_applied|stale",
+  "job_effect": "not_required|applied|already_applied|stale",
+  "mapping_effect": "not_required|applied|already_applied|stale"
 }
 ```
 
@@ -575,14 +816,29 @@ event names a subtitle job that does not yet exist, it returns
 Errors use one bounded response type:
 
 ```json
-{"error":"metadata_not_ready|job_not_ready|validation_failed|integrity_conflict|conflict_exhausted|internal"}
+{
+  "event_id": "uuid when the bounded envelope supplied one",
+  "error": "metadata_not_ready|job_not_ready|validation_failed|integrity_conflict|conflict_exhausted|internal"
+}
 ```
 
 Invalid bodies or signatures return minimal generic errors without parser,
-storage, secret, or upstream details. A mixed result aggregates as `applied`
-when any required record applied the event, `duplicate` when every required
-record already applied it, and `stale` when every required record is stale.
-Conflicting mixed ordering is an integrity error rather than success.
+storage, secret, or upstream details and omit `event_id` when no validated
+envelope identity exists. Aggregation is exhaustive:
+
+- `not_required` is valid only for an effect excluded by the event contract;
+- `applied` means at least one required effect is `applied`, while every other
+  required effect is `applied`, `already_applied`, or `stale`;
+- `duplicate` means every required effect is `already_applied`;
+- `stale` means no required effect is `applied`, at least one is `stale`, and
+  every other required effect is `stale` or `already_applied`.
+
+There is always at least one required effect: the blob. A required effect
+reported as `not_required`, an effect value outside this matrix, an event
+identity/digest conflict, or an aggregate that does not match its effects is
+an integrity error rather than success. This explicitly permits partial-retry
+results such as blob `already_applied`, job `applied`, mapping `stale`, with
+aggregate `applied`, and duplicate/stale mixtures with aggregate `stale`.
 
 ### Generation-matched writes
 
@@ -592,7 +848,12 @@ hash-to-job mapping record. Each watermark contains:
 
 - operation ordering fields;
 - last sequence;
-- last event ID.
+- last event ID;
+- lowercase SHA-256 digest of the canonical event bytes.
+
+Equal ordering coordinates are a duplicate only when both event ID and digest
+match the watermark. Equal coordinates with a different event ID or digest are
+an integrity conflict even after the pending object has been deleted.
 
 Webhook paths bypass the five-minute POP-local metadata cache. They read the KV
 value and generation marker, run the pure transition decision, then write with
@@ -630,16 +891,85 @@ A duplicate blob effect does not short-circuit later effects. Therefore a
 retry after a partial failure can finish the subtitle job and purges without
 incrementing attempt counters or regressing blob state.
 
-The event's explicit `job_id` is authoritative. A stale event cannot repoint
-the hash mapping because the mapping applies the same total-order decision.
-Forced replacement with a newer operation wins; a late completion for the old
-job is stale for the mapping while remaining independently classifiable for
-that old job record.
+The event's explicit `job_id` is authoritative for its subtitle-job record. A
+stale event cannot repoint the canonical hash mapping because that mapping
+applies the same total-order decision. Forced replacement with a newer
+operation wins; a late completion for the old job is stale for the mapping
+while remaining independently classifiable for that old job record. Once a
+job has been superseded in the canonical mapping, an event for that older job
+can never reclaim it.
 
-Failure counters are changed inside the CAS transition only when that record's
-watermark has not already accepted the event. Completion and failure updates
-are absolute assignments derived from the typed event; retrying them is
-idempotent.
+Failure counters are changed inside the CAS transition using the
+matching-epoch maximum ordinal rule. Completion and failure fields are
+otherwise absolute assignments derived from the typed event. Retrying either
+transition is idempotent.
+
+### Hash-to-job bridge and ordering
+
+The existing hash-to-job key contains a raw job-ID string. The typed mapping is
+introduced in a new `subtitle-job-map-v2:<sha256>` key; the legacy key is never
+overwritten with JSON.
+
+Every mapping-writing path is first moved behind one compile-visible
+`mutate_hash_job_mapping` helper. The inventory includes forced-job creation,
+manual transcript controls, admin repair, subtitle dispatch, recovery, and
+every direct KV insert found by a repository test. The helper reads key
+`mapping_writes_paused` from the dedicated Fastly Config Store
+`operational_controls` without an application cache before mutation. Missing,
+malformed, or unreadable control state fails closed. When paused, every
+mapping-writing route returns:
+
+```json
+{"error":"mapping_writes_paused","retryable":true}
+```
+
+with HTTP 503 and `Retry-After: 30`, before changing a job or mapping. No
+caller-supplied flag bypasses the helper.
+
+The freeze-capable bridge package is globally active before the control is
+used. Operators verify the active service version, wait ten minutes for POP
+propagation, and probe every inventoried route through multi-region POPs. They
+then set `mapping_writes_paused=true`, wait another ten minutes, and require
+all probes to return the exact paused response, the
+`active_mapping_writers` gauge to remain zero, and no successful mapping-write
+log for two minutes. Any missing signal keeps the freeze in place and blocks
+migration. Resume occurs only after v2 parity verification: set the control
+false, probe one safe canary mutation, verify v2/legacy parity, then resume
+processor admissions.
+
+A bridge Fastly release, deployed to every POP before status delivery is
+enabled:
+
+- reads the v2 mapping first and falls back to the legacy raw string;
+- includes and round-trips all optional watermark fields that later releases
+  can populate;
+- after global bridge verification, writes the legacy raw string for
+  compatibility and generation-matches a typed v2 record for every new or
+  forced job;
+- gives each forced-job creation its own UUIDv7 operation ID, start time, and
+  sequence, and installs that ordering watermark in v2 before dispatching the
+  job;
+- uses generation-aware writes for every existing full-record mutation.
+
+After the bridge helper is globally verified, both the Fastly mapping gate and
+Cloud Run admission pause remain active during drain and migration. A
+reconciliation pass converts every legacy mapping to its v2 baseline and
+verifies parity. Only then does v2 become authoritative and both controls
+resume in the order above. There is therefore no accepted legacy write after
+v2 initialization that can be lost. Status delivery writes v2 only. Legacy
+writes continue from bridge-or-newer packages for one compatibility release
+and are then removed. The pre-v2 key may be deleted only after the seven-day
+stable window and a scan proves every active mapping has v2 state.
+
+For a legacy-only mapping first encountered by bridge code, v2 is initialized
+with the current job ID and a reserved baseline watermark:
+`operation_started_at_ms=0`, nil UUID, sequence `0`, and the canonical digest
+of the typed baseline record. Sequence zero is invalid for events and exists
+only for this migration sentinel, which orders below every real operation. A
+forced-job transition and baseline creation both use create/CAS; after a
+conflict they reload, and every real forced-job operation supersedes the
+baseline. Events for a job other than the v2 canonical job may update that
+job's own record, but mapping effect is `stale`.
 
 Legacy status endpoints remain only until the new edge route and worker are
 verified. They do not accept the new route-scoped credential. Queue-first
@@ -661,11 +991,18 @@ Provision one `derivative-status-delivery` queue in the delivery region:
 
 The queue overrides scheme, host, path, empty query, POST method,
 `Content-Type: application/json`, OIDC service account, and audience.
-Task creators supply only the deterministic name and bounded body—no URL,
-query, authentication, or caller-selected headers. The delivery service
-rejects a non-empty query, unexpected content type, oversized body, duplicate
-content-type, or unknown JSON field. Cloud Tasks informational headers are
-logged only as bounded delivery metadata and are never treated as identity.
+The adapter uses `CreateTask`, because deterministic task IDs are required,
+and supplies the API-required fixed placeholder URL
+`https://invalid.invalid/`. Task creators otherwise supply only the
+deterministic name and bounded body—no query, authentication, or
+caller-selected headers. The `ALWAYS` override replaces the placeholder
+scheme, host, path, method, headers, OIDC service account, and audience before
+dispatch. Deployment contract tests inspect the queue configuration and send
+a task containing the placeholder to prove the delivery service, not the
+placeholder, receives it. The delivery service rejects a non-empty query,
+unexpected content type, oversized body, duplicate content-type, or unknown
+JSON field. Cloud Tasks informational headers are logged only as bounded
+delivery metadata and are never treated as identity.
 
 Task names derive from event IDs. Cloud Tasks may retain a deleted task name
 for up to 24 hours; `AlreadyExists` means "currently queued or still
@@ -689,12 +1026,21 @@ The worker handles:
 | Malformed, oversized, mismatched, or unexpected Fastly 2xx | 503; retain and alert |
 | Fastly 401/403 | 503; retain, high-severity credential alert |
 | Fastly 409/408/425/429/5xx or network error | 503; retain and retry |
-| Other Fastly 4xx | Create dead, delete pending generation, 204 |
+| Exact authenticated `400 validation_failed` with matching event ID and schema | Create dead, delete pending generation, 204 |
+| Fastly 404/405, unknown or mismatched 4xx, or malformed error | 503; retain and alert route/configuration failure |
 | Fastly success followed by cleanup failure | 503; retry safely |
 
 Dead records contain the original sanitized event, classification, upstream
 status code when present, first/last attempt timestamps, and no response body
 or credential.
+
+Automatic dead-lettering is deliberately allowlisted. It occurs only for a
+locally detected structurally corrupt known-version event, or an authenticated
+Fastly response whose exact bounded body is
+`{"event_id":"<same-id>","error":"validation_failed"}` with HTTP 400.
+`integrity_conflict`, 404, 405, every unrecognized status/error pair, and every
+malformed response retain pending and page an operator. Route propagation,
+rollback skew, or target misconfiguration therefore cannot discard an event.
 
 Before deletion, the worker parses the bounded Fastly response, verifies the
 exact schema, echoed event ID, aggregate outcome, and every required effect.
@@ -708,14 +1054,15 @@ configuration, and service mode without calling Fastly.
 ## Reconciliation job
 
 Cloud Scheduler requests a Cloud Run Job once per minute. The job first
-acquires `control/reconcile-lease.json` with a generation-matched write. The
-lease records execution ID and expiry; a live lease makes a duplicate
-Scheduler invocation exit successfully without scanning. A crashed execution
-can be reclaimed after ten minutes using generation match. Correctness does
-not depend on Cloud Run preventing overlapping executions.
+acquires `lease.json` in the reconciliation-control bucket with a
+generation-matched write. The lease records execution ID, acquisition time,
+and expiry; a live lease makes a duplicate Scheduler invocation exit
+successfully without scanning. A crashed execution can be reclaimed after ten
+minutes using generation match. Correctness does not depend on Cloud Run
+preventing overlapping executions.
 
 The job stores the next GCS page token and cycle start time in
-`control/reconcile-cursor.json` using a generation-match update. It advances
+`cursor.json` in the control bucket using a generation-match update. It advances
 the cursor after every scanned page even when records on that page already
 have tasks or are temporarily failing. At end-of-list it records cycle
 completion and resets the cursor.
@@ -731,6 +1078,15 @@ backlog larger than one page, a permanently failing first page, cursor CAS
 conflicts, lease contention/expiry, invalid cursor recovery, a crash before
 and after cursor advancement, and full-cycle reset.
 
+After every normal exit, including a bounded per-record failure, a `finally`
+path deletes the exact lease generation acquired by that execution. A release
+precondition failure is logged and does not delete another execution's lease.
+If the process crashes before `finally`, expiry-only reclamation applies.
+The reconciler identity has exact get/create/update/delete permission for the
+two control objects. Tests cover successful release, early-return release,
+panic/error cleanup, release races, crash expiry, and inability to access any
+other bucket.
+
 For every pending object older than two minutes, it creates the deterministic
 task. `AlreadyExists` is recorded and scanning continues.
 
@@ -740,7 +1096,8 @@ Provide a checked-in admin CLI using the recovery identity from the IAM table.
 It emits canonical JSON with `schema_version`, `recovery_run_id`, creation
 time, source evidence, ordered entries, and a SHA-256 manifest digest.
 
-Artifact recovery has `discover`, `plan`, `apply`, and `verify` phases.
+Artifact recovery has `discover`, `plan-intent`, `prepare`, `apply`, and
+`verify` phases.
 
 `discover`:
 
@@ -750,21 +1107,57 @@ Artifact recovery has `discover`, `plan`, `apply`, and `verify` phases.
   from structured logs/Sentry evidence;
 - does not mutate cloud state.
 
-`plan`:
+`plan-intent`:
 
 - validates every hash and current Fastly metadata response;
 - excludes absent, deleted, or otherwise ineligible blob metadata;
 - shows counts by derivative and desired status;
-- creates one UUIDv7 recovery operation and deterministic UUIDv5 event IDs;
-- writes a plan containing the source-manifest digest.
+- creates one UUIDv7 `recovery_run_id` for the reviewed manifest;
+- writes a non-mutating intent manifest and digest, without operation IDs,
+  attempt ordinals, or publishable event bytes.
+
+`prepare`:
+
+- requires the reviewed intent digest and an explicit `--confirm-prepare`;
+- creates and persists one UUIDv7 status `operation_id` per ordered
+  hash/derivative entry, with at most 32 status events and deterministic
+  UUIDv5 event IDs derived from that entry's operation ID and sequence;
+- transactionally reserves the exact Firestore attempt epoch/ordinal for every
+  operation, idempotently keyed by operation ID;
+- in the same Firestore transaction, creates
+  `recovery_preparations/<recovery_run_id>:<entry_index>` containing the stable
+  operation ID, allocation, canonical bytes, and digest; an existing matching
+  preparation is reused and a mismatch is an integrity error;
+- writes a prepared artifact containing every exact canonical event byte,
+  intent digest, allocation evidence, and a prepared-artifact digest;
+- does not create pending objects, tasks, Fastly writes, or processor work.
+
+An operator reviews the prepared artifact after reservation. Preparation is
+the explicit mutation boundary; discover and plan-intent remain dry-run.
+Abandoned or crashed preparations retain their admitted ordinal reservations
+and durable preparation records. Retrying prepare reads the exact known entry
+document, so a crash between transaction commit and local artifact write
+reconstructs identical bytes rather than allocating a new operation. These
+reservations do not change public failure counters unless a later reviewed
+event uses a higher ordinal. Exhaustion follows the reviewed epoch-rotation
+procedure above rather than silently reusing numbers.
 
 `apply`:
 
-- requires the reviewed manifest and an explicit confirmation flag;
-- refuses a plan whose source digest or canonical bytes changed after review;
-- creates new recovery operations using the normal typed outbox publisher;
+- requires the reviewed prepared-artifact digest and an explicit
+  `--confirm-apply`;
+- refuses an artifact whose intent digest, allocation evidence, event IDs, or
+  canonical bytes changed after review;
+- publishes exactly the operation IDs and event IDs stored in the reviewed
+  prepared artifact using the normal typed outbox publisher;
 - never calls the processor or retranscodes media;
 - is idempotent when rerun with the same manifest.
+
+`recovery_run_id` groups audit output only; it is never used as a status
+operation ID. Replanning creates a new run. Re-preparing the same intent
+reuses its persisted operation/allocation records; reapplying the same
+reviewed prepared artifact reuses its IDs and canonical bytes, so every entry
+remains idempotent even when a manifest contains hundreds of hashes.
 
 `verify` reports artifact count, planned count, applied count, remaining
 stale count, and terminal retry suppression. The current incident's known
@@ -775,40 +1168,69 @@ Dead-letter operations are separate:
 - `dead list` shows bounded IDs, classifications, ages, and derivatives;
 - `dead inspect <event_id>` validates and prints a redacted canonical record;
 - `dead plan-replay <event_id>` requires an operator-supplied correction and
-  creates a new recovery operation rather than changing the immutable event;
-- `dead apply-replay <reviewed-plan> --confirm` binds to the plan digest,
-  publishes the corrective event, and leaves the original dead record for its
-  30-day audit retention;
+  creates a replay intent rather than changing the immutable event;
+- `dead prepare-replay <reviewed-intent> --confirm-prepare` follows the same
+  ordinal-reservation and exact-event review boundary;
+- `dead apply-replay <reviewed-prepared-artifact> --confirm-apply` binds to the
+  prepared digest, publishes the corrective event, and leaves the original
+  dead record for its 30-day audit retention;
 - `dead verify-replay` confirms the corrective event reached Fastly.
 
-CLI output is machine-readable JSON by default. Mutation commands require the
-dedicated recovery identity, explicit project/bucket inputs, a reviewed plan
-digest, and `--confirm`; discovery and planning never mutate cloud state.
+CLI output is machine-readable JSON by default. Prepare/apply commands require
+the dedicated recovery identity, explicit project/bucket/database inputs, the
+appropriate reviewed digest, and distinct confirmation flags. Discovery and
+intent planning never mutate cloud state.
 
 ## Deployment order
 
-1. Add native CAS helpers, optional watermarks, versioned Fastly endpoints,
-   HMAC verification, and tests.
-2. Publish Fastly with `fastly compute publish`, purge the service, and verify
-   legacy behavior plus the new routes.
-3. Provision the private outbox bucket, queue with enforced overrides,
-   identities/IAM, private worker, reconciliation job, metrics, and alerts.
-4. Deploy the delivery worker and test unauthenticated rejection, task OIDC,
+0. Restore the active P1 independently of the long rollout: align the current
+   legacy callback secret, verify live transcript and transcode callbacks, and
+   run an audited artifact-backed metadata repair for the incident window.
+   This repair does not wait for the 24-hour canary and does not retranscode.
+1. Publish the freeze-capable bridge Fastly release. It moves every
+   full-record mutation to generation-aware CAS, includes and losslessly
+   round-trips every optional blob/job/v2 watermark field, inventories and
+   gates every mapping writer, and dual-reads legacy/v2 mappings while legacy
+   remains authoritative. It does not yet create v2 baselines or accept
+   delivery watermarks.
+2. Purge and prove the bridge active through the declared propagation/probe
+   gate. Set the Fastly mapping control to paused, switch Cloud Run traffic to
+   the maintenance revision, and satisfy both mapping-writer and processor
+   drain criteria.
+3. With both controls still paused, migrate legacy mappings to v2 baselines,
+   reconcile parity, and declare the bridge version the rollback floor. Make
+   v2 authoritative, canary-unfreeze the mapping gate, then resume processor
+   admissions. No v2 mapping becomes authoritative during mixed-POP
+   propagation.
+4. Add versioned status endpoints and HMAC verification on top of the bridge;
+   publish with `fastly compute publish`, purge, and verify legacy behavior
+   plus the new routes.
+5. Provision the five private state buckets, dedicated Firestore attempt
+   database, queue with enforced overrides, identities/IAM, private worker,
+   reconciliation job, metrics, and alerts.
+6. Deploy the delivery worker and test unauthenticated rejection, task OIDC,
    HMAC overlap, retry, dead-letter, CAS conflict, and secret rotation.
-5. Add processor HMAC verification in dual-accept mode. Inventory and update
+7. Add processor HMAC verification in dual-accept mode. Inventory and update
    every caller before rejection becomes mandatory: Fastly on-demand
    transcript/transcode paths, `cloud-run-upload`, `backfill.sh`,
    `backfill-prioritized.sh`, incident recovery tooling, and any documented
    operator command. Verify each caller, then reject unsigned requests.
-6. Deploy queue-first producer support disabled and run controlled synthetic
+8. Deploy queue-first producer support in a named, zero-traffic processor
+   revision and run controlled synthetic
    transcript/transcode canaries through the complete production queue and
    Fastly path for 24 hours.
-7. Enable queue-first publication atomically for all real transcript and
-   transcode status events if canary criteria pass.
-8. Disable legacy status endpoints and observe for seven days.
-9. Run incident recovery in dry-run, review its manifest, apply it, and verify
-   convergence.
-10. Remove old shared status-sender code after fourteen stable days.
+9. If canary criteria pass, pause new processor admissions, wait for the old
+   revision's bounded in-flight operations to finish, verify zero legacy
+   callbacks for twice the maximum operation timeout, switch Cloud Run traffic
+   100% to the named queue-first revision, and resume admissions. This is the
+   rollout control plane; no per-instance feature flag or mixed direct/queued
+   status mode is permitted.
+10. Disable legacy status endpoints and observe for seven days.
+11. Run the new recovery tool for any residual artifact/status drift: review
+    the dry-run intent, prepare exact allocated events, review the prepared
+    digest, apply, and verify convergence.
+12. Remove old shared status-sender code and legacy mapping writes after
+    fourteen stable days.
 
 Rollback never disables immutable outbox persistence while processors accept
 work. Depending on the faulty layer it either:
@@ -817,10 +1239,15 @@ work. Depending on the faulty layer it either:
   final events; or
 - keeps processor publication active while pausing only queue dispatch.
 
-Pending/dead objects are never deleted by rollback. If the new Fastly route is
-the fault, pause queue dispatch, keep outbox publication active, roll back
-Fastly atomically, correct the route, and resume. Never switch queued
-producers to unordered direct delivery.
+Pending/dead objects are never deleted by rollback. Before step 3, Fastly may
+roll back normally. After any watermark or v2 canonical mapping exists, the
+pre-CAS package is permanently ineligible: rollback may activate only the
+declared bridge floor or a later CAS-compatible version. Slow POP propagation
+is treated as a mixed-version deployment, so queue-first enablement waits
+until probes prove every sampled POP understands optional watermarks and v2
+mappings. If the new Fastly route is the fault, pause queue dispatch, keep
+outbox publication active, activate the bridge floor, correct the route, and
+resume. Never switch queued producers to unordered direct delivery.
 
 ## Observability and alerts
 
@@ -840,6 +1267,8 @@ structured logs, not metric labels.
 Measure:
 
 - enqueue success/failure and latency;
+- active derivative operations by processor revision;
+- active mapping writers and mapping-freeze rejections by Fastly version;
 - delivery outcome, attempt count, and latency;
 - Fastly response class;
 - queue depth and oldest task age;
@@ -910,6 +1339,13 @@ During a prolonged dependency outage, artifacts may be directly retrievable
 while metadata remains pending. The pending event remains durable, the
 operator is alerted, and recovery occurs automatically after service returns.
 
+If derivative computation or artifact upload succeeds but terminal-event
+persistence returns 503, the caller sees a retryable processing failure rather
+than success. Support should describe this as a temporary processing state:
+the artifact is safe, a retry with a new signed request reuses the existing
+artifact, publishes completion without recomputation, and does not require a
+new user upload.
+
 ## Coverage gate
 
 The scaffolded root coverage command does not include
@@ -953,10 +1389,13 @@ Every implementation slice begins with a failing native test.
 ### Pure domain tests
 
 - typed transcript/transcode serialization and field allowlists;
-- size, UUID, hash, timestamp, sequence, attempt, and error bounds;
+- size, UUID, hash, timestamp, sequence, attempt epoch/ordinal, and error
+  bounds;
 - total-order same-millisecond UUID tie-break;
 - retry/dead/unknown-version classification;
-- transition decisions for applied, duplicate, stale, and newer operation.
+- transition decisions for applied, duplicate, stale, and newer operation;
+- exhaustive aggregate/effect response combinations;
+- equal-order event-ID and canonical-digest conflicts.
 
 ### Fastly metadata tests
 
@@ -967,11 +1406,20 @@ generation-matched writes.
 - CAS success and conflict reload;
 - conflict exhaustion;
 - duplicate failure does not increment;
+- out-of-order failures converge via matching-epoch maximum ordinal;
+- a stale failure cannot alter a newer complete, terminal, or attempt epoch;
 - partial blob success followed by job failure completes on retry;
 - missing blob/job returns retryable 409;
 - cache purge is retried after durable effects;
 - transcript and transcode use independent blob watermarks;
 - forced hash-to-job replacement rejects a late old-job event;
+- legacy raw mapping bridge, baseline sentinel, v2 preference, dual-write
+  window, and a forced-job/migration race;
+- post-watermark rollback accepts the CAS bridge floor and rejects a pre-CAS
+  package;
+- every mapping writer is inventory-enforced through the fail-closed dynamic
+  gate; migration cannot start until propagation, route probes, zero-active,
+  and quiet-log criteria all pass;
 - moderation/delete/upload/backfill/subtitle-dispatch races preserve all
   unrelated fields and delivery watermarks;
 - every existing full-record writer uses the generation-aware path.
@@ -981,15 +1429,33 @@ generation-matched writes.
 - unsigned, stale, malformed, and wrong-secret processor requests are rejected
   before work;
 - captured signatures cannot replay across method/path/body/request ID;
+- every runtime passes the shared byte-level HMAC fixtures;
 - replay markers reject repeated expensive work and expire after 24 hours;
 - pre-authentication body limits reject oversized requests;
 - current and overlap secrets are accepted;
+- processor auth verify returns the exact bounded response and performs no
+  replay, lock, attempt, outbox, artifact, or compute mutation;
+- maintenance mode returns retryable 503 on every compute route while health
+  and verification remain available;
+- traffic pause/drain fails closed for every nonzero or unavailable signal and
+  resumes only to an explicit named revision;
 - pending persistence precedes task creation;
 - pending create conflict requires byte equality;
 - task-create failure leaves a recoverable pending event;
 - existing artifact makes a retried processor request publish completion
   without recomputation;
-- duplicate transcode request is suppressed by its GCS lock.
+- duplicate transcode request is suppressed by its GCS lock;
+- attempt allocation is atomic, monotonic, bounded, and idempotent per
+  operation ID;
+- every permanent-input terminal code suppresses later compute before lock
+  acquisition, while transient/provider codes do not;
+- suppression clear requires the dedicated operator identity, reviewed digest,
+  and new epoch;
+- suppression present with missing pending and/or task reconstructs exact
+  canonical bytes before lock acquisition and returns without compute;
+- processor/recovery can create/read but cannot update/delete suppression,
+  while the operator rotates the Firestore epoch before exact-generation
+  deletion.
 
 ### Delivery service tests
 
@@ -1004,23 +1470,40 @@ Use injected in-memory outbox/secret providers and a local HTTP server.
 - dead create-before-delete generation ordering;
 - both-present dead/pending cleanup and mismatch protection;
 - missing pending is acknowledged;
-- unknown schema remains pending.
+- unknown schema remains pending;
+- 404, 405, unknown 4xx, mismatched error code, and malformed Fastly errors
+  retain pending;
+- only exact matching `400 validation_failed` and local structural corruption
+  create dead records.
 
 ### Reconciler and recovery tests
 
 - multi-page backlog cannot starve later pages;
 - durable cursor recovery at every crash boundary;
 - overlapping execution prevention;
+- generation-matched lease release on success, early error, and release race,
+  plus expiry recovery after a simulated crash;
 - task-name tombstone and `AlreadyExists` behavior;
-- dry-run recovery never mutates;
-- same manifest applies idempotently;
+- recovery discover and intent dry-run never mutate;
+- intent planning never mutates, prepare reserves stable ordinals without
+  publishing, and apply refuses unreviewed or changed canonical bytes;
+- crashed/repeated prepare and apply reuse stable IDs/ordinals idempotently;
 - recovery excludes ineligible metadata and never invokes processors.
 
 ### Deployment smoke tests
 
 - private worker rejects unauthenticated invocation;
+- processor signer rotation is proven through the non-compute verification
+  route for Fastly, upload, and operator call paths;
+- a maintenance revision receives 100% traffic, rejects admissions, and meets
+  the 900/1,800-second drain contract before bridge or queue-first cutover;
+- all mapping-writing routes reject through the Fastly freeze control before
+  migration, and v2/legacy parity is verified before controlled resume;
 - queue-level host/path/method/OIDC overrides cannot be bypassed by task input;
 - runtime identities cannot invoke or read outside their matrix;
+- effective IAM grants listing only on the pending/dead/media buckets declared
+  above and prevents delivery from deleting dead/control/replay objects;
+- recovery can read but cannot create or delete dead records;
 - delivery HMAC cannot authenticate any admin route;
 - processor HMAC cannot authenticate a status or admin route;
 - a deliberate Fastly 403 stays pending and drains after credential repair;
@@ -1040,9 +1523,23 @@ non-secret commands and expected output for:
 - pending and dead inspection;
 - dead revalidation and replay as a new corrective operation;
 - reconciliation cursor inspection/reset with safety checks;
-- incident recovery dry-run/apply/verification;
+- incident recovery discover/intent dry-run, ordinal preparation, exact-event
+  review, apply, and verification;
 - transcript and transcode end-to-end validation;
 - rollback and backlog drain.
+
+Each alert and privileged action names an operational owner role and escalation
+target: processor owner, delivery owner, Fastly owner, incident commander, or
+support lead. The runbook also covers terminal-suppression inspection and
+operator-only reviewed clearing, the immediate legacy-secret P1 repair,
+maintenance-window alert annotations during queue pauses/rotation, and the
+admission pause required for bridge and queue-first cutovers.
+
+Maintenance annotations may mute only expected backlog, rate, and age
+notifications for a bounded auto-expiring window. Integrity, dead-letter,
+authorization, credential, and untracked-event alerts remain active. Resume
+requires an explicit post-maintenance queue/pending/lock check and removal of
+any remaining mute.
 
 ## Design-review sources
 

--- a/docs/superpowers/specs/2026-07-24-perceptual-video-hashing-research-spike-design.md
+++ b/docs/superpowers/specs/2026-07-24-perceptual-video-hashing-research-spike-design.md
@@ -165,20 +165,26 @@ directory:
 ./benchmark preflight --manifest <file> --input-root <dir> --runs-root <dir>
 ./benchmark smoke --runs-root <dir>
 ./benchmark pilot --manifest <file> --input-root <dir> --runs-root <dir>
+./benchmark accept-pilot --runs-root <dir> --run <run-id>
 ./benchmark tune --runs-root <dir> --run <run-id>
 ./benchmark test --runs-root <dir> --run <run-id> \
   --freeze <frozen-operating-points.json>
 ./benchmark report --runs-root <dir> --run <run-id>
+./benchmark accept --runs-root <dir> --run <run-id> --conclusion <value>
 ./benchmark cleanup --runs-root <dir> --run <run-id>
-./benchmark full --manifest <file> --input-root <dir> --runs-root <dir>
+./benchmark full --manifest <file> --input-root <dir> --runs-root <dir> \
+  [--run <run-id>]
 ```
 
-`full` is the one-command happy path and invokes the same visible phases in
-order, prints its allocated run ID, and passes the same explicit runs root and
-run ID to every internal phase. Follow-up commands never discover runs through
-global state. Each phase is independently rerunnable when its recorded inputs
-and digests match. Help text documents required mounts and emits the exact
-container command rather than relying on shell aliases or operator memory.
+`full` is the one-command computational path and invokes the same visible
+phases in order, prints its allocated run ID, and passes the same explicit
+runs root and run ID to every internal phase. A real-media run pauses for
+pilot acceptance before full-corpus work and ends pending final human
+acceptance; it never cleans restricted evidence before acceptance. Follow-up
+commands never discover runs through global state. Each phase is independently
+rerunnable when its recorded inputs and digests match. Help text documents
+required mounts and emits the exact container command rather than relying on
+shell aliases or operator memory.
 
 `preflight` is read-only. It validates the manifest and runtime isolation,
 probes inputs inside the sandbox, calculates the expected source/variant/query
@@ -209,8 +215,11 @@ rejected. Its top-level fields are:
 
 - `schema_version`, exactly `1`;
 - `corpus_id`, an opaque identifier;
-- `attestation`, with literal booleans `authorized_for_local_research` and
-  `non_sensitive`, both true, plus an opaque approver role;
+- `attestation`, with literal booleans `authorized_for_local_research`,
+  `non_sensitive`, and `perceptually_distinct_distractors`, all true, plus
+  opaque aliases for the corpus approver, benchmark operator, safety reviewer,
+  and decision owner, and literal confirmation that the corpus approver and
+  decision owner are human;
 - `items`, a nonempty array.
 
 Each item contains:
@@ -237,7 +246,13 @@ A minimal valid shape is:
   "attestation": {
     "authorized_for_local_research": true,
     "non_sensitive": true,
-    "approver_role": "corpus-approver"
+    "perceptually_distinct_distractors": true,
+    "corpus_approver_human": true,
+    "decision_owner_human": true,
+    "corpus_approver_role": "corpus-approver",
+    "benchmark_operator_role": "benchmark-operator",
+    "safety_reviewer_role": "safety-reviewer",
+    "decision_owner_role": "decision-owner"
   },
   "items": [
     {
@@ -625,6 +640,8 @@ runs/<run-id>/
   metrics.json
   report.md
   failures.jsonl
+  pilot-acceptance.json
+  decision-acceptance.json
 ```
 
 The entire `runs/` tree, local inputs, generated variants, and fingerprints

--- a/docs/superpowers/specs/2026-07-24-perceptual-video-hashing-research-spike-design.md
+++ b/docs/superpowers/specs/2026-07-24-perceptual-video-hashing-research-spike-design.md
@@ -1,0 +1,762 @@
+# Perceptual Video Hashing Research Spike Design
+
+**Date:** 2026-07-24
+**Status:** Approved
+
+## Decision summary
+
+Run an offline, reproducible benchmark of two open-source perceptual video
+hashing systems:
+
+- **vPDQ** as the primary candidate;
+- **TMK+PDQF** as the fixed-length baseline.
+
+The spike determines whether either system can reliably recognize
+near-duplicate and transformed Divine-style short videos. It does not add
+hashing to the upload path, integrate a sensitive hash corpus, take moderation
+action, or change user-visible behavior.
+
+The expected outcome is a measured recommendation among vPDQ, TMK+PDQF, or no
+adoption. The benchmark must not presume that deploying perceptual hashing is
+the correct conclusion.
+
+## Problem
+
+Divine identifies exact media bytes with SHA-256, but an exact digest changes
+after a harmless re-encode, resize, crop, overlay, or remux. That makes it
+unsuitable for recognizing a previously reviewed video when the bytes have
+changed.
+
+Perceptual hashing may provide a reusable moderation-memory signal for:
+
+1. routing likely reuploads of known harmful material to review;
+2. avoiding repeated expensive analysis of equivalent media;
+3. later supporting repost or attribution workflows.
+
+Safety is the first use case. A perceptual match would be a review signal, not
+an enforcement verdict. False positives must not automatically quarantine,
+delete, downrank, or label content.
+
+The repository does not currently implement perceptual video matching. The
+upload service computes a cryptographic SHA-256 while streaming media, and the
+asynchronous transcode and blob-processing services perform separate
+derivative and provenance work. The existing video branch in
+`cloud-functions/process-blob/main.py` does not yet extract a thumbnail. A
+sibling moderation project pins a Python PDQ package but does not call it.
+These facts make a self-contained experiment safer than inserting unmeasured
+native hashing code into an operational service.
+
+## Why these two candidates
+
+The public [ThreatExchange repository](https://github.com/facebook/ThreatExchange)
+defines:
+
+- **vPDQ**, which applies PDQ across sampled video frames and supports matching
+  overlapping clips by comparing sets of deduplicated frame hashes;
+- **TMK+PDQF**, which produces a compact fixed-length signature optimized for
+  near-identical full videos.
+
+Frame-sampled PDQ is not a third candidate: it is the basic mechanism of vPDQ.
+Comparing a hand-rolled frame sampler would duplicate vPDQ while losing its
+published matching behavior.
+
+The public
+[PHVSpec benchmark](https://www.technologycoalition.org/knowledge-hub/phvspec-a-benchmark-based-analysis-of-perceptual-hash-systems-for-videos)
+found that vPDQ had substantially higher recall than TMK+PDQF at each
+algorithm's highest-F1 operating point, while both allowed local processing.
+That external result is useful for candidate selection, but it cannot answer
+how the algorithms behave on Divine's short loops and expected
+transformations. The spike therefore tests both on a Divine-shaped corpus.
+
+Proprietary systems and sensitive external hash-sharing networks are excluded.
+They introduce access, policy, legal, and interoperability questions that are
+not needed to establish whether the underlying technique is useful.
+
+## Goals
+
+- Measure recognition quality across transformations common to short-form
+  video.
+- Measure false matches against a distinct nonmatching corpus.
+- Measure hash time, query time, failures, and fingerprint size.
+- Select thresholds on a development split and evaluate them once on an
+  isolated test split.
+- Produce a deterministic, inspectable benchmark that another engineer can
+  run from a local manifest.
+- Keep all source media, source URLs, per-video fingerprints, and credentials
+  out of git.
+- Produce a recommendation with explicit uncertainty and failure modes.
+
+## Non-goals
+
+- Production service or schema changes.
+- Upload, Fastly, GCS, Eventarc, Cloud Run, Osprey, or moderation-queue
+  integration.
+- Automatic moderation, blocking, labeling, deduplication, or attribution.
+- Obtaining or testing a sensitive external reference corpus.
+- Detecting previously unseen harmful content.
+- Identifying authorship, ownership, intent, or whether media is AI-generated.
+- Choosing a long-term cross-repository service boundary.
+- Benchmarking every commercial perceptual hashing product.
+
+## Repository boundary
+
+The later implementation plan should create one isolated experiment under:
+
+```text
+experiments/perceptual-video-hashing/
+  Dockerfile
+  README.md
+  requirements.lock
+  src/
+  tests/
+  fixtures/
+  config/
+```
+
+`fixtures/` contains only scripts or specifications for generating tiny
+synthetic videos. It contains no user media.
+
+The experiment consumes a caller-provided local manifest and writes generated
+artifacts below a gitignored run directory. It does not import production
+service modules or require production credentials. This boundary makes it
+clear that benchmark code is not an approved production dependency.
+
+## Reproducible toolchain
+
+The container pins the public ThreatExchange source to commit:
+
+```text
+baefb4ed67b6cdc1d4c82dbaef858d50866ac424
+```
+
+It builds the official vPDQ and TMK+PDQF implementations with pinned system
+packages and FFmpeg. The runner records:
+
+- ThreatExchange commit;
+- base container image digest and exact installed package versions;
+- container image digest;
+- FFmpeg version;
+- host OS, architecture, and CPU model;
+- benchmark configuration digest;
+- input manifest digest;
+- deterministic random seed;
+- command and start time.
+
+The build also emits an SBOM and SHA-256 checksums for the FFmpeg, vPDQ, and
+TMK+PDQF binaries used in the run. Dependency installation uses a dated or
+content-addressed package snapshot so rebuilding does not silently select new
+native libraries.
+
+The experiment must not depend on the unused `pdqhash` Python package already
+pinned elsewhere in the Divine organization. Native dependencies stay inside
+the benchmark container.
+
+The build uses release optimization and runs upstream sample or regression
+vectors for both algorithms. Because TMK output can vary with FFmpeg behavior,
+an upstream-compatibility failure blocks real-media evaluation.
+
+## Operator interface
+
+The repository exposes one entry point, `./benchmark`, from the experiment
+directory:
+
+```text
+./benchmark build
+./benchmark preflight --manifest <file> --input-root <dir> --runs-root <dir>
+./benchmark smoke --runs-root <dir>
+./benchmark pilot --manifest <file> --input-root <dir> --runs-root <dir>
+./benchmark tune --runs-root <dir> --run <run-id>
+./benchmark test --runs-root <dir> --run <run-id> \
+  --freeze <frozen-operating-points.json>
+./benchmark report --runs-root <dir> --run <run-id>
+./benchmark cleanup --runs-root <dir> --run <run-id>
+./benchmark full --manifest <file> --input-root <dir> --runs-root <dir>
+```
+
+`full` is the one-command happy path and invokes the same visible phases in
+order, prints its allocated run ID, and passes the same explicit runs root and
+run ID to every internal phase. Follow-up commands never discover runs through
+global state. Each phase is independently rerunnable when its recorded inputs
+and digests match. Help text documents required mounts and emits the exact
+container command rather than relying on shell aliases or operator memory.
+
+`preflight` is read-only. It validates the manifest and runtime isolation,
+probes inputs inside the sandbox, calculates the expected source/variant/query
+counts, and estimates CPU, wall time, memory, and disk. It refuses to start if
+free disk is less than the estimate plus 25% headroom.
+
+The commands use these exit statuses:
+
+- `0`: requested phase completed and, for `full`, a valid decision report was
+  produced;
+- `2`: usage, manifest, attestation, path, duplicate, or preflight failure
+  before benchmark work;
+- `3`: build, isolation, upstream compatibility, or synthetic smoke failure;
+- `4`: diagnostic partial run; per-item failures exceeded a gate or prevented
+  a valid decision.
+
+An exit-4 run still produces a clearly headed `NO DECISION — PARTIAL RUN`
+diagnostic report. It cannot emit a recommendation. Undecodable individual
+files and bounded transform/hash failures are recorded and allow remaining
+items to run; schema, containment, attestation, isolation, freeze-digest, or
+ground-truth errors abort immediately. Expected, attempted, succeeded, and
+failed counts appear for every phase and transformation.
+
+### Manifest contract
+
+The manifest is strict UTF-8 JSON with `schema_version: 1`; unknown keys are
+rejected. Its top-level fields are:
+
+- `schema_version`, exactly `1`;
+- `corpus_id`, an opaque identifier;
+- `attestation`, with literal booleans `authorized_for_local_research` and
+  `non_sensitive`, both true, plus an opaque approver role;
+- `items`, a nonempty array.
+
+Each item contains:
+
+- `id`, unique and matching `^[a-z0-9][a-z0-9_-]{2,63}$`;
+- `path`, a unique normalized relative path below the input root, with no
+  absolute prefix, `..`, empty component, or symlink;
+- `role`, either `source` or `distractor`;
+- `corpus`, one of `divine_public`, `archive_public`, or
+  `synthetic_generated`;
+- `use_basis`, one of `owned_or_licensed`, `public_local_research`, or
+  `archive_local_research`;
+- `visual_classes`, a unique array drawn from the checked-in technical image
+  characteristic enum;
+- `duplicate_group`, either null or an opaque group identifier used to keep
+  known equivalents together.
+
+A minimal valid shape is:
+
+```json
+{
+  "schema_version": 1,
+  "corpus_id": "study_01",
+  "attestation": {
+    "authorized_for_local_research": true,
+    "non_sensitive": true,
+    "approver_role": "corpus-approver"
+  },
+  "items": [
+    {
+      "id": "src_001",
+      "path": "sources/src_001.mp4",
+      "role": "source",
+      "corpus": "divine_public",
+      "use_basis": "public_local_research",
+      "visual_classes": ["live_action", "camera_motion"],
+      "duplicate_group": null
+    }
+  ]
+}
+```
+
+Free-form descriptions and source locators are intentionally absent. Preflight
+computes SHA-256 rather than trusting an operator-supplied digest and rejects
+duplicate IDs, paths, or unexplained exact digests.
+
+## Dataset
+
+### Real samples
+
+Use 100 non-sensitive source videos:
+
+- 50 current, publicly available Divine videos;
+- 50 publicly available archived Vine videos.
+
+Selection should cover the formats and visual character of six-second social
+video without attempting demographic, behavioral, or moderation profiling.
+The corpus should include animation, live action, text-heavy clips, low-light
+clips, static scenes, camera motion, and fast cuts.
+
+Before selection, the benchmark configuration sets a minimum of ten sources
+for each listed visual class; one source may satisfy several classes. The
+sanitized report publishes achieved class counts so accidental corpus skew is
+visible. These are technical image characteristics, not labels about creators
+or people depicted.
+
+The benchmark runner never downloads production media. An authorized operator
+places files in a local input directory and creates a manifest containing
+opaque sample IDs, relative file paths, corpus class, and declared license or
+public-use basis. No account ID, pubkey, event ID, caption, username, source
+URL, moderation label, or human name is permitted in the manifest.
+
+Before a run, the operator attests separately that every selected file is both
+authorized for local research use and non-sensitive. Public reachability alone
+does not satisfy this check, because accidentally exposed or subsequently
+privatized media may still be reachable.
+
+Add at least 400 distinct nonmatching distractor videos. Distractors must not
+be transformations or known reposts of any source video. A preflight exact
+SHA-256 check rejects duplicate bytes; manual or provenance-based selection is
+still required because exact hashes cannot prove perceptual distinctness.
+
+### Synthetic samples
+
+Tests generate small videos from FFmpeg test sources, moving shapes, and
+generated tones. Synthetic fixtures verify the harness without exposing real
+media and are not included in reported real-corpus quality metrics.
+
+### Split isolation
+
+Assign source videos deterministically to:
+
+- 60% training/exploration;
+- 20% threshold-development;
+- 20% held-out test.
+
+All transformations of a source inherit that source's split. No source,
+transformation, extracted frame, or fingerprint may cross splits. The
+training split validates the harness and explores ranges. The development
+split selects one operating point per algorithm. The test split is evaluated
+once for the final report.
+
+Distractors use a separate deterministic negative split: 100 for threshold
+development and at least 300 held out for the final test. Training explores
+negative pairs between distinct training references. If a source is found to
+duplicate another source, both are removed or assigned to the same split
+before any metrics are calculated.
+
+## Transformation matrix
+
+For every source, generate deterministic variants that exercise:
+
+1. container remux with no intended visual change;
+2. H.264 re-encode at two quality levels;
+3. downscale to 480p and 240p;
+4. frame-rate conversion;
+5. a fixed text or watermark overlay;
+6. letterboxing or black padding;
+7. 5% and 10% spatial crops followed by resize;
+8. horizontal reflection;
+9. 0.9x and 1.1x speed changes;
+10. a middle subsequence;
+11. a loop or simple concatenated remix.
+
+FFmpeg commands, fonts, overlay contents, codecs, seeds, and output metadata
+are fixed in configuration. Each generated variant records its parent,
+transformation class, exact parameters, and SHA-256.
+
+The subsequence and remix classes are especially important because vPDQ can
+recognize overlapping clips from its unordered set of unique sampled-frame
+hashes, while TMK+PDQF is optimized for a near-identical full video. vPDQ does
+not perform temporal alignment and ignores frame order and timestamps during
+comparison; remix or reordering results must not be described as sequence
+recognition. Results for these classes must not be mixed into a single average
+that hides the architectural difference.
+
+## Ownership, staging, and budget
+
+Four recorded roles bound the work:
+
+- the **corpus approver** attests authorization and non-sensitivity;
+- the **benchmark operator** executes the documented commands;
+- the **safety reviewer** reviews omissions, false matches, limitations, and
+  report sanitization;
+- the **decision owner** accepts the final go/no-go conclusion.
+
+The corpus approver and decision owner must be human and distinct. Provenance
+records role aliases, not personal identifiers.
+
+Execution proceeds through stop/go stages:
+
+1. native release build, upstream compatibility vectors, and synthetic smoke;
+2. a five-source-per-corpus pilot plus 20 distractors exercising every
+   transformation;
+3. full corpus generation and development tuning;
+4. frozen held-out test and aggregate report.
+
+Stage 1 stops if either candidate cannot build, parse its upstream vectors, or
+distinguish the synthetic exact/re-encode positive from the unrelated
+negative. Stage 2 stops if either candidate is nonfunctional on supported
+media, if sandbox limits are repeatedly exhausted, if projected full-run
+resources exceed the budget, or if transformation failure makes the corpus
+unrepresentative. A stopped stage produces a diagnostic no-decision report
+before any larger collection or transformation begins.
+
+The spike is capped at five engineering days, 200 CPU-hours, 250 GiB of
+ephemeral benchmark storage, and seven calendar days from first real-media
+run to cleanup. Exceeding a cap stops the experiment and requires a new scope
+decision; it does not justify turning the harness into a production service.
+
+## Benchmark flow
+
+```text
+validate manifest and privacy fields
+  -> probe/decode every input
+  -> assign source-level splits
+  -> generate deterministic variants
+  -> hash references with vPDQ and TMK+PDQF
+  -> query positive variants and negative distractors
+  -> sweep thresholds on training/development only
+  -> freeze one operating point per algorithm
+  -> evaluate held-out test once
+  -> write raw machine results and a sanitized aggregate report
+```
+
+Hash generation and matching run locally with outbound network access
+disabled after the container image has been built. The runner must fail closed
+if the manifest contains disallowed identifying fields or paths outside the
+declared input root.
+
+### Untrusted-media execution boundary
+
+All real media is treated as hostile parser input. The documented run command
+starts the benchmark container with:
+
+- a non-root numeric UID and GID;
+- a read-only root filesystem;
+- the caller-owned input directory mounted read-only;
+- one separately mounted benchmark-owned writable run directory;
+- every Linux capability dropped and `no-new-privileges` enabled;
+- bounded CPU, memory, process count, output size, and wall-clock time;
+- no outbound or inbound network;
+- no host, home directory, SSH agent, cloud configuration, credential, or
+  container-engine socket mounts;
+- an explicit minimal environment allowlist rather than inherited host
+  variables.
+
+The runner accepts only regular files and rejects every symlink, device,
+socket, FIFO, and hard-linked file with an unexpected link count. It resolves
+and validates canonical containment at manifest load and immediately before
+each subprocess opens a path. Subprocesses receive argument arrays directly;
+the runner never invokes a shell or interpolates paths into command strings.
+
+FFmpeg and FFprobe run with standard input disabled, protocol access restricted
+to the minimum local `file`/`pipe` set needed by the checked-in transforms,
+playlist indirection disabled, and an explicit allowlist of supported local
+container demuxers. Inputs requiring another protocol, indirection mechanism,
+or demuxer fail as unsupported. Generated output paths are created by the
+runner under the owned run directory and cannot be chosen by manifest fields.
+
+### Retrieval protocol and ground truth
+
+Each split is evaluated as an independent reference collection:
+
+- its canonical source videos form the reference index;
+- every generated variant is a positive query whose only expected reference
+  is its parent source;
+- every distractor is a negative query with no expected reference.
+
+Before benchmarking, reviewers remove or group sources that are genuinely
+similar to more than one reference. The manifest records this decision without
+identifying the source.
+
+For every query/reference pair that crosses the algorithm's threshold, the
+harness records an opaque query ID, opaque reference ID, raw score, threshold,
+and outcome. A returned parent pair is a true positive; a returned wrong
+reference is a false positive; and a parent not returned is a false negative.
+All non-returned negative pairs form the true-negative denominator. A query
+may produce both a true positive and false positives, so top-one accuracy
+cannot substitute for pair-level precision and false-positive rate.
+
+The report also includes operational query-level counts:
+
+- positive queries with the correct parent anywhere in the returned set;
+- positive queries with at least one wrong reference;
+- distractor queries with any returned reference;
+- queries returning more than one reference.
+
+This protocol prevents a permissive matcher from appearing successful merely
+because the correct parent was one of many results. It also makes the reference
+collection size explicit; results cannot be extrapolated to Divine scale
+without a later larger shadow evaluation.
+
+Quality evaluation scores every query against every canonical reference in its
+split. It uses no approximate index, candidate pruning, nearest-neighbor
+library, or early-exit retrieval layer. Optional indexed experiments may be
+reported separately for performance exploration, but they cannot contribute
+to quality gates or replace exhaustive results.
+
+Expected variant count, successfully generated count, and failed count are
+reported for each transform. Generation or decode failures remain in the
+denominator for completion-rate metrics and cannot be silently excluded from
+quality conclusions.
+
+## Threshold selection
+
+The exact supported threshold controls must be taken from the pinned official
+implementations rather than recreated in the harness.
+
+For vPDQ, the canonical source is always the comparison/reference and its
+variant or a distractor is always the query. The sweep controls its asymmetric
+parameters independently:
+
+- PDQ Hamming-distance threshold `D`: 16, 24, 31, and 40;
+- minimum frame-quality filter `F`: 0, 25, 50, and 75;
+- comparison/reference matched-frame percentage `Pc`: 0%, 25%, 50%, 80%,
+  and 100%;
+- query matched-frame percentage `Pq`: 0%, 25%, 50%, 80%, and 100%, including
+  the official example's 0% case.
+
+For TMK+PDQF, explore:
+
+- TMK+PDQF level-one and level-two similarity thresholds around 0.70, 0.80,
+  0.90, and 0.95.
+
+These are sweep bounds, not endorsed production defaults. Unsupported or
+semantically invalid combinations are removed and documented after inspecting
+the pinned CLI behavior. Frame-sampling cadence and all remaining tool options
+are fixed before development evaluation and recorded in the freeze artifact.
+
+Choose each standalone operating point with this lexicographic rule:
+
+1. held-development precision at least 99%;
+2. highest recall among points satisfying that precision floor;
+3. lower compute cost when quality is statistically indistinguishable.
+
+If no point reaches 99% development precision, select the highest-precision
+point for diagnosis and mark the candidate as failing the quality gate. Do not
+adjust thresholds after seeing test results.
+
+The selected algorithm, all thresholds, orientation, sample cadence, tool
+version, development-result digest, and configuration digest are written to a
+content-addressed `frozen-operating-points.json`. The held-out command requires
+that artifact, verifies every digest, and has no tuning code path.
+
+## Metrics
+
+Report confusion counts and the following metrics for every algorithm,
+threshold, split, and transformation class:
+
+- precision;
+- recall;
+- F1;
+- false-positive rate;
+- false negatives;
+- hash-generation wall time and CPU time per second of source video;
+- query wall time per reference/query comparison or indexed query;
+- fingerprint and index bytes per second and per six-second video;
+- decode/hash/query failure count and failure reason.
+
+The final test report includes deterministic bootstrap 95% confidence
+intervals. Positive variants are clustered and resampled at the parent-source
+level; negative distractors are clustered by query ID. Source-level resampling
+prevents many variants of one clip from creating false statistical confidence.
+The quality gate's precision statistic is exhaustive candidate-pair precision;
+correct-parent recall and the fraction of negative queries returning any match
+are separately named operational statistics.
+
+Overall aggregates are shown only alongside transformation-level results. The
+report calls out the worst-performing transform and never ranks candidates
+solely by average F1.
+
+## Spike completion and decision criteria
+
+The research spike is complete when:
+
+- one documented command builds the pinned container and runs the benchmark
+  from a validated manifest;
+- all available source variants and distractors are processed, with every
+  omission explained;
+- synthetic integration tests demonstrate an exact/re-encoded positive and an
+  unrelated negative for both candidates;
+- no source bytes, source URLs, identifying metadata, cryptographic digests,
+  or perceptual fingerprints are committed;
+- a machine-readable result and sanitized aggregate report reproduce the
+  recommendation.
+
+A candidate earns a recommendation for a later, separately designed pilot
+only if its held-out operating point:
+
+- has at least 99% exhaustive candidate-pair precision;
+- returns no match for any of the at least 300 held-out distractor queries and
+  reports the exact one-sided 95% upper confidence bound on the true
+  query-level false-match rate;
+- has at least 90% recall for remux, re-encode, downscale, and watermark
+  classes;
+- reports crop, padding, speed, subsequence, and remix performance separately;
+- processes at least 99% of supported inputs without a crash;
+- hashes at no more than 0.1 CPU-seconds per second of input on the recorded
+  reference machine;
+- averages no more than 10 KiB of fingerprint data per six-second video.
+
+The performance and storage bounds are feasibility screens, not production
+SLOs. The corpus is too small to prove production safety. Passing means only
+that a larger shadow-mode pilot is worth designing.
+
+Zero observed distractor matches is a screening gate, not a claim that the
+false-match rate is zero. With this corpus size, its confidence bound remains
+far too weak to authorize production enforcement.
+
+The report applies this cross-candidate rule:
+
+1. if neither candidate passes every gate, recommend no adoption;
+2. if exactly one passes, recommend that candidate;
+3. if both pass, compare their correct-parent recall with a paired
+   source-level bootstrap;
+4. prefer a candidate for quality only when its recall advantage is at least
+   five percentage points, the 95% interval for that difference excludes
+   zero, and it does not materially regress another required transformation;
+5. when quality is statistically indistinguishable, choose lower measured
+   hash CPU, then lower fingerprint bytes; if both are within 10%, prefer
+   TMK+PDQF's simpler fixed-length storage/query model.
+
+The spike evaluates standalone candidates only. A hybrid would require its own
+ordering, joint threshold tuning, cost model, and held-out freeze, so it is
+deferred rather than invented after test results.
+
+The report must therefore choose exactly one conclusion:
+
+1. recommend vPDQ for a later shadow pilot;
+2. recommend TMK+PDQF for a later shadow pilot;
+3. recommend no adoption.
+
+`report.md` begins with the selected conclusion and a pass/fail table for every
+decision criterion. Transformation-level quality follows, then
+failures/omissions, uncertainty, reproducibility provenance, and limitations.
+It also projects shadow-pilot hashing CPU, storage, and review-queue volume as
+ranges at 10,000, 100,000, and 1,000,000 daily uploads using the measured
+rates and the false-match confidence bound. These projections are planning
+inputs, not production forecasts.
+
+## Output and retention
+
+Each local run writes:
+
+```text
+runs/<run-id>/
+  provenance.json
+  normalized-manifest.json
+  frozen-operating-points.json
+  raw-results.jsonl
+  metrics.json
+  report.md
+  failures.jsonl
+```
+
+The entire `runs/` tree, local inputs, generated variants, and fingerprints
+are gitignored. A sanitized `report.md` may be copied into documentation only
+after checking that it contains aggregate metrics, opaque IDs where examples
+are essential, and no recoverable fingerprints or source paths.
+
+The benchmark never deletes caller-owned input originals. Each run directory
+contains an ownership marker created before any outputs; cleanup refuses a
+directory without that marker, revalidates its canonical location below the
+configured runs root, and deletes only benchmark-owned copies, variants,
+fingerprints, raw pair results, and temporary files for that exact run ID.
+
+The runner invokes scoped cleanup on success and on handled failure. Data kept
+temporarily for diagnosis has a maximum seven-day retention period, and the
+README provides a command that identifies and removes expired owned runs.
+Aggregate-only reporting is the default. Including even an opaque per-video
+example requires an explicit manual sanitization review.
+
+## Privacy, security, and product safeguards
+
+- Inputs are public and non-sensitive; known harmful material is not required.
+- All hashing and matching happens locally.
+- No third-party API receives video, frames, fingerprints, or queries.
+- The run environment has no production credentials.
+- The container receives only an explicit environment allowlist and cannot see
+  host credential directories or agents.
+- Input paths are contained below one declared root and opened without
+  following symlinks outside that root.
+- Output identifiers are opaque and unlinkable to Divine accounts or Nostr
+  identities.
+- Per-video fingerprints are treated as derived sensitive data even when the
+  source is public.
+- Fingerprints and media never appear in logs, test snapshots, exceptions, or
+  committed fixtures.
+- A match is explicitly documented as evidence of visual similarity, not
+  identity, authorship, policy violation, intent, or legal status.
+- Nothing in the spike can call moderation or deletion endpoints.
+
+## Test strategy
+
+Implementation follows TDD. Unit tests are written and observed failing before
+their production code for:
+
+- manifest schema and rejection of identifying/disallowed fields;
+- path containment and symlink escape;
+- deterministic source-level split isolation;
+- transformation command construction and provenance;
+- official tool-output parsing and failure classification;
+- threshold sweep generation and frozen operating-point selection;
+- confusion matrices and zero-denominator handling;
+- source-level bootstrap confidence intervals;
+- sanitization of reports and logs.
+
+Container integration tests use generated synthetic videos to verify:
+
+- both official tools build from the pinned source;
+- exact and re-encoded positives match at a documented smoke threshold;
+- an unrelated synthetic video does not match;
+- malformed and undecodable files produce bounded structured failures;
+- repeated runs with the same seed produce identical assignments and metrics.
+
+The applicable coverage threshold is read from
+`.coverage-thresholds.json` when implementation begins. The benchmark runner
+must meet the repository gate; native third-party code is excluded from Divine
+coverage calculations.
+
+## Risks and mitigations
+
+### Benign data is only a proxy
+
+A non-sensitive corpus avoids handling harmful material but cannot establish
+performance on every adversarial or policy-relevant video. The final report
+must state this limitation, and any later safety pilot requires a separately
+approved, access-controlled evaluation.
+
+### Small-corpus false confidence
+
+Four hundred distractors cannot demonstrate a production-scale false-positive
+rate. The 99% precision floor is a screening point estimate, not proof of
+production safety; confidence intervals are source-grouped, and passing does
+not authorize enforcement.
+
+### Benchmark leakage
+
+Selecting thresholds after examining test results would inflate performance.
+The split is source-isolated, operating points are frozen before the test
+evaluation, and the test command records that freeze.
+
+### Native dependency and supply-chain cost
+
+Both candidates require FFmpeg and native code. Pinning an exact public commit
+and container packages makes the experiment reproducible. Any production use
+would require a separate dependency, license, vulnerability, and maintenance
+review.
+
+### Metric masking
+
+Short clips can make an aggregate look healthy while failing on padding,
+cropping, or partial reuse. Per-transformation results and worst-class
+reporting are mandatory.
+
+### Misuse as a verdict
+
+Perceptual similarity can be mistaken for policy certainty. The spike has no
+enforcement path, and any later system must route matches to human review with
+auditable corpus provenance and thresholds.
+
+## Expected outcome
+
+Based on public benchmark evidence and six-second-video needs, vPDQ is the
+leading candidate because it has stronger published recognition performance
+and can match overlapping clips. TMK+PDQF remains a useful baseline because
+its fixed-length signature has a predictable and readily indexable storage
+model for full-video near duplicates.
+
+That expectation is a hypothesis. The benchmark is successful if it produces
+credible evidence against it as readily as evidence for it.
+
+## Design review
+
+The mandatory design-review gate approved this design after review by:
+
+- Product Management;
+- Architecture;
+- Operator Experience;
+- Security and Privacy;
+- CTO/Executive.
+
+Review changes corrected vPDQ's unordered frame-set semantics, made quality
+evaluation exhaustive, defined its asymmetric controls and orientation,
+removed an unevaluated hybrid conclusion, hardened untrusted-media execution,
+added staged ownership and resource caps, specified the complete operator and
+manifest contract, and made false-positive and cross-candidate decisions
+explicit.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -176,6 +176,8 @@ mod tests {
             transcript_retry_after: None,
             transcript_attempt_count: 0,
             transcript_terminal: false,
+            transcode_generation: None,
+            transcript_generation: None,
         };
         let mut resp = Response::from_status(StatusCode::OK);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1297,6 +1297,9 @@ struct ParsedTranscodeStatusWebhook {
     error_message: Option<String>,
     retry_after_epoch_secs: Option<u64>,
     terminal: bool,
+    /// Monotonic ordering token from the sender. `None` for legacy senders that
+    /// predate the queue; those are always applied (no ordering info to act on).
+    generation: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1311,6 +1314,8 @@ struct ParsedTranscriptStatusWebhook {
     error_message: Option<String>,
     retry_after_epoch_secs: Option<u64>,
     terminal: bool,
+    /// Monotonic ordering token from the sender. `None` for legacy senders.
+    generation: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1405,7 +1410,20 @@ fn parse_transcode_status_webhook_payload(
         error_message: payload["error_message"].as_str().map(|s| s.to_string()),
         retry_after_epoch_secs: parse_optional_retry_after_epoch(payload, now_epoch_secs),
         terminal: parse_optional_bool(payload, "terminal").unwrap_or(false),
+        generation: payload["generation"].as_u64(),
     })
+}
+
+/// Decide whether an incoming status callback is stale relative to what is
+/// already stored. Returns true when the incoming generation is strictly less
+/// than the stored one — i.e. a superseded duplicate that must not be applied.
+/// A missing generation on either side means "no ordering info", so never
+/// stale: legacy senders and first-ever updates always apply.
+fn is_stale_generation(incoming: Option<u64>, stored: Option<u64>) -> bool {
+    match (incoming, stored) {
+        (Some(inc), Some(cur)) => inc < cur,
+        _ => false,
+    }
 }
 
 fn parse_transcript_status_webhook_payload(
@@ -1445,6 +1463,7 @@ fn parse_transcript_status_webhook_payload(
         error_message: payload["error_message"].as_str().map(|s| s.to_string()),
         retry_after_epoch_secs: parse_optional_retry_after_epoch(payload, now_epoch_secs),
         terminal: parse_optional_bool(payload, "terminal").unwrap_or(false),
+        generation: payload["generation"].as_u64(),
     })
 }
 
@@ -2240,6 +2259,8 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
         transcript_retry_after: None,
         transcript_attempt_count: 0,
         transcript_terminal: false,
+        transcode_generation: None,
+        transcript_generation: None,
     };
     let _ = put_blob_metadata(&audio_metadata);
 
@@ -3230,6 +3251,8 @@ fn handle_upload(mut req: Request) -> Result<Response> {
         transcript_retry_after: None,
         transcript_attempt_count: 0,
         transcript_terminal: false,
+        transcode_generation: None,
+        transcript_generation: None,
     };
 
     put_blob_metadata(&metadata)?;
@@ -3459,6 +3482,8 @@ fn publish_upload_service_upload(
             0
         },
         transcript_terminal,
+        transcode_generation: None,
+        transcript_generation: None,
     };
 
     put_blob_metadata(&metadata)?;
@@ -4451,6 +4476,8 @@ fn handle_mirror(mut req: Request) -> Result<Response> {
         transcript_retry_after: None,
         transcript_attempt_count: 0,
         transcript_terminal: false,
+        transcode_generation: None,
+        transcript_generation: None,
     };
 
     put_blob_metadata(&metadata)?;
@@ -4905,44 +4932,57 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
     }
 }
 
-/// POST /admin/transcode-status - Webhook from divine-transcoder service
-/// Updates transcode status for a blob after HLS generation
-fn handle_transcode_status(mut req: Request) -> Result<Response> {
-    // Try to get webhook secret from secret store (same as moderation webhook)
-    let expected_secret: Option<String> =
-        fastly::secret_store::SecretStore::open("blossom_secrets")
-            .ok()
-            .and_then(|store| store.get("webhook_secret"))
-            .map(|secret| String::from_utf8(secret.plaintext().to_vec()).unwrap_or_default());
+/// Validate a transcoder status callback's bearer token.
+///
+/// Accepts EITHER the shared `webhook_secret` (also used by
+/// divine-moderation-service) OR a dedicated `transcoder_webhook_secret`. The
+/// second key lets the transcoder authenticate with its own credential without
+/// sharing moderation's secret — so the transcoder can be re-keyed
+/// independently. Fail-closed if neither key is configured.
+fn validate_transcoder_webhook(req: &Request, label: &str) -> Result<()> {
+    let store = fastly::secret_store::SecretStore::open("blossom_secrets")
+        .map_err(|_| BlossomError::Forbidden("Secret store not available".into()))?;
 
-    // Get Authorization header
-    let auth_header = req
+    let provided = req
         .get_header(header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string());
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|s| s.trim().to_string());
 
-    // Validate secret if configured
-    if let Some(ref expected) = expected_secret {
-        match auth_header {
-            Some(ref header) if header.starts_with("Bearer ") => {
-                let provided = header.strip_prefix("Bearer ").unwrap_or("");
-                if provided != expected.trim() {
-                    eprintln!("[TRANSCODE] Invalid webhook secret");
-                    return Err(BlossomError::Forbidden("Invalid webhook secret".into()));
-                }
+    let mut any_configured = false;
+    for key in ["webhook_secret", "transcoder_webhook_secret"] {
+        if let Some(secret) = store.get(key) {
+            let expected = String::from_utf8(secret.plaintext().to_vec()).unwrap_or_default();
+            let expected = expected.trim().to_string();
+            if expected.is_empty() {
+                continue;
             }
-            _ => {
-                eprintln!("[TRANSCODE] Missing or invalid Authorization header");
-                return Err(BlossomError::AuthRequired("Webhook secret required".into()));
+            any_configured = true;
+            if provided.as_deref() == Some(expected.as_str()) {
+                return Ok(());
             }
         }
-    } else {
-        // Fail closed: reject requests if webhook_secret is not configured
-        eprintln!("[TRANSCODE] webhook_secret not configured, rejecting request");
+    }
+
+    if !any_configured {
+        // Fail closed: reject if no webhook secret is configured at all.
+        eprintln!("[{}] no webhook secret configured, rejecting request", label);
         return Err(BlossomError::Forbidden(
             "Webhook secret not configured".into(),
         ));
     }
+    if provided.is_none() {
+        eprintln!("[{}] Missing or invalid Authorization header", label);
+        return Err(BlossomError::AuthRequired("Webhook secret required".into()));
+    }
+    eprintln!("[{}] Invalid webhook secret", label);
+    Err(BlossomError::Forbidden("Invalid webhook secret".into()))
+}
+
+/// POST /admin/transcode-status - Webhook from divine-transcoder service
+/// Updates transcode status for a blob after HLS generation
+fn handle_transcode_status(mut req: Request) -> Result<Response> {
+    validate_transcoder_webhook(&req, "TRANSCODE")?;
 
     // Parse JSON body
     let body = req.take_body().into_string();
@@ -4964,6 +5004,26 @@ fn handle_transcode_status(mut req: Request) -> Result<Response> {
 
     validate_sha256_format(sha256)?;
 
+    // Drop stale/duplicate callbacks: if the incoming generation is older than
+    // what we already applied, this is a superseded redelivery. Return 200 so
+    // Cloud Tasks stops retrying it, but do not apply or purge.
+    if let Some(existing) = crate::metadata::get_blob_metadata(sha256)? {
+        if is_stale_generation(parsed.generation, existing.transcode_generation) {
+            eprintln!(
+                "[TRANSCODE] Ignoring stale callback for {}: incoming gen {:?} < stored {:?}",
+                sha256, parsed.generation, existing.transcode_generation
+            );
+            let response = serde_json::json!({
+                "success": true,
+                "sha256": sha256,
+                "ignored": "stale_generation"
+            });
+            let mut resp = json_response(StatusCode::OK, &response);
+            add_cors_headers(&mut resp);
+            return Ok(resp);
+        }
+    }
+
     // Update transcode status (and optionally file size and dimensions if provided)
     use crate::metadata::update_transcode_status_with_metadata;
     match update_transcode_status_with_metadata(
@@ -4978,6 +5038,7 @@ fn handle_transcode_status(mut req: Request) -> Result<Response> {
             retry_after: parsed.retry_after_epoch_secs,
             terminal: Some(parsed.terminal),
             increment_attempt_count: matches!(parsed.status, TranscodeStatus::Failed),
+            generation: parsed.generation,
         },
     ) {
         Ok(()) => {
@@ -5038,41 +5099,7 @@ fn handle_transcode_status(mut req: Request) -> Result<Response> {
 /// POST /admin/transcript-status - Webhook from divine-transcoder service
 /// Updates transcript status for a blob after VTT generation
 fn handle_transcript_status(mut req: Request) -> Result<Response> {
-    // Try to get webhook secret from secret store (same as moderation/transcode webhook)
-    let expected_secret: Option<String> =
-        fastly::secret_store::SecretStore::open("blossom_secrets")
-            .ok()
-            .and_then(|store| store.get("webhook_secret"))
-            .map(|secret| String::from_utf8(secret.plaintext().to_vec()).unwrap_or_default());
-
-    // Get Authorization header
-    let auth_header = req
-        .get_header(header::AUTHORIZATION)
-        .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string());
-
-    // Validate secret if configured
-    if let Some(ref expected) = expected_secret {
-        match auth_header {
-            Some(ref header) if header.starts_with("Bearer ") => {
-                let provided = header.strip_prefix("Bearer ").unwrap_or("");
-                if provided != expected.trim() {
-                    eprintln!("[TRANSCRIPT] Invalid webhook secret");
-                    return Err(BlossomError::Forbidden("Invalid webhook secret".into()));
-                }
-            }
-            _ => {
-                eprintln!("[TRANSCRIPT] Missing or invalid Authorization header");
-                return Err(BlossomError::AuthRequired("Webhook secret required".into()));
-            }
-        }
-    } else {
-        // Fail closed: reject requests if webhook_secret is not configured
-        eprintln!("[TRANSCRIPT] webhook_secret not configured, rejecting request");
-        return Err(BlossomError::Forbidden(
-            "Webhook secret not configured".into(),
-        ));
-    }
+    validate_transcoder_webhook(&req, "TRANSCRIPT")?;
 
     // Parse JSON body
     let body = req.take_body().into_string();
@@ -5089,6 +5116,24 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
 
     validate_sha256_format(sha256)?;
 
+    // Drop stale/duplicate callbacks (see handle_transcode_status).
+    if let Some(existing) = crate::metadata::get_blob_metadata(sha256)? {
+        if is_stale_generation(parsed.generation, existing.transcript_generation) {
+            eprintln!(
+                "[TRANSCRIPT] Ignoring stale callback for {}: incoming gen {:?} < stored {:?}",
+                sha256, parsed.generation, existing.transcript_generation
+            );
+            let response = serde_json::json!({
+                "success": true,
+                "sha256": sha256,
+                "ignored": "stale_generation"
+            });
+            let mut resp = json_response(StatusCode::OK, &response);
+            add_cors_headers(&mut resp);
+            return Ok(resp);
+        }
+    }
+
     use crate::metadata::update_transcript_status;
     match update_transcript_status(
         sha256,
@@ -5100,6 +5145,7 @@ fn handle_transcript_status(mut req: Request) -> Result<Response> {
             retry_after: parsed.retry_after_epoch_secs,
             terminal: Some(parsed.terminal),
             increment_attempt_count: matches!(parsed.status, TranscriptStatus::Failed),
+            generation: parsed.generation,
         },
     ) {
         Ok(()) => {
@@ -5772,16 +5818,62 @@ mod tests {
     use super::{
         backfill_batch_cursor, classify_audio_reuse_availability, decide_transcode_fetch_action,
         decide_transcript_fetch_action, error_response, is_alias_only_audio_blob,
-        is_quality_variant_path, parse_quality_variant_path,
-        parse_transcript_status_webhook_payload, should_delete_derived_audio_blob,
-        should_eagerly_trigger_transcription, should_set_audio_content_length,
-        upload_capability_headers, upload_control_host, upload_exposed_headers,
-        AudioReuseAvailability, TranscodeFetchAction, TranscriptFetchAction,
+        is_quality_variant_path, is_stale_generation, parse_quality_variant_path,
+        parse_transcode_status_webhook_payload, parse_transcript_status_webhook_payload,
+        should_delete_derived_audio_blob, should_eagerly_trigger_transcription,
+        should_set_audio_content_length, upload_capability_headers, upload_control_host,
+        upload_exposed_headers, AudioReuseAvailability, TranscodeFetchAction, TranscriptFetchAction,
         TranscriptPendingState,
     };
     use crate::blossom::{TranscodeStatus, TranscriptStatus};
     use crate::error::{BlossomError, Result as BlossomResult};
     use fastly::http::StatusCode;
+
+    #[test]
+    fn stale_generation_ordering() {
+        // Newer supersedes older -> older is stale.
+        assert!(is_stale_generation(Some(3), Some(5)));
+        // Equal is not stale (idempotent redelivery still applies once; the
+        // no-op write is harmless and status is unchanged).
+        assert!(!is_stale_generation(Some(5), Some(5)));
+        // Newer than stored -> apply.
+        assert!(!is_stale_generation(Some(6), Some(5)));
+        // Missing info on either side -> never stale (legacy sender / first update).
+        assert!(!is_stale_generation(None, Some(5)));
+        assert!(!is_stale_generation(Some(3), None));
+        assert!(!is_stale_generation(None, None));
+    }
+
+    #[test]
+    fn transcode_payload_parses_generation() {
+        let payload = serde_json::json!({
+            "sha256": "a".repeat(64),
+            "status": "complete",
+            "generation": 1_700_000_000_123_u64
+        });
+        let parsed = parse_transcode_status_webhook_payload(&payload, 0).unwrap();
+        assert_eq!(parsed.generation, Some(1_700_000_000_123));
+
+        // A legacy payload with no generation parses as None (always applied).
+        let legacy = serde_json::json!({ "sha256": "a".repeat(64), "status": "complete" });
+        assert_eq!(
+            parse_transcode_status_webhook_payload(&legacy, 0)
+                .unwrap()
+                .generation,
+            None
+        );
+    }
+
+    #[test]
+    fn transcript_payload_parses_generation() {
+        let payload = serde_json::json!({
+            "sha256": "b".repeat(64),
+            "status": "processing",
+            "generation": 42_u64
+        });
+        let parsed = parse_transcript_status_webhook_payload(&payload, 0).unwrap();
+        assert_eq!(parsed.generation, Some(42));
+    }
 
     #[test]
     fn quality_variant_path_valid() {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -281,6 +281,10 @@ pub struct TranscodeMetadataUpdate {
     pub retry_after: Option<u64>,
     pub terminal: Option<bool>,
     pub increment_attempt_count: bool,
+    /// Monotonic ordering token from the sender. When present it is persisted so
+    /// later callbacks can be ordered against it. `None` (internal callers)
+    /// leaves any stored generation untouched.
+    pub generation: Option<u64>,
 }
 
 /// Update transcode status and associated failure metadata for a video blob.
@@ -332,6 +336,10 @@ pub fn update_transcode_status_with_metadata(
         metadata.dim = Some(d);
     }
 
+    // Persist the ordering token when the sender provided one; otherwise keep
+    // whatever is already stored (internal callers pass None).
+    metadata.transcode_generation = update.generation.or(metadata.transcode_generation);
+
     put_blob_metadata(&metadata)?;
 
     Ok(())
@@ -346,6 +354,8 @@ pub struct TranscriptMetadataUpdate {
     pub retry_after: Option<u64>,
     pub terminal: Option<bool>,
     pub increment_attempt_count: bool,
+    /// Monotonic ordering token from the sender; see `TranscodeMetadataUpdate`.
+    pub generation: Option<u64>,
 }
 
 pub fn update_transcript_status(
@@ -386,6 +396,7 @@ pub fn update_transcript_status(
             metadata.transcript_terminal = update.terminal.unwrap_or(false);
         }
     }
+    metadata.transcript_generation = update.generation.or(metadata.transcript_generation);
     put_blob_metadata(&metadata)?;
 
     Ok(())


### PR DESCRIPTION
## Summary

Make transcoder status callbacks (HLS + transcript) durable, and fix a pre-existing auth failure that had been silently dropping all of them.

**Delivery**
- Transcoder `send_status_webhook` / `send_transcript_status_webhook` now route through `deliver_status_payload`: enqueue to a Cloud Tasks queue when `STATUS_QUEUE_ENABLED`, else direct POST (rollback path). Cloud Tasks owns retries, backoff, and dead-lettering.
- Each callback carries a monotonic `generation` (send-time millis).

**Receiver ordering / idempotency**
- `BlobMetadata` gains `transcode_generation` / `transcript_generation`.
- Both status handlers drop callbacks whose generation is older than what's stored, returning `200 {"ignored":"stale_generation"}` so the queue stops retrying. Redelivery of the same update is a no-op.
- Backward compatible: a missing `generation` always applies (legacy senders, first update).

**Webhook auth fix**
- Transcoder status callbacks had been returning `403 Invalid webhook secret` for a long time — a secret mismatch between the transcoder's credential and the edge's stored value (the latter shared with, and canonical to, the moderation service). The system had been relying entirely on the `admin_sweep` GCS-reconciliation backstop.
- `validate_transcoder_webhook` now accepts a dedicated `transcoder_webhook_secret` in addition to the shared `webhook_secret`, letting the transcoder be re-keyed independently. The shared secret is untouched, so the moderation path is unaffected.

## Motivation

Status callbacks were not "occasionally lost" — they were being rejected on auth, so derivative status only ever advanced via reconciliation. This makes delivery durable and correct, and removes the silent auth failure.

## Linked issue

None yet — happy to file one if wanted. Design/rollout notes: `docs/superpowers/plans/2026-07-24-derivative-status-queue-simple.md`.

## Manual validation

- Auth: `POST /admin/transcode-status` with the new transcoder secret → `404` (past auth, unknown blob); `/admin/transcript-status` → `202`; wrong secret → `403`. No new `403`s from the redeployed transcoder revision.
- Build: transcoder unit tests + `blossom-core` tests pass; edge type-checks via `cargo check --tests` (Fastly SDK is WASM-only, so edge `#[test]`s can't link natively — per AGENTS.md).
- Rollout: queue created; enqueuer role granted; two Cloud Monitoring alerts (queue depth, failing delivery attempts); edge + transcoder deployed; `STATUS_QUEUE_ENABLED=true`.

## No visual change

Backend/infra only. No edge/upload/UI behavior change beyond the delivery transport and stale-drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)