### PR TITLE
fix(harness): cap ProofMode headers so the debugger stops reproducing the bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         working-directory: cloud-run-transcoder
         run: python3 -m unittest discover -s tests -p 'test_*.py'
 
+      - name: Run script Python tests
+        run: python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+
       - name: Run clippy
         run: cargo clippy --locked --all-targets --all-features
 

--- a/scripts/debug_upload_harness.py
+++ b/scripts/debug_upload_harness.py
@@ -19,6 +19,20 @@ import urllib.request
 DEFAULT_TIMEOUT_SECONDS = 30
 SUCCESS_STATUSES = {200, 201, 204}
 
+# Combined wire budget for the X-ProofMode-* request headers, mirroring
+# BlossomUploadService.maxProofModeHeaderBytes in divine-mobile.
+#
+# media.divine.video rejects requests whose combined headers exceed 128 KiB
+# over HTTP/1.1 (with a 502) or 64 KiB over HTTP/2 (by closing the connection).
+# An Android hardware attestation chain is ~54 KB and lands in the manifest
+# twice — ~75 KB base64 in X-ProofMode-Manifest plus ~72 KB in
+# X-ProofMode-Attestation — so replaying a real proof through this harness
+# reproduced the client bug instead of diagnosing it.
+#
+# No Blossom server reads these headers; the canonical manifest is the
+# proofmode tag on the kind 34236 event.
+MAX_PROOF_HEADER_BYTES = 8192
+
 
 class HarnessError(RuntimeError):
     """Raised when the harness cannot execute a request or parse a response."""
@@ -110,23 +124,62 @@ def _encode_proof_header_value(value: object) -> str:
     return base64.b64encode(string_value.encode("utf-8")).decode("ascii")
 
 
-def build_proof_headers(proof: dict[str, object]) -> dict[str, str]:
-    headers: dict[str, str] = {}
+def build_proof_headers(
+    proof: dict[str, object],
+    *,
+    max_bytes: int = MAX_PROOF_HEADER_BYTES,
+    warn: TextIO | None = None,
+) -> dict[str, str]:
+    """Build the X-ProofMode-* headers, capped at ``max_bytes`` on the wire.
+
+    Ordered cheapest-and-most-identifying first so a proof that busts the
+    budget still carries the C2PA id and the signature. See
+    ``MAX_PROOF_HEADER_BYTES`` for why an oversized proof is dropped.
+    """
     manifest_json = json.dumps(proof, separators=(",", ":"))
-    headers["X-ProofMode-Manifest"] = base64.b64encode(
-        manifest_json.encode("utf-8")
-    ).decode("ascii")
-    if "pgpSignature" in proof:
-        headers["X-ProofMode-Signature"] = _encode_proof_header_value(
-            proof["pgpSignature"]
-        )
-    if "deviceAttestation" in proof:
-        headers["X-ProofMode-Attestation"] = _encode_proof_header_value(
-            proof["deviceAttestation"]
-        )
+    candidates: list[tuple[str, str]] = []
+
     c2pa_manifest_id = proof.get("c2paManifestId") or proof.get("c2pa_manifest_id")
     if c2pa_manifest_id is not None:
-        headers["X-ProofMode-C2PA"] = _encode_proof_header_value(c2pa_manifest_id)
+        candidates.append(
+            ("X-ProofMode-C2PA", _encode_proof_header_value(c2pa_manifest_id))
+        )
+    if "pgpSignature" in proof:
+        candidates.append(
+            ("X-ProofMode-Signature", _encode_proof_header_value(proof["pgpSignature"]))
+        )
+    if "deviceAttestation" in proof:
+        candidates.append(
+            (
+                "X-ProofMode-Attestation",
+                _encode_proof_header_value(proof["deviceAttestation"]),
+            )
+        )
+    candidates.append(
+        (
+            "X-ProofMode-Manifest",
+            base64.b64encode(manifest_json.encode("utf-8")).decode("ascii"),
+        )
+    )
+
+    headers: dict[str, str] = {}
+    used_bytes = 0
+    dropped: list[str] = []
+    for name, value in candidates:
+        # "name: value\r\n" is what actually counts against the edge budget.
+        wire_bytes = len(name) + len(value) + 4
+        if used_bytes + wire_bytes > max_bytes:
+            dropped.append(f"{name} ({len(value)}B)")
+            continue
+        used_bytes += wire_bytes
+        headers[name] = value
+
+    if dropped and warn is not None:
+        print(
+            f"warning: ProofMode headers over the {max_bytes} byte budget; "
+            f"sending {used_bytes} bytes and dropping {', '.join(dropped)}",
+            file=warn,
+        )
     return headers
 
 
@@ -621,7 +674,7 @@ def main(argv: list[str] | None = None) -> int:
         validate_args(args)
         server_url = normalize_server_url(args.server)
         proof_headers = (
-            build_proof_headers(load_proof_json(args.proof_json))
+            build_proof_headers(load_proof_json(args.proof_json), warn=sys.stderr)
             if args.proof_json is not None
             else None
         )

--- a/scripts/debug_upload_harness.py
+++ b/scripts/debug_upload_harness.py
@@ -148,6 +148,12 @@ def build_proof_headers(
         candidates.append(
             ("X-ProofMode-Signature", _encode_proof_header_value(proof["pgpSignature"]))
         )
+    # Paired with the signature: without the key the signature cannot be
+    # verified from headers alone.
+    if "publicKey" in proof:
+        candidates.append(
+            ("X-ProofMode-PublicKey", _encode_proof_header_value(proof["publicKey"]))
+        )
     if "deviceAttestation" in proof:
         candidates.append(
             (

--- a/scripts/debug_upload_harness.py
+++ b/scripts/debug_upload_harness.py
@@ -24,10 +24,13 @@ SUCCESS_STATUSES = {200, 201, 204}
 #
 # media.divine.video rejects requests whose combined headers exceed 128 KiB
 # over HTTP/1.1 (with a 502) or 64 KiB over HTTP/2 (by closing the connection).
-# An Android hardware attestation chain is ~54 KB and lands in the manifest
-# twice — ~75 KB base64 in X-ProofMode-Manifest plus ~72 KB in
-# X-ProofMode-Attestation — so replaying a real proof through this harness
-# reproduced the client bug instead of diagnosing it.
+# A device attestation lands in the request twice — base64 in
+# X-ProofMode-Manifest and again in X-ProofMode-Attestation — so a raw
+# attestation over roughly 47.5 KB busts the limit and replaying such a proof
+# through this harness reproduced the client bug instead of diagnosing it.
+# Android attestation size is device-dependent (it is the
+# X509Certificate.toString() dump of the whole chain), which is why only some
+# devices were affected.
 #
 # No Blossom server reads these headers; the canonical manifest is the
 # proofmode tag on the kind 34236 event.

--- a/scripts/debug_upload_harness.py
+++ b/scripts/debug_upload_harness.py
@@ -117,9 +117,15 @@ def should_use_resumable(*, mode: str) -> bool:
     return mode == "resumable"
 
 
-def load_proof_json(path: str | Path) -> dict[str, object]:
+def load_proof_manifest(path: str | Path) -> tuple[dict[str, object], str]:
     proof_path = Path(path)
-    return json.loads(proof_path.read_text(encoding="utf-8"))
+    manifest_json = proof_path.read_text(encoding="utf-8")
+    return json.loads(manifest_json), manifest_json
+
+
+def load_proof_json(path: str | Path) -> dict[str, object]:
+    proof, _manifest_json = load_proof_manifest(path)
+    return proof
 
 
 def _encode_proof_header_value(value: object) -> str:
@@ -130,6 +136,7 @@ def _encode_proof_header_value(value: object) -> str:
 def build_proof_headers(
     proof: dict[str, object],
     *,
+    manifest_json: str | None = None,
     max_bytes: int = MAX_PROOF_HEADER_BYTES,
     warn: TextIO | None = None,
 ) -> dict[str, str]:
@@ -138,8 +145,10 @@ def build_proof_headers(
     Ordered cheapest-and-most-identifying first so a proof that busts the
     budget still carries the C2PA id and the signature. See
     ``MAX_PROOF_HEADER_BYTES`` for why an oversized proof is dropped.
+    Pass ``max_bytes=0`` to disable the cap for limit probing.
     """
-    manifest_json = json.dumps(proof, separators=(",", ":"))
+    if manifest_json is None:
+        manifest_json = json.dumps(proof, separators=(",", ":"))
     candidates: list[tuple[str, str]] = []
 
     c2pa_manifest_id = proof.get("c2paManifestId") or proof.get("c2pa_manifest_id")
@@ -177,7 +186,7 @@ def build_proof_headers(
     for name, value in candidates:
         # "name: value\r\n" is what actually counts against the edge budget.
         wire_bytes = len(name) + len(value) + 4
-        if used_bytes + wire_bytes > max_bytes:
+        if max_bytes > 0 and used_bytes + wire_bytes > max_bytes:
             dropped.append(f"{name} ({len(value)}B)")
             continue
         used_bytes += wire_bytes
@@ -629,6 +638,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a ProofMode manifest JSON file",
     )
     parser.add_argument(
+        "--max-proof-header-bytes",
+        type=int,
+        default=MAX_PROOF_HEADER_BYTES,
+        help=(
+            "Combined X-ProofMode-* wire budget in bytes; "
+            "use 0 to send all proof headers"
+        ),
+    )
+    parser.add_argument(
         "--complete-only",
         action="store_true",
         help="Replay only POST /upload/{id}/complete for an existing session",
@@ -660,6 +678,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def validate_args(args: argparse.Namespace) -> None:
+    if args.max_proof_header_bytes < 0:
+        raise HarnessError("--max-proof-header-bytes must be non-negative")
+
     if args.complete_only:
         if not args.upload_id:
             raise HarnessError("--complete-only requires --upload-id")
@@ -682,11 +703,15 @@ def main(argv: list[str] | None = None) -> int:
     try:
         validate_args(args)
         server_url = normalize_server_url(args.server)
-        proof_headers = (
-            build_proof_headers(load_proof_json(args.proof_json), warn=sys.stderr)
-            if args.proof_json is not None
-            else None
-        )
+        proof_headers = None
+        if args.proof_json is not None:
+            proof, manifest_json = load_proof_manifest(args.proof_json)
+            proof_headers = build_proof_headers(
+                proof,
+                manifest_json=manifest_json,
+                max_bytes=args.max_proof_header_bytes,
+                warn=sys.stderr,
+            )
         client = UploadHttpClient(timeout_seconds=args.timeout_seconds)
 
         if args.complete_only:

--- a/scripts/tests/test_debug_upload_harness.py
+++ b/scripts/tests/test_debug_upload_harness.py
@@ -69,8 +69,9 @@ class DebugUploadHarnessTests(unittest.TestCase):
         # the manifest twice, which put the client past what
         # media.divine.video accepts and turned every upload into a 502.
         proof = {
-            "pgpSignature": "sig",
-            "deviceAttestation": "A" * 54000,
+            "pgpSignature": "S" * 821,
+            "publicKey": "K" * 2048,
+            "deviceAttestation": "A" * 53826,
             "c2paManifestId": "urn:c2pa:manifest",
         }
         warnings = io.StringIO()
@@ -78,10 +79,19 @@ class DebugUploadHarnessTests(unittest.TestCase):
         headers = build_proof_headers(proof, warn=warnings)
 
         self.assertIn("X-ProofMode-C2PA", headers)
-        self.assertIn("X-ProofMode-Signature", headers)
         self.assertNotIn("X-ProofMode-Attestation", headers)
         self.assertNotIn("X-ProofMode-Manifest", headers)
         self.assertIn("over the 8192 byte budget", warnings.getvalue())
+        # The signature and the key that verifies it survive intact; keeping a
+        # signature without its key would leave an uncheckable proof.
+        self.assertEqual(
+            base64.b64decode(headers["X-ProofMode-Signature"]).decode("utf-8"),
+            "S" * 821,
+        )
+        self.assertEqual(
+            base64.b64decode(headers["X-ProofMode-PublicKey"]).decode("utf-8"),
+            "K" * 2048,
+        )
 
     def test_build_proof_headers_stays_within_budget(self) -> None:
         proof = {

--- a/scripts/tests/test_debug_upload_harness.py
+++ b/scripts/tests/test_debug_upload_harness.py
@@ -6,6 +6,7 @@ import unittest
 import urllib.error
 
 from scripts.debug_upload_harness import (
+    MAX_PROOF_HEADER_BYTES,
     UploadHttpClient,
     build_complete_body,
     build_proof_headers,
@@ -62,6 +63,44 @@ class DebugUploadHarnessTests(unittest.TestCase):
             headers["X-ProofMode-C2PA"],
             base64.b64encode(b"urn:c2pa:manifest").decode("ascii"),
         )
+
+    def test_build_proof_headers_drops_bulk_over_budget(self) -> None:
+        # A real Android hardware attestation chain runs ~54 KB and lands in
+        # the manifest twice, which put the client past what
+        # media.divine.video accepts and turned every upload into a 502.
+        proof = {
+            "pgpSignature": "sig",
+            "deviceAttestation": "A" * 54000,
+            "c2paManifestId": "urn:c2pa:manifest",
+        }
+        warnings = io.StringIO()
+
+        headers = build_proof_headers(proof, warn=warnings)
+
+        self.assertIn("X-ProofMode-C2PA", headers)
+        self.assertIn("X-ProofMode-Signature", headers)
+        self.assertNotIn("X-ProofMode-Attestation", headers)
+        self.assertNotIn("X-ProofMode-Manifest", headers)
+        self.assertIn("over the 8192 byte budget", warnings.getvalue())
+
+    def test_build_proof_headers_stays_within_budget(self) -> None:
+        proof = {
+            "pgpSignature": "sig",
+            "deviceAttestation": "A" * 54000,
+            "c2paManifestId": "urn:c2pa:manifest",
+        }
+
+        headers = build_proof_headers(proof)
+
+        wire_bytes = sum(len(name) + len(value) + 4 for name, value in headers.items())
+        self.assertLessEqual(wire_bytes, MAX_PROOF_HEADER_BYTES)
+
+    def test_build_proof_headers_is_silent_within_budget(self) -> None:
+        warnings = io.StringIO()
+
+        build_proof_headers({"pgpSignature": "sig"}, warn=warnings)
+
+        self.assertEqual(warnings.getvalue(), "")
 
     def test_summarize_response_truncates_large_bodies(self) -> None:
         summary = summarize_response(

--- a/scripts/tests/test_debug_upload_harness.py
+++ b/scripts/tests/test_debug_upload_harness.py
@@ -9,8 +9,10 @@ from scripts.debug_upload_harness import (
     MAX_PROOF_HEADER_BYTES,
     UploadHttpClient,
     build_complete_body,
+    build_parser,
     build_proof_headers,
     chunk_ranges,
+    load_proof_manifest,
     load_proof_json,
     normalize_server_url,
     should_use_resumable,
@@ -112,6 +114,29 @@ class DebugUploadHarnessTests(unittest.TestCase):
 
         self.assertEqual(warnings.getvalue(), "")
 
+    def test_build_proof_headers_uses_raw_manifest_json_when_provided(self) -> None:
+        manifest_json = '{\n  "pgpSignature": "sig",\n  "place": "München"\n}\n'
+        proof = json.loads(manifest_json)
+
+        headers = build_proof_headers(proof, manifest_json=manifest_json)
+
+        self.assertEqual(
+            headers["X-ProofMode-Manifest"],
+            base64.b64encode(manifest_json.encode("utf-8")).decode("ascii"),
+        )
+
+    def test_build_proof_headers_can_disable_budget(self) -> None:
+        proof = {
+            "pgpSignature": "sig",
+            "deviceAttestation": "A" * 54000,
+            "c2paManifestId": "urn:c2pa:manifest",
+        }
+
+        headers = build_proof_headers(proof, max_bytes=0)
+
+        self.assertIn("X-ProofMode-Attestation", headers)
+        self.assertIn("X-ProofMode-Manifest", headers)
+
     def test_summarize_response_truncates_large_bodies(self) -> None:
         summary = summarize_response(
             method="POST",
@@ -135,6 +160,28 @@ class DebugUploadHarnessTests(unittest.TestCase):
         proof = load_proof_json(fixture_path)
         self.assertEqual(proof["deviceAttestation"], {"nonce": "abc123"})
         self.assertEqual(proof["pgpSignature"], "proof-signature")
+
+    def test_load_proof_manifest_retains_raw_json(self) -> None:
+        fixture_path = (
+            Path(__file__).resolve().parent / "fixtures" / "proofmode.json"
+        )
+        proof, manifest_json = load_proof_manifest(fixture_path)
+        self.assertEqual(proof["pgpSignature"], "proof-signature")
+        self.assertEqual(manifest_json, fixture_path.read_text(encoding="utf-8"))
+
+    def test_parser_exposes_proof_header_budget_override(self) -> None:
+        args = build_parser().parse_args(
+            [
+                "--server",
+                "https://media.divine.video",
+                "--auth-header",
+                "Nostr token",
+                "--max-proof-header-bytes",
+                "0",
+            ]
+        )
+
+        self.assertEqual(args.max_proof_header_bytes, 0)
 
     def test_summarize_request_body_hashes_binary_payloads(self) -> None:
         summary = summarize_request_body(


### PR DESCRIPTION
## Summary

- Cap the `X-ProofMode-*` headers the debug upload harness sends at 8 KiB combined, ordered cheapest-and-most-identifying first (`X-ProofMode-C2PA` → `-Signature` → `-PublicKey` → `-Attestation` → `-Manifest`)
- Mirror the new `X-ProofMode-PublicKey` header the client now sends, so the harness keeps reproducing what the app actually puts on the wire
- Warn on stderr naming what was dropped, so request-header size becomes visible instead of silent
- No server behaviour changes — this is the harness only

## Motivation

Replaying a real mobile proof through the harness reproduced the exact failure it exists to diagnose.

An Android device attestation is the `X509Certificate.toString()` dump of the whole cert chain — device-dependent in size — and it travels twice: base64-encoded in `X-ProofMode-Manifest` and again in `X-ProofMode-Attestation`. Measured against `media.divine.video`, combined request headers must stay under **128 KiB over HTTP/1.1** (past it the edge answers `502`) and under **64 KiB over HTTP/2** (past it the connection is closed mid-request). The HTTP/1.1 boundary is sharp: 130,800 bytes still reaches the handler (`401`), 131,000 returns `502`.

In practice that means a raw attestation over roughly 47.5 KB breaks the request (47,500 B → `401`, 48,000 B → `502`), so this bites on some devices and not others — a Pixel 8 Pro emits 53,826 bytes and always fails.

So anyone reaching for this harness to investigate a failing upload got an opaque `502` that reads like a server fault, when the request never had a chance. That is how the mobile-side bug stayed unexplained.

Worth recording while it is fresh: **nothing in this repo reads `X-ProofMode-*`.** The edge service has no reference to `proofmode` outside this script and docs, and `divine-upload-server` has none at all. The canonical manifest is the `proofmode` tag on the kind 34236 event, and the C2PA manifest is embedded in the uploaded bytes — which is what `cloud-functions/process-blob` reads. Dropping an oversized header therefore loses nothing.

The client-side fix is divinevideo/divine-mobile#6507; the 8 KiB budget here mirrors `BlossomUploadService.maxProofModeHeaderBytes` there.

## Related Issue

- Closes #166

## Validation

- [x] `python3 -m unittest scripts.tests.test_debug_upload_harness` — 16 tests pass, including the pre-existing `test_build_proof_headers_maps_expected_fields`, which pins backward compatibility: every header that shipped before keeps its exact value. The change is additive rather than byte-identical — a proof carrying `publicKey` now also sends `X-ProofMode-PublicKey` even when everything fits the budget; the pre-existing fixture has no `publicKey`, which is why its headers come out unchanged
- [ ] `cargo check --tests --locked` — not run, no Rust touched
- [ ] `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked` — not run, no Rust touched
- [ ] `cargo clippy --locked --all-targets --all-features` — not run, no Rust touched
- [x] I could not run some validation locally, and I explained why below

The Rust gates are skipped deliberately: this PR touches only the Python harness, its tests, and CI test discovery. Happy to run them if the repo prefers them green on every PR regardless of scope.

## Manual Test Plan / Notes

Not exercised end-to-end against production with a real proof JSON — the new path is covered by unit tests only here. The client-side twin of this logic has since run on a real Samsung Galaxy (divinevideo/divine-mobile#6507): the budget fired as designed — `sent 1121 bytes and dropped X-ProofMode-Attestation (11956B), X-ProofMode-Manifest (13512B)` — and the upload completed. One finding worth carrying over: that capture's manifest contained no `publicKey` at all (libProofMode emitted no `<hash>-pubkey.asc`), so a genuine Android proof of that shape sends the signature alone and `X-ProofMode-PublicKey` never fires — the signature/key pairing only holds for proofs that actually include the key. A maintainer replaying `--proof-json` with a big-attestation manifest should see the warning line and a completing request rather than a 502.

## Visuals / API Examples

- [x] No visual change

Warning emitted for an oversized proof:

```
warning: ProofMode headers over the 8192 byte budget; sending 3958 bytes and dropping X-ProofMode-Attestation (71768B), X-ProofMode-Manifest (75856B)
```

`X-ProofMode-C2PA` (60 B), `-Signature` (1,096 B) and `-PublicKey` (2,732 B) survive — 3,958 of the 8,192 byte budget.

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved


