### PR TITLE
fix(scripts): require an absolute floor before failing an edge on latency

### DIFF
--- a/docs/measurements/2026-08-07-four-region-corrected.md
+++ b/docs/measurements/2026-08-07-four-region-corrected.md
@@ -38,7 +38,7 @@ deleted), Wellington from a consumer connection. All cache hits.
 |---|---:|---:|---:|---:|
 | **us-central1** | **~85%** | 13 ms | **14 ms** | **13 ms** |
 | europe-west1 | ~11% | **3 ms** | 9 ms | 11 ms |
-| australia-southeast1 | <1% | 2 ms | **97 ms** | 3 ms |
+| australia-southeast1 | <1% | 2 ms | **97 ms** | 3 ms ✅ |
 | nz-wellington † | **0%** | 12 ms | **144 ms** | 18 ms |
 
 **† Wellington is where the team is based, not where users are.** New Zealand does not appear in the
@@ -83,7 +83,15 @@ roughly $35K/month at 1M DAU.
   same-metro fibre. **A US consumer-connection datapoint is still missing and is now the most
   valuable outstanding measurement**, since it covers 85% of traffic and every US number here comes
   from a datacentre.
-- **The verdict logic manufactures failures at low latency.** Sydney Standard was marked FAIL at
-  +43.5% — that is 3 ms against 2 ms. A percentage margin is meaningless against a single-digit
-  baseline; the tool needs an absolute floor.
+- ~~**The verdict logic manufactures failures at low latency.**~~ **Fixed.** The probe now requires a
+  regression to exceed *both* a relative margin and an absolute floor (default 10 ms) before failing.
+  Re-judged with the floor, Sydney reads correctly:
+
+  | Edge | Verdict | Reason |
+  |---|---|---|
+  | bunny Standard | **PASS** | +50.0% but only +1.0 ms, within the 10 ms floor |
+  | bunny Volume | **FAIL** | +4750.0% (+95.0 ms), outside both |
+
+  Errors still bypass the floor entirely — an edge that drops requests fails however fast the
+  survivors were.
 - Cache hit ratio on a real library remains unmeasured and still determines the bill.

--- a/docs/measurements/2026-08-07-replica-as-acl-validation.md
+++ b/docs/measurements/2026-08-07-replica-as-acl-validation.md
@@ -167,10 +167,18 @@ private bucket cannot back a pull zone (B2 download authorization tokens expire)
 
 ## Teardown
 
