### PR TITLE
fix(media): serve public blobs whole so edge cache stores video bytes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -346,6 +346,22 @@ fn should_set_audio_content_length(status: StatusCode) -> bool {
     status != StatusCode::PARTIAL_CONTENT
 }
 
+/// Decide which Range header, if any, to forward to origin storage.
+/// Publicly cacheable objects are always fetched whole: an origin 206 response
+/// cannot be stored by the edge cache, so forwarding client ranges for public
+/// media would send every play to origin. Private/admin responses are never
+/// cached, so their ranges pass through and avoid re-downloading whole objects.
+fn origin_range_for_request(
+    client_range: Option<&str>,
+    publicly_cacheable: bool,
+) -> Option<&str> {
+    if publicly_cacheable {
+        None
+    } else {
+        client_range
+    }
+}
+
 fn clear_stale_audio_mapping(source_hash: &str, audio_hash: &str) {
     let _ = delete_audio_mapping(source_hash);
     match remove_from_audio_source_refs(audio_hash, source_hash) {
@@ -531,8 +547,18 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_string());
 
+    // Public blobs are fetched whole so the edge cache stores the full object;
+    // only private/admin traffic gets partial responses from origin. Keep this
+    // in sync with the cache-header decision below.
+    let publicly_cacheable = !is_admin
+        && metadata
+            .as_ref()
+            .map(|meta| meta.status == BlobStatus::Active)
+            .unwrap_or(false);
+    let upstream_range = origin_range_for_request(range.as_deref(), publicly_cacheable);
+
     // Download from GCS with fallback to CDNs
-    let result = download_blob_with_fallback(&hash, range.as_deref())?;
+    let result = download_blob_with_fallback(&hash, upstream_range)?;
     let mut resp = result.response;
 
     // Surface provenance metadata if present on the origin object.
@@ -2167,6 +2193,7 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
         .get_header(header::RANGE)
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_string());
+    let upstream_range = origin_range_for_request(range.as_deref(), !private_cache);
 
     // 5. Check cache: source->audio mapping
     if let Some(mapping) = get_audio_mapping(&hash)? {
@@ -2176,7 +2203,7 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
                 BlossomError::Internal(format!("Failed to persist audio source refs: {}", e))
             })?;
             // Serve cached audio via redirect or proxy
-            let result = download_blob_with_fallback(&mapping.audio_sha256, range.as_deref())?;
+            let result = download_blob_with_fallback(&mapping.audio_sha256, upstream_range)?;
             let mut resp = result.response;
             add_audio_response_headers(
                 &mut resp,
@@ -2262,7 +2289,7 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
     })?;
 
     // 8. Download and serve the audio
-    let result = download_blob_with_fallback(&audio_sha256, range.as_deref())?;
+    let result = download_blob_with_fallback(&audio_sha256, upstream_range)?;
     let mut resp = result.response;
     add_audio_response_headers(&mut resp, &hash, private_cache, &mime_type, size, duration);
     Ok(resp)
