### PR TITLE
ci: run the edge crate tests under Viceroy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,25 @@ jobs:
       - name: Check edge crate
         run: cargo check --tests --locked
 
+      # Viceroy supplies the Fastly host functions the edge crate links against,
+      # which plain `cargo test` on the host target cannot provide.
+      # Release assets on this tag are mutable, so pin the digest as well as the
+      # version: a substituted binary could otherwise fake the test output the
+      # step below relies on. Update both together when bumping.
+      - name: Install Viceroy
+        env:
+          VICEROY_VERSION: v0.20.1
+          VICEROY_SHA256: c358540ae3054b0f3203125da47a76d50d2facd41cc1ac009a7e7d1f332b0437
+        run: |
+          curl -sSfL -o /tmp/viceroy.tar.gz \
+            "https://github.com/fastly/Viceroy/releases/download/${VICEROY_VERSION}/viceroy_${VICEROY_VERSION}_linux-amd64.tar.gz"
+          echo "${VICEROY_SHA256}  /tmp/viceroy.tar.gz" | sha256sum -c -
+          tar xzf /tmp/viceroy.tar.gz -C /usr/local/bin/
+          viceroy --version
+
+      - name: Run edge crate tests under Viceroy
+        run: ./scripts/run-edge-tests.sh
+
       - name: Run blossom-core tests
         run: cargo test -p blossom-core --locked
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           VICEROY_VERSION: v0.20.1
           VICEROY_SHA256: c358540ae3054b0f3203125da47a76d50d2facd41cc1ac009a7e7d1f332b0437
         run: |
-          curl -sSfL -o /tmp/viceroy.tar.gz \
+          curl --retry 3 --retry-all-errors -sSfL -o /tmp/viceroy.tar.gz \
             "https://github.com/fastly/Viceroy/releases/download/${VICEROY_VERSION}/viceroy_${VICEROY_VERSION}_linux-amd64.tar.gz"
           echo "${VICEROY_SHA256}  /tmp/viceroy.tar.gz" | sha256sum -c -
           tar xzf /tmp/viceroy.tar.gz -C /usr/local/bin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@ If a Divine Brain search or ask tool is available, you may use it for company me
 - Deployment and environment config lives in `fastly.toml*`, `Dockerfile.local`, and service-specific config files. Verify current config before changing domains, buckets, or service bindings.
 
 ## Build, Test, and Validation Commands
