### PR TITLE
fix(edge): accept dedicated transcoder webhook secret

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -56,39 +56,37 @@ pub fn validate_admin_auth(req: &Request) -> Result<()> {
 /// Accepts either admin_token or webhook_secret from the Fastly Secret Store.
 /// Both are checked independently — webhook_secret is used by divine-moderation-service.
 pub fn validate_bearer_token(req: &Request) -> Result<()> {
-    let provided = req
-        .get_header(header::AUTHORIZATION)
+    let provided = extract_bearer_token(req)
+        .ok_or_else(|| BlossomError::AuthRequired("Admin authentication required".into()))?;
+
+    validate_bearer_token_against_secret_keys(&provided, &["admin_token", "webhook_secret"])
+        .map_err(|_| BlossomError::Forbidden("Invalid admin token".into()))
+}
+
+pub fn extract_bearer_token(req: &Request) -> Option<String> {
+    req.get_header(header::AUTHORIZATION)
         .and_then(|h| h.to_str().ok())
         .and_then(|s| s.strip_prefix("Bearer "))
         .map(|s| s.trim().to_string())
-        .ok_or_else(|| BlossomError::AuthRequired("Admin authentication required".into()))?;
+}
 
+pub fn validate_bearer_token_against_secret_keys(provided: &str, keys: &[&str]) -> Result<()> {
     let store = fastly::secret_store::SecretStore::open("blossom_secrets")
         .map_err(|_| BlossomError::Forbidden("Secret store not available".into()))?;
 
-    // Accept admin_token
-    if let Some(secret) = store.get("admin_token") {
-        let token = String::from_utf8(secret.plaintext().to_vec())
-            .unwrap_or_default()
-            .trim()
-            .to_string();
-        if !token.is_empty() && provided == token {
-            return Ok(());
+    for key in keys {
+        if let Some(secret) = store.get(key) {
+            let token = String::from_utf8(secret.plaintext().to_vec())
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            if !token.is_empty() && provided == token {
+                return Ok(());
+            }
         }
     }
 
-    // Accept webhook_secret (used by divine-moderation-service)
-    if let Some(secret) = store.get("webhook_secret") {
-        let token = String::from_utf8(secret.plaintext().to_vec())
-            .unwrap_or_default()
-            .trim()
-            .to_string();
-        if !token.is_empty() && provided == token {
-            return Ok(());
-        }
-    }
-
-    Err(BlossomError::Forbidden("Invalid admin token".into()))
+    Err(BlossomError::Forbidden("Invalid bearer token".into()))
 }
 
 /// Extract session token from Cookie header
@@ -108,7 +106,7 @@ fn get_session_cookie(req: &Request) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{get_session_cookie, set_admin_blob_response_headers};
+    use super::{extract_bearer_token, get_session_cookie, set_admin_blob_response_headers};
     use crate::blossom::{BlobMetadata, BlobStatus};
     use fastly::http::header;
     use fastly::http::StatusCode;
@@ -128,6 +126,22 @@ mod tests {
         req.set_header(header::COOKIE, "session=abc123");
 
         assert_eq!(get_session_cookie(&req), None);
+    }
+
+    #[test]
+    fn extracts_trimmed_bearer_token() {
+        let mut req = Request::get("https://media.divine.video/admin");
+        req.set_header(header::AUTHORIZATION, "Bearer  s3cret  ");
+
+        assert_eq!(extract_bearer_token(&req).as_deref(), Some("s3cret"));
+    }
+
+    #[test]
+    fn bearer_token_requires_bearer_scheme() {
+        let mut req = Request::get("https://media.divine.video/admin");
+        req.set_header(header::AUTHORIZATION, "Basic s3cret");
+
+        assert_eq!(extract_bearer_token(&req), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5009,44 +5009,32 @@ fn handle_admin_moderate(mut req: Request) -> Result<Response> {
     }
 }
 
+fn validate_transcoder_webhook(req: &Request, label: &str) -> Result<()> {
+    let Some(provided) = admin::extract_bearer_token(req) else {
+        eprintln!("[{}] Missing or invalid Authorization header", label);
+        return Err(BlossomError::AuthRequired("Webhook secret required".into()));
+    };
+
+    match admin::validate_bearer_token_against_secret_keys(
+        &provided,
+        &["webhook_secret", "transcoder_webhook_secret"],
+    ) {
+        Ok(()) => Ok(()),
+        Err(BlossomError::Forbidden(message)) if message == "Secret store not available" => {
+            eprintln!("[{}] secret store not available, rejecting request", label);
+            Err(BlossomError::Forbidden("Secret store not available".into()))
+        }
+        Err(_) => {
+            eprintln!("[{}] Invalid webhook secret", label);
+            Err(BlossomError::Forbidden("Invalid webhook secret".into()))
+        }
+    }
+}
+
 /// POST /admin/transcode-status - Webhook from divine-transcoder service
 /// Updates transcode status for a blob after HLS generation
 fn handle_transcode_status(mut req: Request) -> Result<Response> {
-    // Try to get webhook secret from secret store (same as moderation webhook)
-    let expected_secret: Option<String> =
-        fastly::secret_store::SecretStore::open("blossom_secrets")
-            .ok()
-            .and_then(|store| store.get("webhook_secret"))
-            .map(|secret| String::from_utf8(secret.plaintext().to_vec()).unwrap_or_default());
-
-    // Get Authorization header
-    let auth_header = req
-        .get_header(header::AUTHORIZATION)
-        .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string());
-
-    // Validate secret if configured
-    if let Some(ref expected) = expected_secret {
-        match auth_header {
-            Some(ref header) if header.starts_with("Bearer ") => {
-                let provided = header.strip_prefix("Bearer ").unwrap_or("");
-                if provided != expected.trim() {
-                    eprintln!("[TRANSCODE] Invalid webhook secret");
-                    return Err(BlossomError::Forbidden("Invalid webhook secret".into()));
-                }
-            }
-            _ => {
-                eprintln!("[TRANSCODE] Missing or invalid Authorization header");
-                return Err(BlossomError::AuthRequired("Webhook secret required".into()));
-            }
-        }
-    } else {
-        // Fail closed: reject requests if webhook_secret is not configured
-        eprintln!("[TRANSCODE] webhook_secret not configured, rejecting request");
-        return Err(BlossomError::Forbidden(
-            "Webhook secret not configured".into(),
-        ));
-    }
+    validate_transcoder_webhook(&req, "TRANSCODE")?;
 
     // Parse JSON body
     let body = req.take_body().into_string();
@@ -5142,41 +5130,7 @@ fn handle_transcode_status(mut req: Request) -> Result<Response> {
 /// POST /admin/transcript-status - Webhook from divine-transcoder service
 /// Updates transcript status for a blob after VTT generation
 fn handle_transcript_status(mut req: Request) -> Result<Response> {
-    // Try to get webhook secret from secret store (same as moderation/transcode webhook)
-    let expected_secret: Option<String> =
-        fastly::secret_store::SecretStore::open("blossom_secrets")
-            .ok()
-            .and_then(|store| store.get("webhook_secret"))
-            .map(|secret| String::from_utf8(secret.plaintext().to_vec()).unwrap_or_default());
-
-    // Get Authorization header
-    let auth_header = req
-        .get_header(header::AUTHORIZATION)
-        .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string());
-
-    // Validate secret if configured
-    if let Some(ref expected) = expected_secret {
-        match auth_header {
-            Some(ref header) if header.starts_with("Bearer ") => {
-                let provided = header.strip_prefix("Bearer ").unwrap_or("");
-                if provided != expected.trim() {
-                    eprintln!("[TRANSCRIPT] Invalid webhook secret");
-                    return Err(BlossomError::Forbidden("Invalid webhook secret".into()));
-                }
-            }
-            _ => {
-                eprintln!("[TRANSCRIPT] Missing or invalid Authorization header");
-                return Err(BlossomError::AuthRequired("Webhook secret required".into()));
-            }
-        }
-    } else {
-        // Fail closed: reject requests if webhook_secret is not configured
-        eprintln!("[TRANSCRIPT] webhook_secret not configured, rejecting request");
-        return Err(BlossomError::Forbidden(
-            "Webhook secret not configured".into(),
-        ));
-    }
+    validate_transcoder_webhook(&req, "TRANSCRIPT")?;
 
     // Parse JSON body
     let body = req.take_body().into_string();


### PR DESCRIPTION
## Summary
- share bearer token parsing/Secret Store validation for admin-style bearer checks
- let transcoder status callbacks authenticate with either webhook_secret or transcoder_webhook_secret
- keep moderation on the existing shared webhook_secret path

## Motivation
Closes #156. The transcoder status endpoints currently accept only the shared moderation webhook secret, which couples transcoder credential rotation to moderation and can make status callbacks 403 when the credentials diverge.

## Validation
- cargo check --tests --locked

## No visual change
Backend auth path only.