### PR TITLE
fix(edge): stop stamping generations on non-terminal status writes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1298,7 +1298,7 @@ fn purge_transcript_content_cache(hash: &str) {
 
 fn edge_transcript_metadata_update(status: TranscriptStatus) -> TranscriptMetadataUpdate {
     TranscriptMetadataUpdate {
-        generation: Some(crate::metadata::edge_transcript_status_generation(status)),
+        generation: crate::metadata::edge_transcript_status_generation(status),
         ..TranscriptMetadataUpdate::default()
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -263,7 +263,7 @@ pub fn update_blob_status(hash: &str, status: BlobStatus) -> Result<()> {
 
 /// Update transcode status for a video blob
 pub fn update_transcode_status(hash: &str, status: crate::blossom::TranscodeStatus) -> Result<()> {
-    let generation = Some(edge_transcode_status_generation(status));
+    let generation = edge_transcode_status_generation(status);
     update_transcode_status_with_metadata(
         hash,
         status,
@@ -344,12 +344,42 @@ fn current_generation_ms() -> u64 {
         .unwrap_or(0)
 }
 
-fn edge_transcode_status_generation(status: crate::blossom::TranscodeStatus) -> u64 {
-    status_generation_from_ms(current_generation_ms(), transcode_status_event_sequence(status))
+/// Generation for an edge-originated transcode status write, if it deserves one.
+///
+/// Only terminal states are stamped. A `processing` write records that the edge
+/// asked for work, not that any happened, and its timestamp is the moment of the
+/// write rather than the start of an attempt. Stamping it lets a re-trigger that
+/// does no work outrank the attempt that actually finishes, because the winning
+/// attempt's terminal generation is anchored to its earlier start.
+fn edge_transcode_status_generation(status: crate::blossom::TranscodeStatus) -> Option<u64> {
+    match status {
+        crate::blossom::TranscodeStatus::Pending | crate::blossom::TranscodeStatus::Processing => {
+            None
+        }
+        crate::blossom::TranscodeStatus::Complete | crate::blossom::TranscodeStatus::Failed => {
+            Some(status_generation_from_ms(
+                current_generation_ms(),
+                transcode_status_event_sequence(status),
+            ))
+        }
+    }
 }
 
-pub fn edge_transcript_status_generation(status: crate::blossom::TranscriptStatus) -> u64 {
-    status_generation_from_ms(current_generation_ms(), transcript_status_event_sequence(status))
+/// Generation for an edge-originated transcript status write, if it deserves one.
+///
+/// See [`edge_transcode_status_generation`] for why non-terminal writes are not
+/// stamped.
+pub fn edge_transcript_status_generation(status: crate::blossom::TranscriptStatus) -> Option<u64> {
+    match status {
+        crate::blossom::TranscriptStatus::Pending
+        | crate::blossom::TranscriptStatus::Processing => None,
+        crate::blossom::TranscriptStatus::Complete | crate::blossom::TranscriptStatus::Failed => {
+            Some(status_generation_from_ms(
+                current_generation_ms(),
+                transcript_status_event_sequence(status),
+            ))
+        }
+    }
 }
 
 fn duplicate_generation(incoming: Option<u64>, stored: Option<u64>) -> bool {
@@ -1357,8 +1387,9 @@ pub fn delete_audio_source_refs(audio_hash: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        duplicate_generation, generation_rejection, stale_generation, status_generation_from_ms,
-        transcript_status_event_sequence, transcode_status_event_sequence, StatusUpdateOutcome,
+        duplicate_generation, edge_transcode_status_generation, edge_transcript_status_generation,
+        generation_rejection, stale_generation, status_generation_from_ms,
+        transcode_status_event_sequence, transcript_status_event_sequence, StatusUpdateOutcome,
     };
 
     #[test]
@@ -1457,6 +1488,88 @@ mod tests {
         assert_eq!(
             generation_rejection(None, None, true, true),
             Some(StatusUpdateOutcome::MalformedGeneration { stored: None })
+        );
+    }
+
+    #[test]
+    fn edge_writes_stamp_only_terminal_states() {
+        use crate::blossom::{TranscodeStatus, TranscriptStatus};
+
+        assert_eq!(
+            edge_transcode_status_generation(TranscodeStatus::Processing),
+            None
+        );
+        assert_eq!(
+            edge_transcode_status_generation(TranscodeStatus::Pending),
+            None
+        );
+        assert!(edge_transcode_status_generation(TranscodeStatus::Complete).is_some());
+        assert!(edge_transcode_status_generation(TranscodeStatus::Failed).is_some());
+
+        assert_eq!(
+            edge_transcript_status_generation(TranscriptStatus::Processing),
+            None
+        );
+        assert_eq!(
+            edge_transcript_status_generation(TranscriptStatus::Pending),
+            None
+        );
+        assert!(edge_transcript_status_generation(TranscriptStatus::Complete).is_some());
+        assert!(edge_transcript_status_generation(TranscriptStatus::Failed).is_some());
+    }
+
+    #[test]
+    fn edge_retrigger_does_not_outrank_the_attempt_that_finishes() {
+        // Reproduces blob 8b1067db on 2026-08-05. A transcript attempt started at
+        // 02:20:54.669 and completed at 02:21:00. Between those, the edge asked for
+        // transcription again; the transcoder logged the second request as a
+        // duplicate and did no work for it.
+        //
+        // The edge previously stamped that re-trigger with a write-time generation,
+        // which outranked the finishing attempt's terminal generation because the
+        // latter is anchored to its earlier start. The completion was discarded and
+        // the blob stayed at `processing` while its VTT sat in storage.
+        let attempt_start_ms = 1_785_896_454_669;
+        let retrigger_ms = 1_785_896_456_908;
+
+        let attempt_processing = status_generation_from_ms(
+            attempt_start_ms,
+            transcript_status_event_sequence(crate::blossom::TranscriptStatus::Processing),
+        );
+        let attempt_terminal = status_generation_from_ms(
+            attempt_start_ms,
+            transcript_status_event_sequence(crate::blossom::TranscriptStatus::Complete),
+        );
+
+        // The write-time stamp the edge used to produce, kept here to show why the
+        // completion lost rather than to assert current behaviour.
+        let retrigger_stamp = status_generation_from_ms(
+            retrigger_ms,
+            transcript_status_event_sequence(crate::blossom::TranscriptStatus::Processing),
+        );
+        assert!(attempt_terminal < retrigger_stamp);
+        assert_eq!(
+            generation_rejection(Some(attempt_terminal), Some(retrigger_stamp), true, false),
+            Some(StatusUpdateOutcome::StaleGeneration {
+                incoming: Some(attempt_terminal),
+                stored: Some(retrigger_stamp),
+            })
+        );
+
+        // The edge no longer stamps a re-trigger, so the stored generation stays at
+        // the attempt's own processing event and the completion applies.
+        assert_eq!(
+            edge_transcript_status_generation(crate::blossom::TranscriptStatus::Processing),
+            None
+        );
+        assert_eq!(
+            generation_rejection(
+                Some(attempt_terminal),
+                Some(attempt_processing),
+                true,
+                false
+            ),
+            None
         );
     }
 }


### PR DESCRIPTION
## Summary

- Edge-originated status writes no longer stamp a derivative generation for `pending` or `processing`. Only `complete` and `failed` are stamped.
- Adds a regression test replaying the production sequence that exposed this, and a test asserting only terminal states are stamped.

## Motivation

A transcript finished, its VTT was written to storage, and the blob stayed at `transcript_status: processing`.

The edge stamps its own writes with the time of the write, while the transcoder stamps callbacks with the time its attempt started. Those are not comparable. When the edge re-triggered transcription for a blob that was already being transcribed, it stamped that re-trigger with a newer generation than the terminal callback of the attempt that was about to finish. The transcoder logged the second request as a duplicate and did no work for it, but its stamp still outranked the real completion, which was then discarded as stale.

Stranded status is not cosmetic. `to_descriptor` only emits the `vtt` URL when `transcript_status` is `Complete`, so clients are never told the transcript exists, never request it, and the existing read-path self-heal never runs. The same shape applies to `hls` and `transcode_status`.

A `processing` write records that the edge asked for work, not that any happened, so it has no state worth defending. Terminal writes keep their stamp, so the protection against a delayed callback regressing repaired state is unchanged.

## Related Issue

- Regression from #159. No separate issue was filed; this was found while verifying that rollout in production.

## Validation

- [x] `cargo check --tests --locked`
- [x] `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked` — 34 passed
- [x] `cargo clippy --locked --all-targets --all-features` — no errors
- [x] relevant service-local checks for touched Cloud Run or Python code

The edge crate's own tests do run, contrary to what has been assumed. They need the wasm target and Viceroy rather than the host target:

```
CARGO_TARGET_WASM32_WASIP1_RUNNER="$HOME/.config/fastly/viceroy run -C fastly.toml --" \
  cargo test --locked --target wasm32-wasip1 --bin fastly-blossom
```

124 passed, 0 failed, up from 122. CI does not run these; see #169.

Formatting drift was compared against `main` and only hunks in newly written code were corrected. Pre-existing drift elsewhere in the touched files was left alone to keep the diff scoped.

## Manual Test Plan / Notes

- Transcode a video that already has a transcription in flight, so the edge issues a duplicate request. Confirm `transcript_status` reaches `complete` and the descriptor includes a `vtt` URL without anyone having to fetch the transcript first.
- Confirm `transcript_generation` on that blob corresponds to the attempt that produced the VTT rather than to the re-trigger.

This does not change the case where an edge self-heal marks `complete` and a later transcoder `complete` carrying `dim` is then rejected as stale. That behavior is unchanged and was not observed in production sampling.

## Visuals / API Examples

- [x] No visual change

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved
