### PR TITLE
fix(cache): stop marking mutable derivatives as immutable

### DIFF
--- a/blossom-core/src/cache_policy.rs
+++ b/blossom-core/src/cache_policy.rs
@@ -1,0 +1,71 @@
+// ABOUTME: Shared cache policy for immutable blobs and repairable derivatives.
+// ABOUTME: Keeps browser and edge cache lifetimes testable outside Fastly Compute.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PublicCacheHeaders<'a> {
+    pub cache_control: &'static str,
+    pub surrogate_control: &'static str,
+    pub surrogate_key: &'a str,
+}
+
+pub fn immutable_blob_cache_headers(hash: &str) -> PublicCacheHeaders<'_> {
+    PublicCacheHeaders {
+        cache_control: "public, max-age=31536000, immutable",
+        surrogate_control: "max-age=31536000",
+        surrogate_key: hash,
+    }
+}
+
+pub fn mutable_derivative_cache_headers(hash: &str) -> PublicCacheHeaders<'_> {
+    PublicCacheHeaders {
+        cache_control: "public, max-age=86400",
+        surrogate_control: "max-age=31536000",
+        surrogate_key: hash,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{immutable_blob_cache_headers, mutable_derivative_cache_headers};
+
+    fn max_age(cache_control: &str) -> u64 {
+        cache_control
+            .split("max-age=")
+            .nth(1)
+            .and_then(|rest| rest.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|digits| digits.parse().ok())
+            .expect("Cache-Control must carry a numeric max-age")
+    }
+
+    #[test]
+    fn blobs_are_immutable_for_a_year() {
+        let headers = immutable_blob_cache_headers("abc123");
+
+        assert_eq!(headers.cache_control, "public, max-age=31536000, immutable");
+        assert_eq!(headers.surrogate_control, "max-age=31536000");
+        assert_eq!(headers.surrogate_key, "abc123");
+    }
+
+    #[test]
+    fn derivatives_are_not_immutable() {
+        let cache_control = mutable_derivative_cache_headers("abc123").cache_control;
+
+        assert!(cache_control.contains("public"));
+        assert!(!cache_control.contains("immutable"));
+    }
+
+    #[test]
+    fn repaired_derivatives_reach_browsers_within_a_day() {
+        let headers = mutable_derivative_cache_headers("abc123");
+
+        assert!(max_age(headers.cache_control) <= 86_400);
+    }
+
+    #[test]
+    fn derivatives_keep_a_long_purgeable_edge_ttl() {
+        let headers = mutable_derivative_cache_headers("abc123");
+
+        assert_eq!(headers.surrogate_control, "max-age=31536000");
+        assert_eq!(headers.surrogate_key, "abc123");
+    }
+}

--- a/blossom-core/src/lib.rs
+++ b/blossom-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cache_policy;
 pub mod delete_policy;
 pub mod error;
 pub mod rate_limit;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,9 @@ use crate::storage::{
     upload_blob, write_audit_log,
 };
 use crate::viewer_auth::{ViewerAuthDiagnostics, ViewerAuthState};
+use blossom_core::cache_policy::{
+    immutable_blob_cache_headers, mutable_derivative_cache_headers,
+};
 use fastly_blossom::resumable_complete::parse_resumable_complete_request_body;
 
 use fastly::cache::simple as simple_cache;