-- `cargo check --tests --locked`: check the Fastly edge crate.
+- `./scripts/run-edge-tests.sh`: run the Fastly edge crate tests under Viceroy.
+- `cargo check --tests --locked`: compile-check the Fastly edge crate tests.
 - `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked`: upload service tests.
 - `cargo clippy --locked --all-targets --all-features`: lint gate used in CI.
 - Use the relevant service-local test or validation command when touching `cloud-run-transcoder/` or `cloud-functions/process-blob/`.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ fastly compute serve
 ### Tests
 
 ```bash
-cargo check --tests --locked                                  # edge crate
+./scripts/run-edge-tests.sh                                  # edge crate tests under Viceroy
+cargo check --tests --locked                                  # edge crate compile check
 cargo test -p blossom-core --locked                           # pure-logic core
 cargo test --manifest-path cloud-run-upload/Cargo.toml --locked
 cargo clippy --locked --all-targets --all-features            # lint gate used in CI

--- a/scripts/run-edge-tests.sh
+++ b/scripts/run-edge-tests.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# ABOUTME: Runs the fastly-blossom edge crate unit tests on wasm32-wasip1 under Viceroy
+# ABOUTME: Asserts the tests actually executed, so a silent regression to zero tests fails CI
+#
+# Plain `cargo test` builds the edge crate for the host target, where the Fastly
+# host functions cannot link. Viceroy provides those host functions, so the tests
+# run when cargo is told to execute the wasm test binaries through it.
+#
+# Usage:
+#   ./scripts/run-edge-tests.sh              # uses `viceroy` from PATH
+#   VICEROY=~/.config/fastly/viceroy ./scripts/run-edge-tests.sh
+#
+# Extra arguments are passed through to cargo test, e.g.:
+#   ./scripts/run-edge-tests.sh generation
+
+set -euo pipefail
+
+VICEROY="${VICEROY:-viceroy}"
+
+# The crate has exactly two unit-test binaries: the lib target (src/lib.rs) and
+# the bin target (src/main.rs). `--lib --bins` selects both and excludes doc
+# tests, which cargo reports as a third zero-count result and which would
+# otherwise blur the executed-test accounting below.
+EXPECTED_TEST_BINARIES=2
+
+command -v "$VICEROY" >/dev/null 2>&1 || {
+  echo "error: viceroy not found (looked for '$VICEROY')" >&2
+  echo "install it from https://github.com/fastly/Viceroy/releases or set VICEROY=<path>" >&2
+  exit 1
+}
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+CARGO_TARGET_WASM32_WASIP1_RUNNER="$VICEROY run -C fastly.toml --" \
+  cargo test --locked --target wasm32-wasip1 --lib --bins "$@" 2>&1 | tee "$log"
+
+# A step that exits zero while running nothing is the exact failure this guard
+# exists to catch: cargo reports success for "0 passed; 0 failed" just as it does
+# for a real run. Count what actually executed and refuse to pass on an empty run.
+read -r results passed ignored <<<"$(awk '
+  /^test result:/ { results++ }
+  /^test result: ok\./ { passed += $4; ignored += $8 }
+  END { print results + 0, passed + 0, ignored + 0 }
+' "$log")"
+
+# `ignored` is reported but not gated on: #[ignore] is sometimes legitimate, and
+# failing on it would be over-strict. Printing it keeps a silent coverage drop
+# visible in the CI log instead of invisible behind a healthy `passed` count.
+echo
+echo "edge crate tests executed under Viceroy: ${passed} passed, ${ignored} ignored across ${results} test binaries"
+
+if [ "$results" -ne "$EXPECTED_TEST_BINARIES" ]; then
+  echo "error: expected $EXPECTED_TEST_BINARIES test binaries, saw $results" >&2
+  echo "the lib or bin test target stopped being built or run; fix it or update EXPECTED_TEST_BINARIES" >&2
+  exit 1
+fi
+
+if [ "$passed" -eq 0 ]; then
+  echo "error: no edge tests executed" >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #169.

CI compiled the edge crate's tests and never ran them. `cargo check --tests` proved
they build; `cargo test` covered only `blossom-core`, `cloud-run-upload` and
`cloud-run-transcoder`. This runs them.

Plain `cargo test` defaults to the host target, where the Fastly host functions
cannot link. Viceroy provides those host functions, so pointing cargo's
`wasm32-wasip1` runner at it makes the tests run. The target is already installed
in this job, so Viceroy is the only new dependency: a prebuilt v0.20.1 tarball,
13.7 MB, seconds to install. No cache — measured, it is not slow enough to be
worth the cache-key maintenance.

Both the version and the SHA-256 are pinned. GitHub reports this tag's assets as
`immutable: false`, so a substituted binary could otherwise forge the very test
output the guard below depends on. The digest is verified before extraction, so
the check fails closed.

**All 179 pass. Nothing is excluded, skipped or non-blocking.** The step lands as
a hard gate.

**The issue's count of 122 is wrong — the real figure is 179 across two test
binaries.** Flagging that explicitly so the difference does not read as scope
creep. Two reasons for it. The issue predates #172, which added two tests. And it
proposes `--bin fastly-blossom`, which runs only one of the crate's two unit-test
binaries.

The crate has two, since `src/lib.rs` and `src/main.rs` both exist:

- bin target (`src/main.rs`) — 124 tests
- lib target (`src/lib.rs`) — 55 tests, of which 4 are unique and cover
  `resumable_complete::parse_resumable_complete_request_body`

The issue's suggested `--bin fastly-blossom` would miss those 4, so the step uses
`--lib --bins`, which also excludes doc tests.

## Proving the tests ran, not that the step exited zero

A step that silently runs nothing is the failure mode this issue exists to fix,
so it is guarded rather than trusted. `scripts/run-edge-tests.sh` sums cargo's own
`test result:` counts, prints them, and fails on an empty run. Every CI run shows:

```
edge crate tests executed under Viceroy: 179 passed, 0 ignored across 2 test binaries
```

`ignored` is reported but not gated on — `#[ignore]` is sometimes legitimate, and
failing on it would be over-strict. Printing it keeps a later coverage drop
visible instead of hidden behind a healthy `passed` count.

Two assertions back that line:

- **Zero tests fails the step.** This is the regression the issue names. Bare
  cargo exits **0** here — measured, not assumed: filtered to a non-existent test
  name it reports `0 passed; 0 failed` and returns 0. Without the guard CI would
  go green having run nothing.
- **Anything other than two test binaries fails the step.** Catches one binary
  silently dropping out — for example reverting to `--bin fastly-blossom`, which
  would lose 55 tests while still printing a healthy-looking 124 passed.

A fixed expected count such as `>= 179` was rejected deliberately: it fails
spuriously when tests are legitimately removed and needs bumping on every PR that
adds one. The two invariants above are structural and do not rot.

## Non-vacuity

Each guard branch was made to fail. Measured exit codes:

| Case | Exit | Result |
|---|---|---|
| Happy path | 0 | `179 passed, 0 ignored across 2 test binaries` |
| Zero tests run, cargo happy | 1 | `error: no edge tests executed` |
| ...same run with the guard removed | **0** | would have passed CI silently — the bug |
| A test binary disappears | 1 | `error: expected 2 test binaries, saw 1` |
| Viceroy not installed | 1 | `error: viceroy not found` |
| Runner env var not honored | 101 | `Exec format error (os error 8)` |
| `fastly.toml` missing | 1 | `error reading 'fastly.toml'` |
| A test genuinely fails | 134 | gate blocks |
| Substituted release asset | 1 | `sha256sum -c` fails; nothing is extracted |

The second and third rows are the same run with and without the guard, which is
the point: the guard is what turns a silent green into a red.

## Validation

Run locally on Linux against the exact artifact CI will use — the prebuilt
`viceroy_v0.20.1_linux-amd64.tar.gz`, not the Viceroy bundled in the Fastly CLI.
Cold wasm build and run: 19 s wall on 32 cores; the runner has 16, so expect
somewhat more on a cold cache. `Swatinem/rust-cache@v2` is already keyed
`wasm32-wasip1` in this job. The `test` job currently takes ~92 s.

No visual change; CI-only.

## Residual risk

**This has never executed on a GitHub runner.** That gap closes only when CI runs
on this PR, and not before.

Two things support it, and both are supporting evidence rather than proof:

- The `/usr/local/bin` write without `sudo` is not a guess — the `deploy` job
  already does exactly that on the same `ubuntu-24.04-16core` label, and its
  `Install Fastly CLI` step succeeds (run 31027721170).
- The full suite was reproduced from a clean target in an Ubuntu 24.04 container
  using the exact release archive and the exact workflow command.

Neither is a run on the actual runner. Please read the `Run edge crate tests under
Viceroy` step's output on this PR before trusting the step, and expect the summary
line to name a non-zero count. Cold-cache job time on the runner is an estimate,
not a measurement.

## Scope

Two files. Only the `test` job is touched. No triggers, permissions, secrets or
other jobs changed.

Separately and untouched: `deploy-process-blob` is failing on `main` and has been
for at least the last two pushes (runs 31027721170 and 30970865200), while `test`,
`docker` and `deploy` are green in both. Unrelated to this change, but it wants
someone's attention.