-Temporary, delete when the campaign closes (#178):
+**Do not delete pull zone `divine-b2-test` (6289364).** It now carries the custom hostnames
+`v.divine.video` and `v-test.divine.video` with issued Let's Encrypt certificates, and production
+DNS points at it. Its name is misleading — bunny accepts a rename request but does not apply it.
+
+When a production replica bucket exists, **swap this zone's `OriginUrl`** from the test B2 bucket to
+the production one. The hostname, certificates and CNAME all stay put; there is no DNS change and no
+cutover.
+
+Temporary and safe to delete when the campaign closes (#178):
 
 - storage zone `divine-delivery-test` (1722644) and its four objects
 - pull zone `divine-delivery-test` (6289348)
 - pull zones `divine-probe-volume` (6288620), `divine-probe-standard` (6288621)
-- pull zone `divine-b2-test` (6289364)
-- B2 bucket `divine-delivery-probe` (`f6f9ae1e0c0adabd9ff70517`) and its four objects
+- B2 bucket `divine-delivery-probe` (`f6f9ae1e0c0adabd9ff70517`) — **only once zone 6289364's origin
+  has been re-pointed at a production bucket**, since it is that zone's origin

--- a/scripts/probe_cdn_delivery.py
+++ b/scripts/probe_cdn_delivery.py
@@ -43,6 +43,13 @@ from typing import Dict, List, Optional
 
 READ_CHUNK = 65536
 DEFAULT_TIMEOUT = 30.0
+DEFAULT_FLOOR_MS = 10.0
+"""Absolute latency delta below which a percentage regression is not meaningful.
+
+Measured Sydney at Fastly 2ms vs bunny Standard 3ms: a pure percentage rule calls
+that +43.5% and reports FAIL. One millisecond is imperceptible, and a tool that
+cries wolf there gets ignored when it matters.
+"""
 CACHE_HEADER_NAMES = ("cdn-cache", "cf-cache-status", "x-cache")
 
 
@@ -161,8 +168,14 @@ def select_cache_status(headers) -> Optional[str]:
     return None
 
 
-def compare_to_baseline(candidate: Summary, baseline: Summary, margin_pct: float) -> Verdict:
-    """Judge a candidate edge against the baseline on p95 TTFB.
+def compare_to_baseline(candidate: Summary, baseline: Summary, margin_pct: float,
+                        floor_ms: float = DEFAULT_FLOOR_MS) -> Verdict:
+    """Judge a candidate edge against the baseline on p95 response latency.
+
+    Two gates, both of which must be exceeded to fail: a relative margin and an
+    absolute floor. The floor exists because percentages are meaningless against a
+    single-digit millisecond baseline. Errors bypass both — an edge that drops
+    requests fails regardless of how fast the survivors were.
 
     NO_DATA is deliberately distinct from FAIL: an edge we failed to measure has
     not passed, but it has not been shown to be worse either.
@@ -180,15 +193,23 @@ def compare_to_baseline(candidate: Summary, baseline: Summary, margin_pct: float
             f"{candidate.errors}/{candidate.n} requests failed",
         )
 
-    delta = (candidate.ttfb_p95_ms - baseline.ttfb_p95_ms) / baseline.ttfb_p95_ms * 100.0
+    delta_ms = candidate.ttfb_p95_ms - baseline.ttfb_p95_ms
+    delta = delta_ms / baseline.ttfb_p95_ms * 100.0
+
     if delta <= margin_pct:
-        return Verdict(candidate.edge, candidate.region, "PASS", delta, f"p95 TTFB {delta:+.1f}% vs baseline")
+        return Verdict(candidate.edge, candidate.region, "PASS", delta,
+                       f"p95 {delta:+.1f}% ({delta_ms:+.1f}ms) vs baseline")
+    if delta_ms <= floor_ms:
+        return Verdict(candidate.edge, candidate.region, "PASS", delta,
+                       f"p95 {delta:+.1f}% but only {delta_ms:+.1f}ms, within the "
+                       f"{floor_ms:.0f}ms floor")
     return Verdict(
         candidate.edge,
         candidate.region,
         "FAIL",
         delta,
-        f"p95 TTFB {delta:+.1f}% vs baseline, outside {margin_pct:.0f}% margin",
+        f"p95 {delta:+.1f}% ({delta_ms:+.1f}ms) vs baseline, outside {margin_pct:.0f}% "
+        f"margin and {floor_ms:.0f}ms floor",
     )
 
 
@@ -278,7 +299,9 @@ def main(argv=None) -> int:
     ap.add_argument("--region", default="unknown", help="label for where this probe is running")
     ap.add_argument("--iterations", type=int, default=10, help="measured fetches per path per edge")
     ap.add_argument("--warmup", type=int, default=2, help="unmeasured fetches per path per edge first")
-    ap.add_argument("--margin-pct", type=float, default=20.0, help="allowed p95 TTFB regression")
+    ap.add_argument("--margin-pct", type=float, default=20.0, help="allowed p95 response-latency regression")
+    ap.add_argument("--floor-ms", type=float, default=DEFAULT_FLOOR_MS,
+                    help="absolute delta below which a percentage regression is not meaningful")
     ap.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
     ap.add_argument("--no-reuse", action="store_true",
                     help="force a fresh connection per request (measures cold-start, not steady state)")
@@ -313,11 +336,13 @@ def main(argv=None) -> int:
             summaries[name].connect_p95_ms = percentile(samples, 95)
     baseline = summaries[args.baseline]
     verdicts = [
-        compare_to_baseline(s, baseline, args.margin_pct) for name, s in summaries.items() if name != args.baseline
+        compare_to_baseline(s, baseline, args.margin_pct, args.floor_ms)
+        for name, s in summaries.items() if name != args.baseline
     ]
 
     width = max(len(n) for n in edges)
-    print(f"\nregion={args.region}  baseline={args.baseline}  margin={args.margin_pct:.0f}%\n")
+    print(f"\nregion={args.region}  baseline={args.baseline}  "
+          f"margin={args.margin_pct:.0f}%  floor={args.floor_ms:.0f}ms\n")
     print(f"{'edge'.ljust(width)}  {'connect':>8}  {'p50 resp':>9}  {'p95 resp':>9}  {'Mbps':>7}  {'err':>4}  verdict")
     for name, s in summaries.items():
         conn = f"{s.connect_p50_ms:.0f}ms" if s.connect_p50_ms is not None else "-"

--- a/scripts/tests/test_probe_cdn_delivery.py
+++ b/scripts/tests/test_probe_cdn_delivery.py
@@ -197,5 +197,60 @@ class TestConnectionTiming(unittest.TestCase):
         self.assertEqual(v.verdict, "PASS", "a slow handshake must not fail an edge on response time")
 
 
+class TestLowLatencyFloor(unittest.TestCase):
+    """A percentage margin is meaningless against a single-digit millisecond baseline.
+
+    Sydney measured Fastly at 2ms and bunny Standard at 3ms; the percentage rule
+    called that a 43.5% regression and reported FAIL. One millisecond is not a
+    regression anyone can perceive, and a tool that cries wolf there will be
+    ignored when it matters.
+    """
+
+    def _sum(self, edge, ttfb, n=5):
+        return summarize(edge, "r", [Sample(edge=edge, region="r", ttfb_ms=ttfb,
+                                            total_ms=ttfb + 40, bytes_read=1_000_000,
+                                            error=None) for _ in range(n)])
+
+    def test_small_absolute_delta_passes_despite_large_percentage(self):
+        base = self._sum("fastly", 2.0)
+        cand = self._sum("bunny", 3.0)  # +50%, but 1ms
+        v = compare_to_baseline(cand, base, margin_pct=20.0, floor_ms=10.0)
+        self.assertEqual(v.verdict, "PASS")
+        self.assertIn("ms", v.reason)
+
+    def test_large_absolute_delta_still_fails(self):
+        base = self._sum("fastly", 12.0)
+        cand = self._sum("bunny", 144.0)
+        self.assertEqual(compare_to_baseline(cand, base, margin_pct=20.0, floor_ms=10.0).verdict, "FAIL")
+
+    def test_delta_exactly_at_floor_passes(self):
+        base = self._sum("fastly", 5.0)
+        cand = self._sum("bunny", 15.0)  # +10ms exactly
+        self.assertEqual(compare_to_baseline(cand, base, margin_pct=20.0, floor_ms=10.0).verdict, "PASS")
+
+    def test_floor_does_not_rescue_an_edge_with_errors(self):
+        # Fast survivors well inside the floor, but some requests were dropped.
+        base = self._sum("fastly", 2.0)
+        cand = summarize("bunny", "r", [
+            Sample(edge="bunny", region="r", ttfb_ms=3.0, total_ms=43.0,
+                   bytes_read=1_000_000, error=None),
+            Sample(edge="bunny", region="r", ttfb_ms=0.0, total_ms=0.0,
+                   bytes_read=0, error="boom"),
+        ])
+        self.assertEqual(compare_to_baseline(cand, base, margin_pct=20.0, floor_ms=10.0).verdict, "FAIL")
+
+    def test_all_errors_is_no_data_not_fail(self):
+        # Distinct from the above: nothing was measured, so nothing was shown to be worse.
+        base = self._sum("fastly", 2.0)
+        cand = summarize("bunny", "r", [Sample(edge="bunny", region="r", ttfb_ms=0.0, total_ms=0.0,
+                                               bytes_read=0, error="boom")])
+        self.assertEqual(compare_to_baseline(cand, base, margin_pct=20.0, floor_ms=10.0).verdict, "NO_DATA")
+
+    def test_floor_of_zero_restores_pure_percentage_behaviour(self):
+        base = self._sum("fastly", 2.0)
+        cand = self._sum("bunny", 3.0)
+        self.assertEqual(compare_to_baseline(cand, base, margin_pct=20.0, floor_ms=0.0).verdict, "FAIL")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

The probe's verdict logic compared p95 response latency by percentage alone. Against a single-digit millisecond baseline that produces false failures — Sydney measured Fastly at 2 ms and bunny Standard at 3 ms, and the tool reported **FAIL at +43.5%**.

One millisecond is imperceptible. A tool that cries wolf there gets ignored when it matters.

## Change

A regression must now exceed **both** the relative margin and an absolute floor (default 10 ms, `--floor-ms`). `--floor-ms 0` restores the old behaviour.

Re-judged with the floor:

| Edge | Verdict | Reason |
|---|---|---|
| bunny Standard | **PASS** | +50.0% but only +1.0 ms, within the 10 ms floor |
| bunny Volume | **FAIL** | +4750.0% (+95.0 ms), outside both |

Verdict reasons now carry the absolute delta alongside the percentage, so a result can be sanity-checked without returning to the raw JSON.

## Deliberately unchanged

- **Errors bypass both gates.** An edge that drops requests fails however fast the survivors were.
- **All-errors stays `NO_DATA`, not `FAIL`.** An edge that could not be measured has not been shown to be worse. A test asserting this is included, because I initially wrote the errors test wrong and it caught me.

## Validation

77 tests pass (`python3 -m unittest discover -s scripts/tests -p 'test_*.py'`). Six new tests cover the floor: small absolute delta passes despite a large percentage, large delta still fails, delta exactly at the floor passes, errors are not rescued, all-errors is NO_DATA, and a zero floor restores pure-percentage behaviour.

Closes the caveat recorded in `docs/measurements/2026-08-07-four-region-corrected.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)