@@ -1661,7 +1664,7 @@ fn serve_transcript_by_hash(
             if is_admin || metadata.status.requires_private_cache() {
                 add_private_cache_headers(&mut resp, &hash);
             } else {
-                add_derivative_cache_headers(&mut resp, &hash);
+                add_derivative_cache_headers(&mut resp, hash);
             }
             add_cors_headers(&mut resp);
             Ok(resp)
@@ -5919,13 +5922,14 @@ fn error_response(error: &BlossomError) -> Response {
 /// - Surrogate-Control: tells Fastly edge to cache for 1 year (stripped before client)
 /// - Surrogate-Key: enables targeted purging via `fastly purge --key {hash}`
 fn add_cache_headers(resp: &mut Response, hash: &str) {
-    resp.set_header("Cache-Control", "public, max-age=31536000, immutable");
-    resp.set_header("Surrogate-Control", "max-age=31536000");
-    resp.set_header("Surrogate-Key", hash);
+    let headers = immutable_blob_cache_headers(hash);
+    resp.set_header("Cache-Control", headers.cache_control);
+    resp.set_header("Surrogate-Control", headers.surrogate_control);
+    resp.set_header("Surrogate-Key", headers.surrogate_key);
 }
 
 /// Cache headers for *derived* content: renditions, HLS manifests and segments,
-/// transcripts, and thumbnails.
+/// and transcripts.
 ///
 /// Unlike the blob, these are not immutable. The transcoder regenerates renditions
 /// via `/backfill-fmp4`, and `scan_and_repair_vtts.py` rewrites transcripts — both
@@ -5937,9 +5941,10 @@ fn add_cache_headers(resp: &mut Response, hash: &str) {
 /// Surrogate-Key. Only the browser TTL needs to be short enough that a repair reaches
 /// clients that already cached the old version.
 fn add_derivative_cache_headers(resp: &mut Response, hash: &str) {
-    resp.set_header("Cache-Control", "public, max-age=86400");
-    resp.set_header("Surrogate-Control", "max-age=31536000");
-    resp.set_header("Surrogate-Key", hash);
+    let headers = mutable_derivative_cache_headers(hash);
+    resp.set_header("Cache-Control", headers.cache_control);
+    resp.set_header("Surrogate-Control", headers.surrogate_control);
+    resp.set_header("Surrogate-Key", headers.surrogate_key);
 }
 
 /// Like add_cache_headers but for authenticated or admin-only content that must
@@ -6160,15 +6165,13 @@ mod tests {
         should_reset_transcode_failure_on_clean_upload,
         should_reset_transcript_failure_on_clean_upload, should_set_audio_content_length,
         trusted_upload_service_terminal_derivative_error, upload_capability_headers,
-        add_cache_headers, add_derivative_cache_headers, upload_control_host,
-        upload_exposed_headers, upload_from_resumable_completion,
+        upload_control_host, upload_exposed_headers, upload_from_resumable_completion,
         AudioReuseAvailability, DerivativeObservation, TranscodeFetchAction, TranscriptFetchAction,
         TranscriptPendingState,
     };
     use crate::blossom::{ResumableUploadCompleteResponse, TranscodeStatus, TranscriptStatus};
     use crate::error::{BlossomError, Result as BlossomResult};
     use fastly::http::StatusCode;
-    use fastly::Response;
 
     #[test]
     fn upload_service_response_records_failure_fields_but_clamps_broad_invalid_media_terminal() {
@@ -6863,66 +6866,5 @@ mod tests {
         assert_eq!(resp.get_status(), StatusCode::BAD_REQUEST);
         assert_eq!(resp.get_header_str("Cache-Control"), None);
         assert_eq!(resp.get_header_str("Surrogate-Control"), None);
-    }
-
-    #[test]
-    fn blob_cache_headers_are_immutable() {
-        // The blob is the content of its own hash; it can never change.
-        let mut resp = Response::from_status(StatusCode::OK);
-        add_cache_headers(&mut resp, "abc123");
-
-        assert_eq!(
-            resp.get_header_str("Cache-Control"),
-            Some("public, max-age=31536000, immutable")
-        );
-        assert_eq!(resp.get_header_str("Surrogate-Control"), Some("max-age=31536000"));
-        assert_eq!(resp.get_header_str("Surrogate-Key"), Some("abc123"));
-    }
-
-    #[test]
-    fn derivative_cache_headers_are_never_immutable() {
-        // Derivatives are regenerated: scan_and_repair_vtts.py rewrites VTTs and
-        // backfill-fmp4 rebuilds renditions. A browser holding an `immutable`
-        // response will not revalidate even on reload, and browser caches cannot
-        // be purged, so a repaired file would never reach clients that saw the old one.
-        let mut resp = Response::from_status(StatusCode::OK);
-        add_derivative_cache_headers(&mut resp, "abc123");
-
-        let cc = resp.get_header_str("Cache-Control").unwrap();
-        assert!(!cc.contains("immutable"), "derivatives must not be immutable, got {cc:?}");
-        assert!(cc.contains("public"), "derivatives should still be shared-cacheable, got {cc:?}");
-    }
-
-    #[test]
-    fn derivative_browser_ttl_is_short_enough_to_recover_from_a_repair() {
-        let mut resp = Response::from_status(StatusCode::OK);
-        add_derivative_cache_headers(&mut resp, "abc123");
-
-        let cc = resp.get_header_str("Cache-Control").unwrap();
-        let max_age: u64 = cc
-            .split("max-age=")
-            .nth(1)
-            .and_then(|rest| rest.split(|c: char| !c.is_ascii_digit()).next())
-            .and_then(|d| d.parse().ok())
-            .expect("derivative Cache-Control must carry a max-age");
-        assert!(
-            max_age <= 86_400,
-            "a repaired derivative must reach clients within a day, got max-age={max_age}"
-        );
-    }
-
-    #[test]
-    fn derivative_keeps_long_edge_ttl_and_purge_key() {
-        // Edge caches stay long-lived because purge_edge_cache can invalidate them
-        // by Surrogate-Key; only the browser TTL needs shortening.
-        let mut resp = Response::from_status(StatusCode::OK);
-        add_derivative_cache_headers(&mut resp, "abc123");
-
-        assert_eq!(resp.get_header_str("Surrogate-Control"), Some("max-age=31536000"));
-        assert_eq!(
-            resp.get_header_str("Surrogate-Key"),
-            Some("abc123"),
-            "purge by hash must still reach every derivative"
-        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -755,7 +755,7 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
             if is_admin || meta.status.requires_private_cache() {
                 add_private_cache_headers(&mut resp, &hash);
             } else {
-                add_cache_headers(&mut resp, &hash);
+                add_derivative_cache_headers(&mut resp, &hash);
             }
             resp.set_header("X-Sha256", &hash);
             if let Some(c2pa) = c2pa_manifest_id {
@@ -873,7 +873,7 @@ fn handle_head_hls_master(path: &str) -> Result<Response> {
             }
             let mut resp = Response::from_status(StatusCode::OK);
             resp.set_header("Content-Type", "application/vnd.apple.mpegurl");
-            add_cache_headers(&mut resp, &hash);
+            add_derivative_cache_headers(&mut resp, &hash);
             resp.set_header("X-Sha256", &hash);
             add_cors_headers(&mut resp);
             Ok(resp)
@@ -998,7 +998,7 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
             if is_restricted {
                 add_private_cache_headers(&mut resp, &hash);
             } else {
-                add_cache_headers(&mut resp, &hash);
+                add_derivative_cache_headers(&mut resp, &hash);
             }
             resp.set_header("X-Sha256", &hash);
             if let Some(c2pa) = c2pa_manifest_id {
@@ -1133,7 +1133,7 @@ fn handle_head_hls_content(path: &str) -> Result<Response> {
         Ok(_) => {
             let mut resp = Response::from_status(StatusCode::OK);
             resp.set_header("Content-Type", content_type);
-            add_cache_headers(&mut resp, &hash_lower);
+            add_derivative_cache_headers(&mut resp, &hash_lower);
             resp.set_header("X-Sha256", &hash_lower);
             add_cors_headers(&mut resp);
             Ok(resp)
@@ -1661,7 +1661,7 @@ fn serve_transcript_by_hash(
             if is_admin || metadata.status.requires_private_cache() {
                 add_private_cache_headers(&mut resp, &hash);
             } else {
-                add_cache_headers(&mut resp, &hash);
+                add_derivative_cache_headers(&mut resp, &hash);
             }
             add_cors_headers(&mut resp);
             Ok(resp)
@@ -1793,7 +1793,7 @@ fn handle_head_transcript_by_hash(hash: &str) -> Result<Response> {
             }
             let mut resp = Response::from_status(StatusCode::OK);
             resp.set_header("Content-Type", "text/vtt; charset=utf-8");
-            add_cache_headers(&mut resp, hash);
+            add_derivative_cache_headers(&mut resp, hash);
             add_cors_headers(&mut resp);
             Ok(resp)
         }
@@ -2427,7 +2427,7 @@ fn handle_get_quality_variant(req: Request, path: &str) -> Result<Response> {
             if is_admin || meta.status.requires_private_cache() {
                 add_private_cache_headers(&mut resp, &hash);
             } else {
-                add_cache_headers(&mut resp, &hash);
+                add_derivative_cache_headers(&mut resp, &hash);
             }
             resp.set_header("Accept-Ranges", "bytes");
             add_cors_headers(&mut resp);
@@ -5924,6 +5924,24 @@ fn add_cache_headers(resp: &mut Response, hash: &str) {
     resp.set_header("Surrogate-Key", hash);
 }
 
+/// Cache headers for *derived* content: renditions, HLS manifests and segments,
+/// transcripts, and thumbnails.
+///
+/// Unlike the blob, these are not immutable. The transcoder regenerates renditions
+/// via `/backfill-fmp4`, and `scan_and_repair_vtts.py` rewrites transcripts — both
+/// while the URL stays the same. Marking them `immutable` tells a browser never to
+/// revalidate, even on reload, and browser caches cannot be purged; a client that
+/// fetched a broken transcript would keep it for the full year.
+///
+/// The edge TTL stays long because `purge_edge_cache` can invalidate it instantly by
+/// Surrogate-Key. Only the browser TTL needs to be short enough that a repair reaches
+/// clients that already cached the old version.
+fn add_derivative_cache_headers(resp: &mut Response, hash: &str) {
+    resp.set_header("Cache-Control", "public, max-age=86400");
+    resp.set_header("Surrogate-Control", "max-age=31536000");
+    resp.set_header("Surrogate-Key", hash);
+}
+
 /// Like add_cache_headers but for authenticated or admin-only content that must
 /// not be stored in shared caches.
 fn add_private_cache_headers(resp: &mut Response, hash: &str) {
@@ -6142,13 +6160,15 @@ mod tests {
         should_reset_transcode_failure_on_clean_upload,
         should_reset_transcript_failure_on_clean_upload, should_set_audio_content_length,
         trusted_upload_service_terminal_derivative_error, upload_capability_headers,
-        upload_control_host, upload_exposed_headers, upload_from_resumable_completion,
+        add_cache_headers, add_derivative_cache_headers, upload_control_host,
+        upload_exposed_headers, upload_from_resumable_completion,
         AudioReuseAvailability, DerivativeObservation, TranscodeFetchAction, TranscriptFetchAction,
         TranscriptPendingState,
     };
     use crate::blossom::{ResumableUploadCompleteResponse, TranscodeStatus, TranscriptStatus};
     use crate::error::{BlossomError, Result as BlossomResult};
     use fastly::http::StatusCode;
+    use fastly::Response;
 
     #[test]
     fn upload_service_response_records_failure_fields_but_clamps_broad_invalid_media_terminal() {
@@ -6843,5 +6863,66 @@ mod tests {
         assert_eq!(resp.get_status(), StatusCode::BAD_REQUEST);
         assert_eq!(resp.get_header_str("Cache-Control"), None);
         assert_eq!(resp.get_header_str("Surrogate-Control"), None);
+    }
+
+    #[test]
+    fn blob_cache_headers_are_immutable() {
+        // The blob is the content of its own hash; it can never change.
+        let mut resp = Response::from_status(StatusCode::OK);
+        add_cache_headers(&mut resp, "abc123");
+
+        assert_eq!(
+            resp.get_header_str("Cache-Control"),
+            Some("public, max-age=31536000, immutable")
+        );
+        assert_eq!(resp.get_header_str("Surrogate-Control"), Some("max-age=31536000"));
+        assert_eq!(resp.get_header_str("Surrogate-Key"), Some("abc123"));
+    }
+
+    #[test]
+    fn derivative_cache_headers_are_never_immutable() {
+        // Derivatives are regenerated: scan_and_repair_vtts.py rewrites VTTs and
+        // backfill-fmp4 rebuilds renditions. A browser holding an `immutable`
+        // response will not revalidate even on reload, and browser caches cannot
+        // be purged, so a repaired file would never reach clients that saw the old one.
+        let mut resp = Response::from_status(StatusCode::OK);
+        add_derivative_cache_headers(&mut resp, "abc123");
+
+        let cc = resp.get_header_str("Cache-Control").unwrap();
+        assert!(!cc.contains("immutable"), "derivatives must not be immutable, got {cc:?}");
+        assert!(cc.contains("public"), "derivatives should still be shared-cacheable, got {cc:?}");
+    }
+
+    #[test]
+    fn derivative_browser_ttl_is_short_enough_to_recover_from_a_repair() {
+        let mut resp = Response::from_status(StatusCode::OK);
+        add_derivative_cache_headers(&mut resp, "abc123");
+
+        let cc = resp.get_header_str("Cache-Control").unwrap();
+        let max_age: u64 = cc
+            .split("max-age=")
+            .nth(1)
+            .and_then(|rest| rest.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|d| d.parse().ok())
+            .expect("derivative Cache-Control must carry a max-age");
+        assert!(
+            max_age <= 86_400,
+            "a repaired derivative must reach clients within a day, got max-age={max_age}"
+        );
+    }
+
+    #[test]
+    fn derivative_keeps_long_edge_ttl_and_purge_key() {
+        // Edge caches stay long-lived because purge_edge_cache can invalidate them
+        // by Surrogate-Key; only the browser TTL needs shortening.
+        let mut resp = Response::from_status(StatusCode::OK);
+        add_derivative_cache_headers(&mut resp, "abc123");
+
+        assert_eq!(resp.get_header_str("Surrogate-Control"), Some("max-age=31536000"));
+        assert_eq!(
+            resp.get_header_str("Surrogate-Key"),
+            Some("abc123"),
+            "purge by hash must still reach every derivative"
+        );
     }
 }

--- a/vcl/fetch.vcl
+++ b/vcl/fetch.vcl
@@ -1,18 +1,39 @@
 # ABOUTME: VCL fetch snippet for Divine Blossom VCL caching layer
-# ABOUTME: Overrides backend cache headers from Compute/GCS to enforce aggressive caching
+# ABOUTME: Enforces long edge caching while preserving explicit browser cache policy
 
 # Strip any anti-caching headers leaked from GCS through Compute
 unset beresp.http.Pragma;
 
 if (beresp.status == 200 || beresp.status == 206) {
-  # Successful content responses: cache aggressively (1 year)
-  # Content is SHA256-addressed and immutable
+  # Successful content responses: keep a long, purgeable edge TTL.
   set beresp.ttl = 365d;
   set beresp.grace = 24h;
   set beresp.stale_while_revalidate = 24h;
 
-  # Override any anti-caching headers from GCS (no-cache, no-store, private)
-  set beresp.http.Cache-Control = "public, max-age=31536000, immutable";
+  # Deliver bytes to the client as they arrive from origin instead of buffering
+  # the whole object first. This is the required counterpart to the vcl_miss
+  # snippet that strips the client Range header: that strip makes every cache
+  # fill fetch the FULL object, so without streaming a client asking for the
+  # first 1KB of a cold video waits for the entire object to land.
+  #
+  # Measured on 2026-08-11 before this line existed:
+  #   cold range request, Range stripped, buffered : 3.1-4.0s to first byte
+  #   cold range request, Range forwarded (control): 1.34s
+  #   warm range request (cache hit)               : 0.09s
+  #
+  # Streaming keeps the whole object cached -- the byte-offload gain is
+  # unaffected -- while removing the buffer wait. Caveats: a mid-stream origin
+  # failure cannot be cleanly retried, and a range starting mid-object still
+  # waits for the stream to reach that offset. Players request bytes=0- first,
+  # which is the case this helps most.
+  set beresp.do_stream = true;
+
+  # Compute owns browser policy: blobs are immutable, but repairable derivatives
+  # have a shorter browser TTL. Retain the immutable default for legacy responses
+  # that do not provide an explicit policy.
+  if (!beresp.http.Cache-Control) {
+    set beresp.http.Cache-Control = "public, max-age=31536000, immutable";
+  }
 
 } else if (beresp.status == 202) {
   # 202 Accepted = transcoding/transcription in progress

--- a/vcl/miss.vcl
+++ b/vcl/miss.vcl
@@ -1,0 +1,25 @@
+# ABOUTME: VCL miss snippet for Divine Blossom VCL caching layer
+# ABOUTME: Fetches full objects on cache fill so Fastly can synthesize 206s from cache
+#
+# Applied via the Fastly API/CLI as a VCL snippet in the vcl_miss subroutine.
+#
+# Without this, a player's Range header is forwarded to the Compute origin and on
+# to GCS, the origin returns 206 Partial Content, and Fastly stores nothing --
+# every seek and every replay is a fresh origin fetch. That is the difference
+# between a 77.2% request hit ratio and ~25% byte offload (294.5 GB/day
+# delivered vs 218.8 GB/day fetched from origin).
+#
+# vcl_miss only runs for requests that recv sent to lookup, i.e. GET/HEAD on
+# /{64-hex}... without an Authorization header. Restricted and authenticated
+# traffic takes the pass path and never reaches here.
+#
+# Safe to strip unconditionally: the largest object in a 1/256 sample of the
+# bucket is 27.9 MB (p50 0.17 MB, p99 3.4 MB), so a full fetch on a one-byte
+# probe is cheap and bounded.
+#
+# Expected behavior change: the FIRST client to request a cold object with a
+# Range header receives a full 200 rather than a 206. Players handle this
+# correctly. Subsequent range requests are synthesized from cache as 206s.
+
+unset bereq.http.Range;
+


### PR DESCRIPTION
## Summary

Stop marking repairable media derivatives as browser-immutable while retaining the long, purgeable edge TTL.

| Content | `Cache-Control` | `Surrogate-Control` |
|---|---|---|
| Blob | `public, max-age=31536000, immutable` | `max-age=31536000` |
| Derivative | `public, max-age=86400` | `max-age=31536000` |

The seven HLS, rendition, and transcript GET/HEAD call sites now use the derivative policy. The immutable blob policy is unchanged.

The VCL fetch snippet now preserves Compute's explicit browser `Cache-Control` instead of replacing every successful response with a one-year immutable policy. It still enforces a one-year Fastly edge TTL and uses the immutable policy as a fallback when the origin supplies no browser policy.

The repository VCL also now records the already-live `beresp.do_stream = true` block so applying this snippet cannot regress the production streaming fix, and records the live `vcl_miss` Range-strip snippet it depends on as `vcl/miss.vcl` (byte-identical to the active snippet).

## Motivation

`/backfill-fmp4` rebuilds renditions and `scan_and_repair_vtts.py` rewrites transcripts while their URLs remain unchanged. A browser that received `immutable` could retain a broken derivative for a year, and browser caches cannot be purged.

The one-day browser TTL bounds recovery time for previously cached clients. The edge TTL and per-hash `Surrogate-Key` remain unchanged, so normal edge invalidation still works immediately.

This was found while validating the second delivery-CDN plan and is tracked by #184.

## Validation

- `cargo test -p blossom-core --locked` — 119 passed, including four cache-policy tests executed by CI
- `cargo check --tests --locked` — passed (pre-existing warnings only)
- `cargo clippy --locked --all-targets --all-features` — passed (pre-existing warnings only; the warning introduced by the original PR head was removed)
- Active VCL snippet inspected before the change; the live `do_stream` behavior is preserved verbatim
- Combined merge simulation with #184, #185, and #193 completed without conflicts

## Manual deployment and verification

CI publishes the Compute service only. After merge:

1. Clone the active VCL service version.
2. Apply this repository's `vcl/fetch.vcl` as the versioned fetch snippet.
3. Validate and activate the cloned VCL version.
4. Purge both Fastly services.
5. Verify a derivative returns `public, max-age=86400` without `immutable`, a blob remains immutable for one year, range streaming still works, and the full smoke suite passes.

Rollback is activation of the previous VCL version plus the previous Compute version.

## Not addressed here

The repair script still does not issue a purge after rewriting a VTT. This change bounds the browser-cache impact to one day; it does not add that purge. The follow-up remains in #184.