### PR TITLE
docs: add deployment runbook for automatic and manual deploys

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory is the index for repository documentation. Current docs first, hi
 - [CHANGELOG.md](../CHANGELOG.md) — release history
 - [docs/api/](api/) — cross-service API contracts (creator-delete, etc.)
 - [docs/runbooks/](runbooks/) — operational runbooks
+- [docs/runbooks/deployment.md](runbooks/deployment.md) — what deploys automatically, what deploys by hand, and which GCP project each service lives in
 - [docs/derivative-status-queue.md](derivative-status-queue.md) — Cloud Tasks rollout notes for derivative status callbacks
 
 ## Historical

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,7 @@ This directory is the index for repository documentation. Current docs first, hi
 - [OAUTH_SETUP.md](../OAUTH_SETUP.md) — OAuth configuration for admin UI
 - [CHANGELOG.md](../CHANGELOG.md) — release history
 - [docs/api/](api/) — cross-service API contracts (creator-delete, etc.)
-- [docs/runbooks/](runbooks/) — operational runbooks
-- [docs/runbooks/deployment.md](runbooks/deployment.md) — what deploys automatically, what deploys by hand, and which GCP project each service lives in
+- [docs/runbooks/](runbooks/) — operational runbooks, including deployment and CDN view counting
 - [docs/derivative-status-queue.md](derivative-status-queue.md) — Cloud Tasks rollout notes for derivative status callbacks
 
 ## Historical

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -33,7 +33,7 @@ It targets the same Cloud Run service that CI deploys on merge, so treat the CI
 job and the manual script as competing deploy paths for one service, not two
 separate services.
 
-## The Cloud Run services are not in the production project
+## The edge Cloud Run backends are not in the production project
 
 The edge hardcodes its backends to project number `149672065768`:
 

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -1,9 +1,9 @@
 # Deployment
 
-Some of this repository deploys itself and some of it does not. Merging to `main`
-publishes the Fastly edge service to production within minutes, with no human
-step. The Cloud Run services do not ship that way — each one is a script someone
-runs by hand.
+Some of this repository deploys itself and some of it does not. After tests pass,
+merging to `main` publishes the Fastly edge service to production within minutes,
+with no human step. Most Cloud Run services do not ship that way — each one is a
+script someone runs by hand.
 
 That asymmetry is the thing to plan around. Any change that spans the edge and a
 Cloud Run service goes out in two stages, the edge first, and there is a window
@@ -11,7 +11,8 @@ where new edge code is talking to an old backend.
 
 ## What ships automatically
 
-`.github/workflows/ci.yml` runs on every push to `main` and deploys, in parallel:
+`.github/workflows/ci.yml` runs on every push to `main`. After the `test` job
+passes, it deploys, in parallel:
 
 - the edge service to Fastly (`fastly compute publish`), followed by a CDN purge
 - `process-blob` to Cloud Run
@@ -19,14 +20,18 @@ where new edge code is talking to an old backend.
 
 ## What ships by hand
 
-Nothing below is in CI. Each is a script you run yourself.
+These services are not deployed by CI. Each is a script you run yourself.
 
 | Service | Script |
 | --- | --- |
 | `divine-transcoder` | `cloud-run-transcoder/deploy.sh` |
 | upload service | `cloud-run-upload/deploy.sh` |
 | Parakeet ASR | `cloud-run-asr-parakeet/deploy.sh` |
-| cloud function | `scripts/deploy-cloud-function.sh` |
+
+`process-blob` also has `scripts/deploy-cloud-function.sh` for manual deploys.
+It targets the same Cloud Run service that CI deploys on merge, so treat the CI
+job and the manual script as competing deploy paths for one service, not two
+separate services.
 
 ## The Cloud Run services are not in the production project
 
@@ -40,24 +45,30 @@ const CLOUD_RUN_HOST: &str = "blossom-upload-rust-149672065768.us-central1.run.a
 That is the proof-of-concept project `rich-compiler-479518-d2`, not
 `dv-platform-prod`. See issue #32, which is open and tracks moving them.
 
