### PR TITLE
perf(upload): drop the avoidable ffmpeg work from PUT /upload

### DIFF
--- a/cloud-run-upload/src/main.rs
+++ b/cloud-run-upload/src/main.rs
@@ -34,10 +34,11 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
     env,
-    sync::Arc,
+    sync::{Arc, LazyLock},
     time::{SystemTime, UNIX_EPOCH},
 };
 use tempfile::NamedTempFile;
+use tokio::sync::Semaphore;
 use tower::Service;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::{error, info, warn};
@@ -965,6 +966,17 @@ async fn download_best_available_media_bytes(
 
 /// On-demand thumbnail generation endpoint
 /// Downloads video from GCS, generates thumbnail, stores it, returns the image
+/// Concurrent on-demand poster extractions allowed per instance.
+///
+/// Each extraction runs a whole ffmpeg process over a temp copy of the video.
+/// `spawn_blocking` alone would let a cold-feed burst launch one per request
+/// up to the blocking pool's size; this bound keeps such a burst from
+/// exhausting the instance's CPU and memory while queued requests wait.
+const MAX_CONCURRENT_THUMBNAIL_EXTRACTIONS: usize = 4;
+
+static THUMBNAIL_EXTRACTION_SLOTS: LazyLock<Semaphore> =
+    LazyLock::new(|| Semaphore::new(MAX_CONCURRENT_THUMBNAIL_EXTRACTIONS));
+
 async fn handle_thumbnail_generate(
     State(state): State<Arc<AppState>>,
     Path(hash): Path<String>,
@@ -1053,6 +1065,11 @@ async fn handle_thumbnail_generate(
     // Generate thumbnail. `extract_thumbnail` shells out with a synchronous
     // `Command`, so it must not run on a runtime worker — a cold feed can ask
     // for many posters at once and would otherwise stall unrelated requests.
+    // The semaphore bounds how many of those ffmpeg processes run at once.
+    let _permit = THUMBNAIL_EXTRACTION_SLOTS
+        .acquire()
+        .await
+        .expect("the extraction semaphore is never closed");
     let extraction = tokio::task::spawn_blocking(move || thumbnail::extract_thumbnail(&video_data))
         .await
         .map_err(|e| anyhow!("Thumbnail extraction task panicked: {}", e))

--- a/cloud-run-upload/src/main.rs
+++ b/cloud-run-upload/src/main.rs
@@ -823,7 +823,9 @@ async fn stream_to_gcs_with_hash(
     // `Bytes` keeps the later clones refcount bumps instead of full copies.
     let original_bytes = Bytes::from(original_bytes);
 
-    // Derivative generation (probe/transcode) can use sanitized bytes.
+    // The remux output stays in-process: only ffprobe reads it, and it is never
+    // stored. The transcoder fetches the original blob from GCS itself, so a
+    // skipped remux changes nothing about what downstream services receive.
     let mut sanitize_error = None;
 
     let derivative_bytes = if needs_derivative_sanitize(content_type, &original_bytes) {

--- a/cloud-run-upload/src/main.rs
+++ b/cloud-run-upload/src/main.rs
@@ -1,6 +1,7 @@
 // ABOUTME: Rust Cloud Run service for Blossom blob uploads
 // ABOUTME: Handles Nostr auth validation, streaming upload to GCS, and SHA-256 hashing
 
+mod mp4;
 mod resumable;
 mod thumbnail;
 
@@ -643,31 +644,14 @@ async fn process_upload(
     )
     .await?;
 
-    let mut thumbnail_error: Option<String> = None;
-    // Extract thumbnail for videos (non-blocking - failures don't fail the upload)
-    let thumbnail_url = if thumbnail::is_video_type(&content_type) {
-        match extract_and_upload_thumbnail(
-            &state.gcs_client,
-            &state.config.gcs_bucket,
-            &state.config.cdn_base_url,
-            &sha256_hash,
-            &all_bytes,
-        )
-        .await
-        {
-            Ok(url) => {
-                info!("Generated thumbnail for {}", sha256_hash);
-                Some(url)
-            }
-            Err(e) => {
-                error!("Thumbnail extraction failed for {}: {}", sha256_hash, e);
-                thumbnail_error = Some(e.to_string());
-                None
-            }
-        }
-    } else {
-        None
-    };
+    // The poster is no longer extracted here. Clients supply their own cover
+    // (mobile uploads the frame the user picked and prefers it over ours), and
+    // a request for `{hash}.jpg` that finds nothing in GCS is served by
+    // `GET /thumbnail/:hash` via the edge. Returning the URL keeps it resolvable
+    // for callers that use it; it is generated on first request instead of on
+    // every upload.
+    let thumbnail_url = thumbnail::is_video_type(&content_type)
+        .then(|| format!("{}/{}.jpg", state.config.cdn_base_url, sha256_hash));
 
     let mut probe_error: Option<String> = None;
     // Probe video dimensions (non-blocking - failures don't fail the upload)
@@ -690,7 +674,6 @@ async fn process_upload(
     let derivative_failure = classify_invalid_media_signal(
         &content_type,
         sanitize_error.as_deref(),
-        thumbnail_error.as_deref(),
         probe_error.as_deref(),
     );
 
@@ -805,13 +788,28 @@ async fn process_upload(
     })
 }
 
+/// Whether the upload needs the ffmpeg remux before derivatives can use it.
+///
+/// A video that already carries moov before mdat is web-compatible as-is, so
+/// the remux would only rewrite it into the layout it already has. Clients that
+/// export with faststart — which divine-mobile does on every render path — land
+/// here and skip an ffmpeg process entirely.
+///
+/// Anything we cannot positively classify as faststart still gets sanitized,
+/// including non-MP4 containers and truncated files. That keeps the remux
+/// covering the case it was added for: iPhone captures, which carry moov at the
+/// end alongside the malformed atoms the remux strips.
+fn needs_derivative_sanitize(content_type: &str, bytes: &[u8]) -> bool {
+    thumbnail::is_video_type(content_type) && mp4::is_faststart(bytes) != Some(true)
+}
+
 async fn stream_to_gcs_with_hash(
     client: &GcsClient,
     bucket: &str,
     content_type: &str,
     body: Body,
     owner: &str,
-) -> Result<(String, u64, Vec<u8>, Option<String>)> {
+) -> Result<(String, u64, Bytes, Option<String>)> {
     let mut original_bytes = Vec::new();
 
     // Collect body stream first; original bytes remain the source of truth for hashing/storage.
@@ -821,21 +819,22 @@ async fn stream_to_gcs_with_hash(
         original_bytes.extend_from_slice(&chunk);
     }
 
-    // Keep original bytes immutable for hash/storage integrity.
-    // Derivative generation (thumbnail/probe/transcode) can use sanitized bytes.
-    let mut derivative_bytes = original_bytes.clone();
+    // Keep original bytes immutable for hash/storage integrity. Sharing them as
+    // `Bytes` keeps the later clones refcount bumps instead of full copies.
+    let original_bytes = Bytes::from(original_bytes);
+
+    // Derivative generation (probe/transcode) can use sanitized bytes.
     let mut sanitize_error = None;
 
-    // Sanitize video bytes for derivative processing only.
-    if thumbnail::is_video_type(content_type) {
-        match sanitize_video(&derivative_bytes).await {
+    let derivative_bytes = if needs_derivative_sanitize(content_type, &original_bytes) {
+        match sanitize_video(&original_bytes).await {
             Ok(sanitized) => {
                 info!(
                     "Prepared sanitized derivative bytes: {} -> {} bytes",
-                    derivative_bytes.len(),
+                    original_bytes.len(),
                     sanitized.len(),
                 );
-                derivative_bytes = sanitized;
+                Bytes::from(sanitized)
             }
             Err(e) => {
                 // Non-fatal: user-caused (corrupt upload, missing moov atom, etc.)
@@ -845,9 +844,15 @@ async fn stream_to_gcs_with_hash(
                     e
                 );
                 sanitize_error = Some(e.to_string());
+                original_bytes.clone()
             }
         }
-    }
+    } else {
+        if thumbnail::is_video_type(content_type) {
+            info!("Video is already faststart, skipping the derivative remux");
+        }
+        original_bytes.clone()
+    };
 
     // Hash and store the original uploaded bytes.
     let mut hasher = Sha256::new();
@@ -880,7 +885,7 @@ async fn stream_to_gcs_with_hash(
     };
 
     client
-        .upload_object(&req, Bytes::from(original_bytes.clone()), &upload_type)
+        .upload_object(&req, original_bytes.clone(), &upload_type)
         .await
         .map_err(|e| anyhow!("GCS upload failed: {}", e))?;
 
@@ -905,39 +910,6 @@ async fn stream_to_gcs_with_hash(
         total_size, sha256_hash, owner
     );
     Ok((sha256_hash, total_size, derivative_bytes, sanitize_error))
-}
-
-/// Extract thumbnail from video and upload to GCS
-/// Returns the thumbnail URL on success
-async fn extract_and_upload_thumbnail(
-    client: &GcsClient,
-    bucket: &str,
-    cdn_base_url: &str,
-    hash: &str,
-    video_data: &[u8],
-) -> Result<String> {
-    // Extract thumbnail using ffmpeg
-    let thumb_result = thumbnail::extract_thumbnail(video_data)?;
-
-    // Upload thumbnail to GCS with path: {hash}.jpg (same as video hash but with .jpg extension)
-    // This allows serving via CDN at media.divine.video/{hash}.jpg
-    let thumb_path = format!("{}.jpg", hash);
-
-    let mut media = Media::new(thumb_path.clone());
-    media.content_type = "image/jpeg".into();
-    let upload_type = UploadType::Simple(media);
-    let req = UploadObjectRequest {
-        bucket: bucket.to_string(),
-        ..Default::default()
-    };
-
-    client
-        .upload_object(&req, Bytes::from(thumb_result.data), &upload_type)
-        .await
-        .map_err(|e| anyhow!("GCS thumbnail upload failed: {}", e))?;
-
-    // Return CDN URL for thumbnail - stored at {hash}.jpg, served via CDN
-    Ok(format!("{}/{}.jpg", cdn_base_url, hash))
 }
 
 fn media_source_candidates(hash: &str) -> [String; 3] {
@@ -1076,8 +1048,15 @@ async fn handle_thumbnail_generate(
         );
     }
 
-    // Generate thumbnail
-    let thumb_result = match thumbnail::extract_thumbnail(&video_data) {
+    // Generate thumbnail. `extract_thumbnail` shells out with a synchronous
+    // `Command`, so it must not run on a runtime worker — a cold feed can ask
+    // for many posters at once and would otherwise stall unrelated requests.
+    let extraction = tokio::task::spawn_blocking(move || thumbnail::extract_thumbnail(&video_data))
+        .await
+        .map_err(|e| anyhow!("Thumbnail extraction task panicked: {}", e))
+        .and_then(|result| result);
+
+    let thumb_result = match extraction {
         Ok(result) => result,
         Err(e) => {
             error!("Failed to generate thumbnail for {}: {}", hash, e);
@@ -1096,7 +1075,7 @@ async fn handle_thumbnail_generate(
     // Upload thumbnail to GCS
     let thumb_path = format!("{}.jpg", hash);
     let mut media = Media::new(thumb_path.clone());
-    media.content_type = "image/jpeg".into();
+    media.content_type = thumb_result.content_type.clone().into();
     let upload_type = UploadType::Simple(media);
     let req = UploadObjectRequest {
         bucket: state.config.gcs_bucket.clone(),
@@ -1269,7 +1248,10 @@ async fn probe_video_dimensions(video_bytes: &[u8]) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_invalid_media_signal, media_source_candidates, new_temp_media_path};
+    use super::{
+        classify_invalid_media_signal, media_source_candidates, needs_derivative_sanitize,
+        new_temp_media_path,
+    };
 
     #[test]
     fn temp_media_paths_are_unique_per_request() {
@@ -1299,7 +1281,6 @@ mod tests {
             "video/mp4",
             Some("ffmpeg sanitize failed: moov atom not found"),
             None,
-            None,
         )
         .expect("sanitize failure should mark invalid media");
 
@@ -1313,7 +1294,6 @@ mod tests {
         let signal = classify_invalid_media_signal(
             "video/mp4",
             None,
-            None,
             Some("ffprobe failed: Invalid data found when processing input"),
         )
         .expect("probe failure should mark invalid media");
@@ -1326,15 +1306,64 @@ mod tests {
     }
 
     #[test]
-    fn invalid_media_classification_ignores_thumbnail_only_failures() {
+    fn invalid_media_classification_ignores_non_video_uploads() {
+        // Images never run the derivative pipeline, so a stray error string
+        // must not gate them out of anything.
         let signal = classify_invalid_media_signal(
-            "video/mp4",
-            None,
-            Some("thumbnail extraction failed"),
-            None,
+            "image/jpeg",
+            Some("ffmpeg sanitize failed: moov atom not found"),
+            Some("ffprobe failed: Invalid data found when processing input"),
         );
 
         assert!(signal.is_none());
+    }
+
+    #[test]
+    fn invalid_media_classification_passes_clean_videos() {
+        assert!(classify_invalid_media_signal("video/mp4", None, None).is_none());
+    }
+
+    /// Build a minimal top-level box sequence for the sanitize-gate tests.
+    fn mp4_with_box_order(order: [&[u8; 4]; 2]) -> Vec<u8> {
+        let mut data = Vec::new();
+        for box_type in [b"ftyp", order[0], order[1]] {
+            data.extend((16u32).to_be_bytes());
+            data.extend_from_slice(box_type);
+            data.extend(std::iter::repeat_n(0u8, 8));
+        }
+        data
+    }
+
+    #[test]
+    fn sanitize_gate_skips_videos_that_are_already_faststart() {
+        let faststart = mp4_with_box_order([b"moov", b"mdat"]);
+
+        assert!(!needs_derivative_sanitize("video/mp4", &faststart));
+    }
+
+    #[test]
+    fn sanitize_gate_remuxes_videos_with_trailing_moov() {
+        let trailing_moov = mp4_with_box_order([b"mdat", b"moov"]);
+
+        assert!(needs_derivative_sanitize("video/mp4", &trailing_moov));
+    }
+
+    #[test]
+    fn sanitize_gate_remuxes_videos_it_cannot_classify() {
+        // WebM and anything else we cannot parse must keep going through the
+        // remux — skipping on "unknown" would ship unsanitized bytes onward.
+        let webm = [0x1A, 0x45, 0xDF, 0xA3, 0x01, 0x00, 0x00, 0x00];
+
+        assert!(needs_derivative_sanitize("video/webm", &webm));
+        assert!(needs_derivative_sanitize("video/mp4", &[]));
+    }
+
+    #[test]
+    fn sanitize_gate_ignores_non_video_uploads() {
+        assert!(!needs_derivative_sanitize(
+            "image/jpeg",
+            &[0xFF, 0xD8, 0xFF, 0xE0]
+        ));
     }
 }
 
@@ -1761,7 +1790,6 @@ async fn maybe_trigger_derivatives(
 fn classify_invalid_media_signal(
     content_type: &str,
     sanitize_error: Option<&str>,
-    _thumbnail_error: Option<&str>,
     probe_error: Option<&str>,
 ) -> Option<DerivativeFailureSignal> {
     if !thumbnail::is_video_type(content_type) {

--- a/cloud-run-upload/src/main.rs
+++ b/cloud-run-upload/src/main.rs
@@ -33,12 +33,13 @@ use k256::schnorr::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{
+    collections::HashMap,
     env,
     sync::{Arc, LazyLock},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tempfile::NamedTempFile;
-use tokio::sync::Semaphore;
+use tokio::sync::{Mutex, Semaphore};
 use tower::Service;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::{error, info, warn};
@@ -982,8 +983,6 @@ async fn download_best_available_media_bytes(
     ))
 }
 
-/// On-demand thumbnail generation endpoint
-/// Downloads video from GCS, generates thumbnail, stores it, returns the image
 /// Concurrent on-demand poster extractions allowed per instance.
 ///
 /// Each extraction runs a whole ffmpeg process over a temp copy of the video.
@@ -991,10 +990,19 @@ async fn download_best_available_media_bytes(
 /// up to the blocking pool's size; this bound keeps such a burst from
 /// exhausting the instance's CPU and memory while queued requests wait.
 const MAX_CONCURRENT_THUMBNAIL_EXTRACTIONS: usize = 4;
+const THUMBNAIL_EXTRACTION_WAIT: Duration = Duration::from_secs(10);
+const THUMBNAIL_NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 
 static THUMBNAIL_EXTRACTION_SLOTS: LazyLock<Semaphore> =
     LazyLock::new(|| Semaphore::new(MAX_CONCURRENT_THUMBNAIL_EXTRACTIONS));
+static THUMBNAIL_IN_FLIGHT: LazyLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static THUMBNAIL_NEGATIVE_CACHE: LazyLock<Mutex<HashMap<String, Instant>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// On-demand thumbnail generation endpoint.
+///
+/// Downloads video from GCS, generates thumbnail, stores it, returns the image.
 async fn handle_thumbnail_generate(
     State(state): State<Arc<AppState>>,
     Path(hash): Path<String>,
@@ -1013,41 +1021,41 @@ async fn handle_thumbnail_generate(
     }
 
     let hash = hash.to_lowercase();
+    generate_thumbnail_response(state, hash).await
+}
 
+async fn generate_thumbnail_response(state: Arc<AppState>, hash: String) -> Response {
     // First check if thumbnail already exists
     let thumb_path = format!("{}.jpg", hash);
-    let thumb_exists = state
-        .gcs_client
-        .get_object(&GetObjectRequest {
-            bucket: state.config.gcs_bucket.clone(),
-            object: thumb_path.clone(),
-            ..Default::default()
-        })
-        .await
-        .is_ok();
+    if let Some(response) = download_existing_thumbnail(&state, &thumb_path).await {
+        return response;
+    }
 
-    if thumb_exists {
-        // Thumbnail already exists, download and return it
-        match state
-            .gcs_client
-            .download_object(
-                &GetObjectRequest {
-                    bucket: state.config.gcs_bucket.clone(),
-                    object: thumb_path,
-                    ..Default::default()
-                },
-                &DownloadRange::default(),
-            )
-            .await
-        {
-            Ok(data) => {
-                return (StatusCode::OK, [(header::CONTENT_TYPE, "image/jpeg")], data)
-                    .into_response();
+    if thumbnail_generation_recently_failed(&hash).await {
+        return thumbnail_generation_unavailable_response("Thumbnail generation previously failed");
+    }
+
+    let generation_lock = thumbnail_generation_lock(&hash).await;
+    let _generation_guard =
+        match tokio::time::timeout(THUMBNAIL_EXTRACTION_WAIT, generation_lock.lock()).await {
+            Ok(guard) => guard,
+            Err(_) => {
+                warn!(
+                    "Timed out waiting for in-flight thumbnail generation for {}",
+                    hash
+                );
+                return thumbnail_generation_busy_response();
             }
-            Err(e) => {
-                error!("Failed to download existing thumbnail: {}", e);
-            }
-        }
+        };
+
+    // Another request may have generated or failed this poster while we waited.
+    if let Some(response) = download_existing_thumbnail(&state, &thumb_path).await {
+        finish_thumbnail_generation(&hash, &generation_lock).await;
+        return response;
+    }
+    if thumbnail_generation_recently_failed(&hash).await {
+        finish_thumbnail_generation(&hash, &generation_lock).await;
+        return thumbnail_generation_unavailable_response("Thumbnail generation previously failed");
     }
 
     // Download the original blob, or fall back to the best available HLS transport stream.
@@ -1061,6 +1069,7 @@ async fn handle_thumbnail_generate(
         Ok(result) => result,
         Err(e) => {
             error!("Failed to download video {}: {}", hash, e);
+            finish_thumbnail_generation(&hash, &generation_lock).await;
             return (
                 StatusCode::NOT_FOUND,
                 [(header::CONTENT_TYPE, "application/json")],
@@ -1084,28 +1093,39 @@ async fn handle_thumbnail_generate(
     // `Command`, so it must not run on a runtime worker — a cold feed can ask
     // for many posters at once and would otherwise stall unrelated requests.
     // The semaphore bounds how many of those ffmpeg processes run at once.
-    let _permit = THUMBNAIL_EXTRACTION_SLOTS
-        .acquire()
-        .await
-        .expect("the extraction semaphore is never closed");
-    let extraction = tokio::task::spawn_blocking(move || thumbnail::extract_thumbnail(&video_data))
-        .await
-        .map_err(|e| anyhow!("Thumbnail extraction task panicked: {}", e))
-        .and_then(|result| result);
+    let extraction = match tokio::time::timeout(
+        THUMBNAIL_EXTRACTION_WAIT,
+        THUMBNAIL_EXTRACTION_SLOTS.acquire(),
+    )
+    .await
+    {
+        Ok(permit) => {
+            let permit = permit.expect("the extraction semaphore is never closed");
+            let extraction =
+                tokio::task::spawn_blocking(move || thumbnail::extract_thumbnail(&video_data))
+                    .await
+                    .map_err(|e| anyhow!("Thumbnail extraction task panicked: {}", e))
+                    .and_then(|result| result);
+            drop(permit);
+            extraction
+        }
+        Err(_) => {
+            warn!(
+                "Timed out waiting for thumbnail extraction slot for {}",
+                hash
+            );
+            finish_thumbnail_generation(&hash, &generation_lock).await;
+            return thumbnail_generation_busy_response();
+        }
+    };
 
     let thumb_result = match extraction {
         Ok(result) => result,
         Err(e) => {
             error!("Failed to generate thumbnail for {}: {}", hash, e);
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                [(header::CONTENT_TYPE, "application/json")],
-                Json(ErrorResponse {
-                    error: "Failed to generate thumbnail".to_string(),
-                })
-                .into_response(),
-            )
-                .into_response();
+            remember_thumbnail_generation_failure(&hash).await;
+            finish_thumbnail_generation(&hash, &generation_lock).await;
+            return thumbnail_generation_unavailable_response("Failed to generate thumbnail");
         }
     };
 
@@ -1129,12 +1149,117 @@ async fn handle_thumbnail_generate(
     }
 
     info!("Generated on-demand thumbnail for {}", hash);
+    clear_thumbnail_generation_failure(&hash).await;
+    finish_thumbnail_generation(&hash, &generation_lock).await;
 
     // Return the thumbnail image
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "image/jpeg")],
         thumb_result.data,
+    )
+        .into_response()
+}
+
+async fn download_existing_thumbnail(state: &Arc<AppState>, thumb_path: &str) -> Option<Response> {
+    let thumb_exists = state
+        .gcs_client
+        .get_object(&GetObjectRequest {
+            bucket: state.config.gcs_bucket.clone(),
+            object: thumb_path.to_string(),
+            ..Default::default()
+        })
+        .await
+        .is_ok();
+
+    if !thumb_exists {
+        return None;
+    }
+
+    match state
+        .gcs_client
+        .download_object(
+            &GetObjectRequest {
+                bucket: state.config.gcs_bucket.clone(),
+                object: thumb_path.to_string(),
+                ..Default::default()
+            },
+            &DownloadRange::default(),
+        )
+        .await
+    {
+        Ok(data) => {
+            Some((StatusCode::OK, [(header::CONTENT_TYPE, "image/jpeg")], data).into_response())
+        }
+        Err(e) => {
+            error!("Failed to download existing thumbnail: {}", e);
+            None
+        }
+    }
+}
+
+async fn thumbnail_generation_lock(hash: &str) -> Arc<Mutex<()>> {
+    let mut in_flight = THUMBNAIL_IN_FLIGHT.lock().await;
+    in_flight
+        .entry(hash.to_string())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
+async fn finish_thumbnail_generation(hash: &str, lock: &Arc<Mutex<()>>) {
+    let mut in_flight = THUMBNAIL_IN_FLIGHT.lock().await;
+    if in_flight
+        .get(hash)
+        .is_some_and(|current| Arc::ptr_eq(current, lock) && Arc::strong_count(lock) == 2)
+    {
+        in_flight.remove(hash);
+    }
+}
+
+async fn thumbnail_generation_recently_failed(hash: &str) -> bool {
+    let now = Instant::now();
+    let mut cache = THUMBNAIL_NEGATIVE_CACHE.lock().await;
+    match cache.get(hash) {
+        Some(expires_at) if *expires_at > now => true,
+        Some(_) => {
+            cache.remove(hash);
+            false
+        }
+        None => false,
+    }
+}
+
+async fn remember_thumbnail_generation_failure(hash: &str) {
+    THUMBNAIL_NEGATIVE_CACHE.lock().await.insert(
+        hash.to_string(),
+        Instant::now() + THUMBNAIL_NEGATIVE_CACHE_TTL,
+    );
+}
+
+async fn clear_thumbnail_generation_failure(hash: &str) {
+    THUMBNAIL_NEGATIVE_CACHE.lock().await.remove(hash);
+}
+
+fn thumbnail_generation_busy_response() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        [(header::CONTENT_TYPE, "application/json")],
+        Json(ErrorResponse {
+            error: "Thumbnail generation is busy".to_string(),
+        })
+        .into_response(),
+    )
+        .into_response()
+}
+
+fn thumbnail_generation_unavailable_response(message: &str) -> Response {
+    (
+        StatusCode::UNPROCESSABLE_ENTITY,
+        [(header::CONTENT_TYPE, "application/json")],
+        Json(ErrorResponse {
+            error: message.to_string(),
+        })
+        .into_response(),
     )
         .into_response()
 }

--- a/cloud-run-upload/src/main.rs
+++ b/cloud-run-upload/src/main.rs
@@ -585,7 +585,16 @@ async fn handle_resumable_complete(
         .complete_session(&upload_id, &auth_event.pubkey)
         .await
     {
-        Ok(response) => {
+        Ok(mut response) => {
+            // Parity with PUT /upload: the poster resolves lazily through the
+            // edge, so this path can advertise the same URL instead of a
+            // `null` clients must special-case.
+            response.thumbnail_url = video_thumbnail_url(
+                &state.config.cdn_base_url,
+                &response.content_type,
+                &response.sha256,
+            );
+
             maybe_trigger_derivatives(
                 state.config.transcoder_url.as_deref(),
                 state.config.transcriber_url.as_deref(),
@@ -651,8 +660,8 @@ async fn process_upload(
     // `GET /thumbnail/:hash` via the edge. Returning the URL keeps it resolvable
     // for callers that use it; it is generated on first request instead of on
     // every upload.
-    let thumbnail_url = thumbnail::is_video_type(&content_type)
-        .then(|| format!("{}/{}.jpg", state.config.cdn_base_url, sha256_hash));
+    let thumbnail_url =
+        video_thumbnail_url(&state.config.cdn_base_url, &content_type, &sha256_hash);
 
     let mut probe_error: Option<String> = None;
     // Probe video dimensions (non-blocking - failures don't fail the upload)
@@ -787,6 +796,15 @@ async fn process_upload(
         transcript_error_message,
         transcript_terminal,
     })
+}
+
+/// CDN URL where a video's poster is (or will be) served.
+///
+/// The object may not exist yet: the edge proxies a `{hash}.jpg` miss to
+/// `GET /thumbnail/:hash`, which generates and stores the poster on first
+/// request. Non-video uploads have no poster and get `None`.
+fn video_thumbnail_url(cdn_base_url: &str, content_type: &str, sha256: &str) -> Option<String> {
+    thumbnail::is_video_type(content_type).then(|| format!("{}/{}.jpg", cdn_base_url, sha256))
 }
 
 /// Whether the upload needs the ffmpeg remux before derivatives can use it.
@@ -1269,7 +1287,7 @@ async fn probe_video_dimensions(video_bytes: &[u8]) -> Result<String> {
 mod tests {
     use super::{
         classify_invalid_media_signal, media_source_candidates, needs_derivative_sanitize,
-        new_temp_media_path,
+        new_temp_media_path, video_thumbnail_url,
     };
 
     #[test]
@@ -1383,6 +1401,20 @@ mod tests {
             "image/jpeg",
             &[0xFF, 0xD8, 0xFF, 0xE0]
         ));
+    }
+
+    #[test]
+    fn thumbnail_url_is_only_advertised_for_videos() {
+        let hash = "0a828bd76eb27c56dee1e970a2e73fe2b2e1ca4443550bbf6e0ee3aa9273e421";
+
+        assert_eq!(
+            video_thumbnail_url("https://cdn.example.com", "video/mp4", hash),
+            Some(format!("https://cdn.example.com/{hash}.jpg"))
+        );
+        assert_eq!(
+            video_thumbnail_url("https://cdn.example.com", "image/jpeg", hash),
+            None
+        );
     }
 }
 

--- a/cloud-run-upload/src/mp4.rs
+++ b/cloud-run-upload/src/mp4.rs
@@ -43,7 +43,7 @@ pub fn is_faststart(data: &[u8]) -> Option<bool> {
             _ => {}
         }
 
-        let size = match declared {
+        let (size, header_len) = match declared {
             // `size == 0` means the box runs to end of file, so nothing we care
             // about can follow it.
             0 => return None,
@@ -52,14 +52,15 @@ pub fn is_faststart(data: &[u8]) -> Option<bool> {
                     return None;
                 }
                 let large = start + BOX_HEADER_LEN as usize;
-                u64::from_be_bytes(data[large..large + 8].try_into().ok()?)
+                let size = u64::from_be_bytes(data[large..large + 8].try_into().ok()?);
+                (size, BOX_HEADER_LEN + LARGE_SIZE_LEN)
             }
-            n => n,
+            n => (n, BOX_HEADER_LEN),
         };
 
-        // A box must at least contain its own header; anything smaller would
-        // stall or rewind the scan.
-        if size < BOX_HEADER_LEN {
+        // A box must at least contain its own header — 16 bytes in the
+        // large-size form; anything smaller would stall or rewind the scan.
+        if size < header_len {
             return None;
         }
 
@@ -181,6 +182,21 @@ mod tests {
         // A declared size below the 8-byte header would never advance.
         data.extend(4u32.to_be_bytes());
         data.extend(b"junk");
+
+        assert_eq!(is_faststart(&data), None);
+    }
+
+    #[test]
+    fn returns_none_on_undersized_large_size_box_rather_than_rewinding() {
+        let mut data = ftyp();
+        // The large-size form spends 16 bytes on its own header. A declared
+        // size of 12 used to advance the scan only 12 bytes, landing it on
+        // bytes the file controls — which here spell a fake `moov`.
+        data.extend(1u32.to_be_bytes());
+        data.extend(b"junk");
+        data.extend(12u64.to_be_bytes());
+        data.extend(b"moov");
+        data.extend(boxed(b"mdat", 16));
 
         assert_eq!(is_faststart(&data), None);
     }

--- a/cloud-run-upload/src/mp4.rs
+++ b/cloud-run-upload/src/mp4.rs
@@ -1,0 +1,187 @@
+// ABOUTME: Minimal ISO-BMFF top-level box scanner
+// ABOUTME: Answers whether an MP4's moov box precedes its mdat box (faststart)
+
+/// Header layout per ISO/IEC 14496-12: a 32-bit size, then a 4-byte type.
+const BOX_HEADER_LEN: u64 = 8;
+/// `size == 1` means the real size follows the type as a 64-bit value.
+const LARGE_SIZE_LEN: u64 = 8;
+/// Cap the scan so a malformed file cannot spin us through millions of boxes.
+const MAX_BOXES_SCANNED: usize = 1024;
+
+/// Whether the video is already laid out for progressive streaming.
+///
+/// Returns `Some(true)` when `moov` appears before `mdat`, `Some(false)` when
+/// `mdat` comes first, and `None` when the bytes are not a recognisable
+/// ISO-BMFF file — a non-MP4 container, or a structure we cannot walk. Callers
+/// should treat `None` as "unknown", not as "not faststart".
+///
+/// This only walks top-level box headers, so it never reads sample data and
+/// runs in microseconds regardless of video size.
+pub fn is_faststart(data: &[u8]) -> Option<bool> {
+    if !starts_with_iso_bmff_box(data) {
+        return None;
+    }
+
+    let total = data.len() as u64;
+    let mut offset: u64 = 0;
+
+    for _ in 0..MAX_BOXES_SCANNED {
+        if offset >= total {
+            break;
+        }
+        if total - offset < BOX_HEADER_LEN {
+            return None;
+        }
+
+        let start = offset as usize;
+        let declared = u32::from_be_bytes(data[start..start + 4].try_into().ok()?) as u64;
+        let box_type = &data[start + 4..start + 8];
+
+        match box_type {
+            b"moov" => return Some(true),
+            b"mdat" => return Some(false),
+            _ => {}
+        }
+
+        let size = match declared {
+            // `size == 0` means the box runs to end of file, so nothing we care
+            // about can follow it.
+            0 => return None,
+            1 => {
+                if total - offset < BOX_HEADER_LEN + LARGE_SIZE_LEN {
+                    return None;
+                }
+                let large = start + BOX_HEADER_LEN as usize;
+                u64::from_be_bytes(data[large..large + 8].try_into().ok()?)
+            }
+            n => n,
+        };
+
+        // A box must at least contain its own header; anything smaller would
+        // stall or rewind the scan.
+        if size < BOX_HEADER_LEN {
+            return None;
+        }
+
+        offset = offset.checked_add(size)?;
+    }
+
+    None
+}
+
+/// Cheap sanity gate: the first box must have a plausible size and a type made
+/// of printable ASCII, which rules out webm, raw streams and truncated files.
+fn starts_with_iso_bmff_box(data: &[u8]) -> bool {
+    if data.len() < BOX_HEADER_LEN as usize {
+        return false;
+    }
+    let declared = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+    if declared != 1 && (declared as u64) < BOX_HEADER_LEN {
+        return false;
+    }
+    data[4..8]
+        .iter()
+        .all(|b| b.is_ascii_graphic() || *b == b' ')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a top-level box with the given type and payload length.
+    fn boxed(box_type: &[u8; 4], payload_len: usize) -> Vec<u8> {
+        let size = BOX_HEADER_LEN as usize + payload_len;
+        let mut out = (size as u32).to_be_bytes().to_vec();
+        out.extend_from_slice(box_type);
+        out.extend(std::iter::repeat_n(0u8, payload_len));
+        out
+    }
+
+    fn ftyp() -> Vec<u8> {
+        boxed(b"ftyp", 24)
+    }
+
+    #[test]
+    fn reports_faststart_when_moov_precedes_mdat() {
+        let mut data = ftyp();
+        data.extend(boxed(b"moov", 64));
+        data.extend(boxed(b"mdat", 512));
+
+        assert_eq!(is_faststart(&data), Some(true));
+    }
+
+    #[test]
+    fn reports_not_faststart_when_mdat_precedes_moov() {
+        let mut data = ftyp();
+        data.extend(boxed(b"mdat", 512));
+        data.extend(boxed(b"moov", 64));
+
+        assert_eq!(is_faststart(&data), Some(false));
+    }
+
+    #[test]
+    fn skips_free_boxes_before_reaching_moov() {
+        let mut data = ftyp();
+        data.extend(boxed(b"free", 128));
+        data.extend(boxed(b"moov", 64));
+        data.extend(boxed(b"mdat", 512));
+
+        assert_eq!(is_faststart(&data), Some(true));
+    }
+
+    #[test]
+    fn handles_64_bit_large_size_boxes() {
+        let mut data = ftyp();
+        // A `size == 1` box carries its real length in the following 8 bytes.
+        let payload = 40usize;
+        let total = BOX_HEADER_LEN as usize + LARGE_SIZE_LEN as usize + payload;
+        data.extend(1u32.to_be_bytes());
+        data.extend(b"skip");
+        data.extend((total as u64).to_be_bytes());
+        data.extend(std::iter::repeat_n(0u8, payload));
+        data.extend(boxed(b"moov", 32));
+
+        assert_eq!(is_faststart(&data), Some(true));
+    }
+
+    #[test]
+    fn returns_none_for_non_mp4_bytes() {
+        // WebM starts with an EBML header, not an ISO-BMFF box.
+        let webm = [0x1A, 0x45, 0xDF, 0xA3, 0x01, 0x00, 0x00, 0x00, 0x00];
+        assert_eq!(is_faststart(&webm), None);
+    }
+
+    #[test]
+    fn returns_none_for_truncated_input() {
+        assert_eq!(is_faststart(&[]), None);
+        assert_eq!(is_faststart(&[0, 0, 0, 24, b'f', b't']), None);
+    }
+
+    #[test]
+    fn returns_none_when_neither_box_is_present() {
+        let mut data = ftyp();
+        data.extend(boxed(b"free", 32));
+
+        assert_eq!(is_faststart(&data), None);
+    }
+
+    #[test]
+    fn returns_none_on_zero_sized_box_rather_than_looping() {
+        let mut data = ftyp();
+        data.extend(0u32.to_be_bytes());
+        data.extend(b"junk");
+        data.extend(boxed(b"moov", 32));
+
+        assert_eq!(is_faststart(&data), None);
+    }
+
+    #[test]
+    fn returns_none_on_undersized_box_rather_than_stalling() {
+        let mut data = ftyp();
+        // A declared size below the 8-byte header would never advance.
+        data.extend(4u32.to_be_bytes());
+        data.extend(b"junk");
+
+        assert_eq!(is_faststart(&data), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,7 +638,11 @@ fn handle_head_blob(path: &str) -> Result<Response> {
             }
         }
 
-        let resp = download_thumbnail(&thumbnail_key)?;
+        let resp = match download_thumbnail(&thumbnail_key) {
+            Ok(resp) => resp,
+            Err(BlossomError::NotFound(_)) => generate_thumbnail_on_demand(thumb_hash)?,
+            Err(e) => return Err(e),
+        };
         let content_length = resp
             .get_header_str("x-goog-stored-content-length")
             .or_else(|| resp.get_header_str("content-length"))
@@ -2795,6 +2799,14 @@ fn generate_thumbnail_on_demand(hash: &str) -> Result<Response> {
         StatusCode::OK => Ok(resp),
         StatusCode::NOT_FOUND => Err(BlossomError::NotFound(
             "Video not found for thumbnail generation".into(),
+        )),
+        status if status == StatusCode::from_u16(422).unwrap() => {
+            Err(BlossomError::UnprocessableEntity(
+                "Thumbnail cannot be generated for this video".into(),
+            ))
+        }
+        StatusCode::SERVICE_UNAVAILABLE => Err(BlossomError::StorageError(
+            "Thumbnail generation is busy".into(),
         )),
         status => Err(BlossomError::StorageError(format!(
             "Thumbnail generation failed with status: {}",


### PR DESCRIPTION
## Summary

`PUT /upload` ran ffmpeg two to four times per video before answering the client — a full remux, one or two thumbnail extractions, and ffprobe. This removes two of those from the request path and leaves the third running only when it can change something.

**Thumbnail extraction is gone from the upload handler.** Clients supply their own cover — mobile extracts the frame the user picked and then explicitly prefers it over the server's — so the server poster was computed for every upload and discarded for nearly all of them. It is not lost: `GET /thumbnail/:hash` already downloads the blob, generates the poster, stores it at `{hash}.jpg` and returns it, and the edge already proxies a `{hash}.jpg` miss there. The poster is now produced on first request instead of on every upload. The response still returns the CDN URL, which resolves through that path, so no caller sees a new `null`.

**The remux is now conditional.** A video whose `moov` box already precedes `mdat` is web-compatible as-is; remuxing rewrites it into the layout it already has. A new top-level box scan (`cloud-run-upload/src/mp4.rs`) answers that in microseconds without spawning a process. divine-mobile exports with `shouldOptimizeForNetworkUse` on every render path, so its uploads skip the remux entirely.

## Motivation

Measured on a real device in divinevideo/divine-mobile#6554: the client-side publish waste is fixed there (~32% faster), and what remained was server-bound. The analysis on #164 established that nothing outside the mobile client depends on the server poster existing eagerly — divine-web and divine-funnelcake resolve the thumbnail from the event tags and never derive it from the video hash, and the moderation dashboard derives it but already degrades on a miss.

Two findings shaped the design:

- **The resumable upload path never generated a poster at all** (`handle_resumable_complete` returned `thumbnail_url: None`). Clients already cope with a missing server poster, which is what made the lazy poster safe to rely on. Review then aligned the two paths in the other direction: resumable completes now advertise the same lazily-resolving URL as `PUT /upload`, through a shared `video_thumbnail_url` helper.
- **The remux doubles as a validity gate** — `sanitize_error` is terminal in `classify_invalid_media_signal` and skips HLS transcoding and transcript generation. Skipping it had to preserve that. It does: `probe_error` from the ffprobe call is terminal in the same function and still runs on every video.

## Safety of the skip

**The remux output never leaves the process.** It is not stored, and the transcoder receives only `{hash, owner}` and fetches the original blob from GCS itself. So downstream services already worked on the unsanitized original before this change, and a skipped remux does not alter what any of them receive. Since the thumbnail extraction is gone, ffprobe is now the only consumer of the remuxed bytes.

That narrows what the skip can actually cost to two mirror-image cases. First: a file that ffmpeg cannot remux, that is nonetheless faststart, and that ffprobe reads without complaint — previously the remux failure would have flagged it `invalid_media`, now the consequence is a transcode attempt that may fail, reported by the transcoder, not silent corruption. Second, the inverse: a faststart file whose atoms make ffprobe fail but that the remux would have repaired — previously cleaned and transcoded, now flagged `invalid_media`. Both require a muxer that deliberately wrote faststart and still produced a file ffmpeg tooling stumbles over; everything else stays on the remux path.

The scan is deliberately conservative about which files reach that path. It returns `Some(true)` only when `moov` is positively found before `mdat`; non-MP4 containers, truncated files and unparseable input return `None` and still get remuxed. Every box must cover at least its own header — 16 bytes in the large-size form — so a malformed size can never rewind the scan onto bytes the file controls. And files with `moov` first come, in practice, from a muxer that was explicitly told to write faststart — our own renderer and transcoder. Camera captures from iPhone and Android put `moov` at the end, so they never take the skip.

## Also in this diff

- `extract_thumbnail` now runs under `spawn_blocking` in the on-demand handler, bounded by a four-slot semaphore. It shells out with a synchronous `Command`, which mattered little when one upload triggered it, but matters now that a cold feed can request many posters at once — and `spawn_blocking` alone would hold one ffmpeg process per request in flight, up to the blocking pool's size.
- The lazy poster path now coalesces on-demand generation per hash on each Cloud Run instance, bounds both same-hash waits and global ffmpeg-slot waits, and caches extraction failures briefly so bad videos do not retry full download plus ffmpeg on every request.
- `HEAD /{hash}.jpg` now follows the same lazy generation fallback as `GET /{hash}.jpg`, so advertised poster URLs do not 404 until a GET warms them.
- `POST /upload/resumable/:id/complete` now returns the same lazily-resolving poster URL as `PUT /upload` instead of `thumbnail_url: null`; both resolve through the same edge path.
- `classify_invalid_media_signal` loses the thumbnail-error parameter it already ignored — no caller can supply one anymore. The test that pinned "thumbnail failures are not terminal" went with it, since it could no longer fail; two tests covering reachable branches replace it.
- The uploaded bytes are held as `Bytes`, so the remaining clones are refcount bumps. A skipped remux now keeps one copy of the video in memory instead of three.

## Validation

- `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked` — 34 passed, 15 of them new (10 for the box scan, 4 for the sanitize gate, 1 for the poster URL helper).
- `cargo check --tests --locked` — passed; existing dead-code warnings remain in the edge crate.
- The undersized-large-size regression test was verified against the pre-fix scanner: the crafted input misparsed to a fake `Some(true)` before the bound and returns `None` after it.
- `cargo clippy --manifest-path cloud-run-upload/Cargo.toml --locked --all-targets` — clean apart from a pre-existing `too_many_arguments` warning on `report_derivative_failure_to_sentry`, untouched here.
- `git diff --check` — clean.
- `rustfmt --edition 2021 --check src/main.rs cloud-run-upload/src/main.rs` still reports pre-existing formatting deviations reached through `mod` declarations and older spots in `src/main.rs`; unrelated rustfmt churn was not included.
- The box scan was checked against real ffmpeg output: a `+faststart` export classifies `Some(true)`, a default export `Some(false)`.

**Not yet run:** no end-to-end upload against the local stack or a deployed environment. Worth checking before merge that a mobile-rendered MP4 logs `Video is already faststart, skipping the derivative remux` and writes no `{hash}.jpg`, and that a subsequent fetch of `{hash}.jpg` generates it through the edge.

No visual change; this is a server-side request-path change.

## Related

- #164 — the analysis this implements
- divinevideo/divine-mobile#6554 — the client-side work and the measurements
- The remaining synchronous remux for non-faststart uploads is a separate question — it gates transcoding and needs its own design pass rather than a removal.

Closes #164