@@ -5831,7 +5858,7 @@ mod tests {
     use super::{
         backfill_batch_cursor, classify_audio_reuse_availability, decide_transcode_fetch_action,
         decide_transcript_fetch_action, error_response, is_alias_only_audio_blob,
-        is_quality_variant_path, parse_quality_variant_path,
+        is_quality_variant_path, origin_range_for_request, parse_quality_variant_path,
         parse_transcript_status_webhook_payload, should_delete_derived_audio_blob,
         should_eagerly_trigger_transcription, should_set_audio_content_length,
         upload_capability_headers, upload_control_host, upload_exposed_headers,
@@ -6134,6 +6161,25 @@ mod tests {
         assert!(!should_set_audio_content_length(
             StatusCode::PARTIAL_CONTENT
         ));
+    }
+
+    #[test]
+    fn publicly_cacheable_media_drops_client_range_for_origin() {
+        assert_eq!(origin_range_for_request(Some("bytes=0-1023"), true), None);
+    }
+
+    #[test]
+    fn privately_cached_media_forwards_client_range_to_origin() {
+        assert_eq!(
+            origin_range_for_request(Some("bytes=0-1023"), false),
+            Some("bytes=0-1023")
+        );
+    }
+
+    #[test]
+    fn origin_range_absent_when_client_sent_no_range() {
+        assert_eq!(origin_range_for_request(None, true), None);
+        assert_eq!(origin_range_for_request(None, false), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,7 +328,7 @@ fn add_audio_response_headers(
 ) {
     let set_full_content_length = should_set_audio_content_length(resp.get_status());
     resp.set_header("Content-Type", mime_type);
-    if set_full_content_length {
+    if set_full_content_length && size_bytes > 0 {
         resp.set_header("Content-Length", size_bytes.to_string());
     }
     resp.set_header("X-Audio-Duration", format!("{}", duration_seconds));
@@ -346,19 +346,28 @@ fn should_set_audio_content_length(status: StatusCode) -> bool {
     status != StatusCode::PARTIAL_CONTENT
 }
 
+fn blob_response_requires_private_cache(
+    is_admin: bool,
+    status: Option<BlobStatus>,
+    has_authorization_header: bool,
+) -> bool {
+    is_admin || has_authorization_header || status.map(|s| s != BlobStatus::Active).unwrap_or(true)
+}
+
 /// Decide which Range header, if any, to forward to origin storage.
-/// Publicly cacheable objects are always fetched whole: an origin 206 response
-/// cannot be stored by the edge cache, so forwarding client ranges for public
-/// media would send every play to origin. Private/admin responses are never
-/// cached, so their ranges pass through and avoid re-downloading whole objects.
+/// Edge-cacheable objects are fetched whole: an origin 206 response cannot be
+/// stored by the cache, so forwarding client ranges would send every play to
+/// origin. Responses that VCL passes or Compute marks private keep the range.
 fn origin_range_for_request(
     client_range: Option<&str>,
-    publicly_cacheable: bool,
+    is_admin: bool,
+    status: Option<BlobStatus>,
+    has_authorization_header: bool,
 ) -> Option<&str> {
-    if publicly_cacheable {
-        None
-    } else {
+    if blob_response_requires_private_cache(is_admin, status, has_authorization_header) {
         client_range
+    } else {
+        None
     }
 }
 
@@ -547,15 +556,18 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_string());
 
-    // Public blobs are fetched whole so the edge cache stores the full object;
-    // only private/admin traffic gets partial responses from origin. Keep this
-    // in sync with the cache-header decision below.
-    let publicly_cacheable = !is_admin
-        && metadata
-            .as_ref()
-            .map(|meta| meta.status == BlobStatus::Active)
-            .unwrap_or(false);
-    let upstream_range = origin_range_for_request(range.as_deref(), publicly_cacheable);
+    let has_authorization_header = req.get_header(header::AUTHORIZATION).is_some();
+    let private_cache = blob_response_requires_private_cache(
+        is_admin,
+        metadata.as_ref().map(|meta| meta.status),
+        has_authorization_header,
+    );
+    let upstream_range = origin_range_for_request(
+        range.as_deref(),
+        is_admin,
+        metadata.as_ref().map(|meta| meta.status),
+        has_authorization_header,
+    );
 
     // Download from GCS with fallback to CDNs
     let result = download_blob_with_fallback(&hash, upstream_range)?;
@@ -614,21 +626,15 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
 
     // Content is addressed by SHA256 hash, so it's immutable - cache aggressively.
     // Exception: restricted/admin content must not be publicly cached.
-    if is_admin {
-        // Admin bypass: never cache, expose moderation status
-        resp.set_header("Cache-Control", "private, no-store");
-        if let Some(ref meta) = metadata {
-            resp.set_header("X-Moderation-Status", &format!("{:?}", meta.status));
-        }
+    if private_cache {
+        add_private_cache_headers(&mut resp, &hash);
     } else {
-        let is_restricted = metadata
-            .as_ref()
-            .map(|m| m.status != BlobStatus::Active)
-            .unwrap_or(false);
-        if is_restricted {
-            add_private_cache_headers(&mut resp, &hash);
-        } else {
-            add_cache_headers(&mut resp, &hash);
+        add_cache_headers(&mut resp, &hash);
+    }
+    if is_admin {
+        // Admin bypass exposes moderation status for tooling.
+        if let Some(ref meta) = metadata {
+            resp.set_header("X-Moderation-Status", format!("{:?}", meta.status));
         }
     }
 
@@ -2178,7 +2184,12 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
         AudioReuseAvailability::LookupUnavailable => return Ok(audio_lookup_unavailable_response()),
     }
 
-    let private_cache = is_admin || metadata.status.requires_private_cache();
+    let has_authorization_header = req.get_header(header::AUTHORIZATION).is_some();
+    let private_cache = blob_response_requires_private_cache(
+        is_admin,
+        Some(metadata.status),
+        has_authorization_header,
+    );
 
     // 4. Must be a video source
     if !is_video_mime_type(&metadata.mime_type) {
@@ -2193,7 +2204,12 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
         .get_header(header::RANGE)
         .and_then(|h| h.to_str().ok())
         .map(|s| s.to_string());
-    let upstream_range = origin_range_for_request(range.as_deref(), !private_cache);
+    let upstream_range = origin_range_for_request(
+        range.as_deref(),
+        is_admin,
+        Some(metadata.status),
+        has_authorization_header,
+    );
 
     // 5. Check cache: source->audio mapping
     if let Some(mapping) = get_audio_mapping(&hash)? {
@@ -2241,7 +2257,9 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
         .audio_sha256
         .ok_or_else(|| BlossomError::Internal("Audio extraction returned no hash".into()))?;
     let duration = extraction.duration.unwrap_or(0.0);
-    let size = extraction.size.unwrap_or(0);
+    let size = extraction
+        .size
+        .ok_or_else(|| BlossomError::Internal("Audio extraction returned no size".into()))?;
     let mime_type = extraction
         .mime_type
         .unwrap_or_else(|| "audio/mp4".to_string());
@@ -5856,7 +5874,8 @@ fn infer_mime_from_path(path: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        backfill_batch_cursor, classify_audio_reuse_availability, decide_transcode_fetch_action,
+        backfill_batch_cursor, blob_response_requires_private_cache,
+        classify_audio_reuse_availability, decide_transcode_fetch_action,
         decide_transcript_fetch_action, error_response, is_alias_only_audio_blob,
         is_quality_variant_path, origin_range_for_request, parse_quality_variant_path,
         parse_transcript_status_webhook_payload, should_delete_derived_audio_blob,
@@ -5865,7 +5884,7 @@ mod tests {
         AudioReuseAvailability, TranscodeFetchAction, TranscriptFetchAction,
         TranscriptPendingState,
     };
-    use crate::blossom::{TranscodeStatus, TranscriptStatus};
+    use crate::blossom::{BlobStatus, TranscodeStatus, TranscriptStatus};
     use crate::error::{BlossomError, Result as BlossomResult};
     use fastly::http::StatusCode;
 
@@ -6164,22 +6183,57 @@ mod tests {
     }
 
     #[test]
-    fn publicly_cacheable_media_drops_client_range_for_origin() {
-        assert_eq!(origin_range_for_request(Some("bytes=0-1023"), true), None);
+    fn public_anonymous_active_media_drops_client_range_for_origin() {
+        assert_eq!(
+            origin_range_for_request(Some("bytes=0-1023"), false, Some(BlobStatus::Active), false),
+            None
+        );
     }
 
     #[test]
-    fn privately_cached_media_forwards_client_range_to_origin() {
+    fn authorized_public_media_forwards_client_range_to_origin() {
         assert_eq!(
-            origin_range_for_request(Some("bytes=0-1023"), false),
+            origin_range_for_request(Some("bytes=0-1023"), false, Some(BlobStatus::Active), true),
+            Some("bytes=0-1023")
+        );
+    }
+
+    #[test]
+    fn admin_media_forwards_client_range_to_origin() {
+        assert_eq!(
+            origin_range_for_request(Some("bytes=0-1023"), true, Some(BlobStatus::Active), false),
+            Some("bytes=0-1023")
+        );
+    }
+
+    #[test]
+    fn pending_media_uses_private_cache_policy_and_forwards_range() {
+        assert!(blob_response_requires_private_cache(
+            false,
+            Some(BlobStatus::Pending),
+            false
+        ));
+        assert_eq!(
+            origin_range_for_request(
+                Some("bytes=0-1023"),
+                false,
+                Some(BlobStatus::Pending),
+                false
+            ),
             Some("bytes=0-1023")
         );
     }
 
     #[test]
     fn origin_range_absent_when_client_sent_no_range() {
-        assert_eq!(origin_range_for_request(None, true), None);
-        assert_eq!(origin_range_for_request(None, false), None);
+        assert_eq!(
+            origin_range_for_request(None, false, Some(BlobStatus::Active), false),
+            None
+        );
+        assert_eq!(
+            origin_range_for_request(None, true, Some(BlobStatus::Active), false),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #154

Publicly edge-cacheable blob/audio GETs are now fetched **whole** from origin instead of forwarding the client's `Range` header, so the VCL edge cache stores the full object and synthesizes 206 Partial Content responses for subsequent anonymous range requests.

The range policy now uses the same cacheability facts as the response headers and VCL pass rule:

- anonymous, non-admin, Active media -> drop the origin range so the edge can cache the full object
- requests with `Authorization`, admin traffic, missing metadata, and non-Active media -> forward the range and mark the response private/no-store

## Motivation

Video players fetch via byte-range requests. Forwarding those ranges to origin produced genuine `206` responses that the edge cache cannot store — so video bytes never entered the cache and every play streamed from origin (request hit rate ~82% vs byte offload ~14%). Full diagnosis and probes: `docs/cache-offload-report-2026-07-29.md` (on `docs/cache-offload-report`).

## Behavior change (externally visible)

- **Cold anonymous public video/audio with a `Range` header**: now returns `200 OK` with the full object instead of `206` with the requested slice. This is RFC 7233-legal (servers MAY ignore Range), but should still get iOS/Android/web playback verification before deploy.
- **Requests carrying `Authorization`**: keep real origin 206s and are marked private/no-store, matching VCL's `return(pass)` behavior and avoiding whole-object re-download amplification on uncached passes.
- **Private/admin/age-gated/non-Active traffic**: keeps real 206s and is not publicly cached.
- **HLS quality-variant paths (`/{hash}/720p`, etc.)** are deliberately unchanged: playlists use EXT-X-BYTERANGE against single-file TS, and strict HLS player behavior with a full 200 needs verification first (tracked in #154).

No visual/client-UI change.

## Validation

- [x] `cargo check --tests --locked` — passed with existing dead-code warnings
- [x] `cargo clippy --locked --all-targets --all-features` — passed with existing warnings
- [x] `cargo test -p blossom-core --locked` — 115 passed
- [x] Unit coverage for origin range/cache policy: public anonymous drops range; Authorization/admin/Pending forward range; absent range stays absent
- [ ] **Post-deploy manual probes** (from #154): repeated identical range request on an anonymous public video must return `x-cache: HIT`; a different range on the same object must also HIT; an authorized public range request should continue to pass through without full-object amplification; watch byte-level origin offload and avg miss time for 48h.

Deploy plan after merge: `fastly compute publish` + purge, then the probes above. Rollback: reactivate previous Compute version.