-Every deploy script defaults `PROJECT_ID` to whatever your active `gcloud`
-configuration points at. If your context is `dv-platform-prod` — the normal case
-— running a script without an explicit project builds and deploys into the wrong
-project. The deploy appears to succeed, the edge keeps calling the old service,
-and nothing changes except a stray service in production.
+Most deploy scripts default `PROJECT_ID` to whatever your active `gcloud`
+configuration points at. `scripts/deploy-cloud-function.sh` is the exception: it
+requires `GCP_PROJECT_ID` and exits if it is unset. If your context is
+`dv-platform-prod` — the normal case — running a script that reads the active
+context without an explicit project may build and deploy into the wrong project.
+The edge keeps calling the old service, and nothing changes except a stray
+service in production. The transcoder script is especially easy to mis-run this
+way because it derives its runtime service account from the target project.
 
-Always pass the project explicitly:
+Always pass the project explicitly, using the variable the script reads:
 
 ```bash
 PROJECT_ID=rich-compiler-479518-d2 ./cloud-run-transcoder/deploy.sh
+PROJECT_ID=rich-compiler-479518-d2 ./cloud-run-upload/deploy.sh
+PROJECT_ID=rich-compiler-479518-d2 ./cloud-run-asr-parakeet/deploy.sh
+GCP_PROJECT_ID=rich-compiler-479518-d2 ./scripts/deploy-cloud-function.sh
 ```
 
 ## Check live configuration before running a deploy script
 
-The scripts use `--update-env-vars` and `--update-secrets`, so keys they do not
-name are preserved. Keys they *do* name are overwritten with the script's
-defaults, which may not match what is running. Compare before you deploy, and
-read names rather than values:
+Only `cloud-run-transcoder/deploy.sh` currently uses `--update-env-vars` and
+`--update-secrets`, so unnamed keys are preserved for transcoder deploys. Keys it
+*does* name are overwritten with the script's defaults, which may not match what
+is running. Compare before you deploy, and read names rather than values:
 
 ```bash
 gcloud run services describe divine-transcoder \
@@ -71,9 +82,20 @@ print('secrets:', sorted(e['name'] for e in c.get('env',[]) if 'valueFrom' in e)
 "
 ```
 
-Never use `--set-env-vars` or `--set-secrets` in these scripts. Both replace the
-entire configuration and silently drop live settings the script does not know
-about. That bug was fixed in #153; do not reintroduce it.
+Do not assume that safety applies to the other deploy paths yet:
+
+- `cloud-run-upload/deploy.sh` still uses `--set-env-vars` and `--set-secrets`.
+- `cloud-run-asr-parakeet/deploy.sh` still uses `--set-env-vars`.
+- `scripts/deploy-cloud-function.sh` still uses `--set-env-vars`.
+- `.github/workflows/ci.yml` still deploys `process-blob` with
+  `--set-env-vars`, so every merge to `main` can replace live `process-blob`
+  environment variables with the smaller CI set.
+
+Never add new `--set-env-vars` or `--set-secrets` usage unless the command owns
+the complete live configuration. Both replace the entire configuration and
+silently drop live settings the deploy path does not name. PR #153 fixed this
+for the transcoder script only; the other deploy paths still need the same
+treatment; see issue #171.
 
 ## Staged rollout when the edge and a backend change together
 

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -1,0 +1,100 @@
+# Deployment
+
+Some of this repository deploys itself and some of it does not. Merging to `main`
+publishes the Fastly edge service to production within minutes, with no human
+step. The Cloud Run services do not ship that way — each one is a script someone
+runs by hand.
+
+That asymmetry is the thing to plan around. Any change that spans the edge and a
+Cloud Run service goes out in two stages, the edge first, and there is a window
+where new edge code is talking to an old backend.
+
+## What ships automatically
+
+`.github/workflows/ci.yml` runs on every push to `main` and deploys, in parallel:
+
+- the edge service to Fastly (`fastly compute publish`), followed by a CDN purge
+- `process-blob` to Cloud Run
+- the container image to GHCR
+
+## What ships by hand
+
+Nothing below is in CI. Each is a script you run yourself.
+
+| Service | Script |
+| --- | --- |
+| `divine-transcoder` | `cloud-run-transcoder/deploy.sh` |
+| upload service | `cloud-run-upload/deploy.sh` |
+| Parakeet ASR | `cloud-run-asr-parakeet/deploy.sh` |
+| cloud function | `scripts/deploy-cloud-function.sh` |
+
+## The Cloud Run services are not in the production project
+
+The edge hardcodes its backends to project number `149672065768`:
+
+```rust
+const CLOUD_RUN_TRANSCODER_HOST: &str = "divine-transcoder-149672065768.us-central1.run.app";
+const CLOUD_RUN_HOST: &str = "blossom-upload-rust-149672065768.us-central1.run.app";
+```
+
+That is the proof-of-concept project `rich-compiler-479518-d2`, not
+`dv-platform-prod`. See issue #32, which is open and tracks moving them.
+
+Every deploy script defaults `PROJECT_ID` to whatever your active `gcloud`
+configuration points at. If your context is `dv-platform-prod` — the normal case
+— running a script without an explicit project builds and deploys into the wrong
+project. The deploy appears to succeed, the edge keeps calling the old service,
+and nothing changes except a stray service in production.
+
+Always pass the project explicitly:
+
+```bash
+PROJECT_ID=rich-compiler-479518-d2 ./cloud-run-transcoder/deploy.sh
+```
+
+## Check live configuration before running a deploy script
+
+The scripts use `--update-env-vars` and `--update-secrets`, so keys they do not
+name are preserved. Keys they *do* name are overwritten with the script's
+defaults, which may not match what is running. Compare before you deploy, and
+read names rather than values:
+
+```bash
+gcloud run services describe divine-transcoder \
+  --project rich-compiler-479518-d2 --region us-central1 --format=json \
+  | python3 -c "
+import json,sys
+c=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]
+print('image:', c['image'])
+print('env:', sorted(e['name'] for e in c.get('env',[]) if 'value' in e))
+print('secrets:', sorted(e['name'] for e in c.get('env',[]) if 'valueFrom' in e))
+"
+```
+
+Never use `--set-env-vars` or `--set-secrets` in these scripts. Both replace the
+entire configuration and silently drop live settings the script does not know
+about. That bug was fixed in #153; do not reintroduce it.
+
+## Staged rollout when the edge and a backend change together
+
+The edge is already live by the time you start deploying the backend, so the
+compatibility question is always "what does new edge do when the old backend
+answers?" Where the edge has a receiver-side switch, set it before merging, not
+after.
+
+The derivative status generation guard is one such switch. See
+[derivative-status-queue.md](../derivative-status-queue.md) for its rollout,
+including the `REQUIRE_DERIVATIVE_STATUS_GENERATION` config-store key that must
+be `false` while the transcoder is still an image that does not send
+`generation`.
+
+## Verifying a transcoder deploy landed
+
+The transcoder does not report its version anywhere the edge can see. Confirm
+from the Cloud Run side that the image tag matches the commit you deployed:
+
+```bash
+gcloud run services describe divine-transcoder \
+  --project rich-compiler-479518-d2 --region us-central1 \
+  --format='value(spec.template.spec.containers[0].image)'
+```


### PR DESCRIPTION
## Summary

- Adds `docs/runbooks/deployment.md` describing which services deploy automatically on merge and which are manual scripts.
- Records that the edge hardcodes both Cloud Run backends to project `149672065768`, the proof-of-concept project, while most deploy scripts default to whatever `gcloud` context the operator happens to have.
- Documents the pre-deploy comparison of live environment and secret binding names, explains that only the transcoder script currently preserves unnamed runtime config with `--update-*`, and calls out the remaining `--set-*` deploy paths as hazards.
- Links the runbook from the docs index.

## Motivation

Merging to `main` publishes the edge to production automatically after tests pass, but most Cloud Run services do not ship that way. Anyone deploying a change that spans both meets a window where new edge code is talking to an old backend, and nothing in the repository said so.

The project mismatch is the sharper problem. Running a deploy script with a normal `dv-platform-prod` context can build and deploy into a project the edge does not call. It looks like it worked, and nothing changes.

## Related Issues

- Relates to #32, which tracks moving the Cloud Run services out of the proof-of-concept project. This does not close it — it documents the situation while it stands.
- Relates to #171, which tracks converting the remaining deploy paths away from `--set-*` replacement semantics.

## Validation

- [x] I could not run some validation locally, and I explained why below

Documentation only; no Rust, Python, or workflow files are touched, so the build and lint gates have nothing to exercise. The runbook was validated by reading the deploy scripts and CI workflow it documents.

The project number, service hostnames, script defaults, `--set-*` usage, and `--update-*` usage were read from the code and workflow. The deploy scripts themselves were read, not executed.

## Manual Test Plan / Notes

- Follow the runbook inspection command against `divine-transcoder` and confirm it prints the image tag plus environment and secret names.
- Reviewers who deploy this repo regularly should check the runbook against how they actually do it. It was written from inspection, not from having run a deploy.

## Visuals / API Examples

- [x] No visual change

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved