### PR TITLE
docs(delivery): select B2 for second CDN origin

### DIFF
--- a/docs/cdn-evaluation-status.md
+++ b/docs/cdn-evaluation-status.md
@@ -69,11 +69,12 @@ all-Standard.
 | bunny storage zone `divine-delivery-test` | id 1722644, region NY | Push replica, 4 approved objects |
 | bunny pull zone `divine-delivery-test` | id 6289348, Volume tier | Backed by the storage zone — the working ACL test |
 | Backblaze B2 | bucket `divine-delivery-probe`, public, 4 objects | Validated as a bunny pull-zone origin |
-| bunny pull zone `divine-b2-test` | id 6289364, Volume tier | Origin is the B2 bucket — full production-shaped topology |
+| bunny pull zone `divine-b2-test` | id 6289364, Volume tier | Origin is the B2 bucket — production-shaped except that the bucket is public, not privately signed |
 | Cloudflare R2 | not started | account exists; no bucket, no token |
 
-Both bunny zones are **temporary probe infrastructure** and pull through Fastly rather than from a
-real delivery origin. They should be deleted when the campaign ends — tracked in #178.
+The `divine-probe-*` zones are **temporary probe infrastructure** and pull through Fastly rather than
+from a real delivery origin; `divine-b2-test` is the one that pulls from B2 directly. All of them
+should be deleted when the campaign ends — tracked in #178.
 
 **The B2 key `blossom-dev` is not scoped.** It reports `ALL BUCKETS` with `deleteBuckets`,
 `writeKeys`, and `bypassGovernance` — the last of which overrides retention and legal hold. It
@@ -137,8 +138,9 @@ receive it — not a query over what already exists.
 ## Open questions
 
 **Measurement**
-- Behaviour against a real delivery origin. Both bunny zones currently pull through Fastly, so
-  origin-fetch and cache-fill behaviour is untested.
+- Behaviour against a *privately signed* delivery origin. The B2 origin measured in next-step 3 was
+  a public bucket; the probe zones pull through Fastly, so origin-fetch and cache-fill behaviour
+  behind AWS signing is untested.
 - Mobile networks and behaviour under load.
 - South America, India, Africa. São Paulo is a Volume PoP; India and Africa are not.
 - Whether Fastly's Sydney p95 outlier (311 ms against a 21 ms p50) reproduces.
@@ -168,8 +170,10 @@ receive it — not a query over what already exists.
 3. ~~Stand up a real delivery origin and re-measure~~ — done. Fastly pull-through, bunny Storage,
    and Backblaze B2 origins all land within 6% of each other on cache hits, so **origin choice does
    not affect delivery performance** and can be decided on cost, durability, and lock-in alone.
-   **Decided on that basis: a private Backblaze B2 bucket, approved-only, with R2 as the first
-   fallback** — see the origin decision plan. The open part is bunny's AWS-signing path to a
+   **Decided — on measured readiness rather than on cost: a private Backblaze B2 bucket,
+   approved-only, with R2 as the first fallback.** R2 remains the stronger paper position on egress
+   and published durability; B2 is the one that has been stood up and drilled. See the origin
+   decision plan. The open part is bunny's AWS-signing path to a
    *private* B2 bucket; the validated probe bucket was public.
 4. Measure South America and India.
 5. Delete the probe zones once the campaign closes (#178).

--- a/docs/cdn-evaluation-status.md
+++ b/docs/cdn-evaluation-status.md
@@ -11,6 +11,7 @@ Entry point for the delivery-origin and second-CDN evaluation. Start here, then 
 |---|---|
 | [cdn-object-storage-vendor-notes.md](cdn-object-storage-vendor-notes.md) | Verified vendor limits, pricing, and API capabilities |
 | [superpowers/specs/2026-08-06-cdn-delivery-steering-design.md](superpowers/specs/2026-08-06-cdn-delivery-steering-design.md) | How to steer traffic between two CDNs, server-side |
+| [superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md](superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md) | **The origin decision** — private B2 as the approved-only replica origin |
 | [measurements/2026-08-07-four-region-corrected.md](measurements/2026-08-07-four-region-corrected.md) | **The current headline result** |
 | [measurements/2026-08-07-four-region-summary.md](measurements/2026-08-07-four-region-summary.md) | Superseded — timing method bundled TLS handshake |
 | [measurements/2026-08-07-replica-as-acl-validation.md](measurements/2026-08-07-replica-as-acl-validation.md) | Working test system proving absence-is-denial |
@@ -167,5 +168,8 @@ receive it — not a query over what already exists.
 3. ~~Stand up a real delivery origin and re-measure~~ — done. Fastly pull-through, bunny Storage,
    and Backblaze B2 origins all land within 6% of each other on cache hits, so **origin choice does
    not affect delivery performance** and can be decided on cost, durability, and lock-in alone.
+   **Decided on that basis: a private Backblaze B2 bucket, approved-only, with R2 as the first
+   fallback** — see the origin decision plan. The open part is bunny's AWS-signing path to a
+   *private* B2 bucket; the validated probe bucket was public.
 4. Measure South America and India.
 5. Delete the probe zones once the campaign closes (#178).

--- a/docs/cdn-object-storage-vendor-notes.md
+++ b/docs/cdn-object-storage-vendor-notes.md
@@ -292,7 +292,10 @@ than assuming.
   from a still-live source URL?
 - Backblaze: does partner-CDN free egress apply to an edge-compute S3 fetch, or only a direct pull
   zone?
-- bunny: can a pull zone originate from R2 or B2 with private-bucket authentication?
+- bunny: can a pull zone originate from B2 with private-bucket authentication? B2 is validated as a
+  pull-zone origin against a *public* probe bucket; the AWS-signing path to a private bucket is the
+  part still unproven, and it is the blocking open question for the selected origin. R2 is untested
+  either way.
 - bunny: purge API latency and rate limits.
 
 ---

--- a/docs/measurements/2026-08-07-replica-as-acl-validation.md
+++ b/docs/measurements/2026-08-07-replica-as-acl-validation.md
@@ -163,7 +163,10 @@ content silently stays 404.
 New B2 accounts cannot create or convert a public bucket until they have **completed payment
 history** — a card on file is not sufficient, and the error is `no_payment_history`. This blocked
 the B2 origin test until a payment was made. Worth knowing before planning around B2, since a
-private bucket cannot back a pull zone (B2 download authorization tokens expire).
+private bucket cannot back a pull zone *over B2's native download path* — `b2_authorize_account`
+download tokens expire, so they cannot be pinned into a pull-zone config. That does not rule out the
+S3-compatible endpoint with AWS signing, which is the route the origin decision selects and which
+remains unproven rather than excluded.
 
 ## Teardown
 

--- a/docs/measurements/2026-08-07-replica-as-acl-validation.md
+++ b/docs/measurements/2026-08-07-replica-as-acl-validation.md
@@ -48,7 +48,7 @@ cannot be eventually-consistent-wrong.
 
 ## Also validated on a Backblaze B2 origin
 
-The same test was repeated with the full production-shaped topology —
+The same test was repeated with the production-shaped topology —
 **GCS (authoritative) → B2 (approved-only replica) → bunny Volume → viewer** — using public bucket
 `divine-delivery-probe` as the pull-zone origin. Identical result:
 
@@ -163,8 +163,9 @@ content silently stays 404.
 New B2 accounts cannot create or convert a public bucket until they have **completed payment
 history** — a card on file is not sufficient, and the error is `no_payment_history`. This blocked
 the B2 origin test until a payment was made. Worth knowing before planning around B2, since a
-private bucket cannot back a pull zone *over B2's native download path* — `b2_authorize_account`
-download tokens expire, so they cannot be pinned into a pull-zone config. That does not rule out the
+private bucket cannot back a pull zone *over B2's native download path* — the download authorization
+from `b2_get_download_authorization`, like the account token from `b2_authorize_account`, is
+time-limited, so neither can be pinned into a pull-zone config. That does not rule out the
 S3-compatible endpoint with AWS signing, which is the route the origin decision selects and which
 remains unproven rather than excluded.
 

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -104,7 +104,14 @@ replicated, and later banned or deleted.
 
 After a blob is approved and public, explicitly copy it to B2 from the existing pipeline. Verify
 length and SHA-256. Record which providers hold it as one field on the existing metadata record.
-Do not block publication on the copy.
+
+Publication does not wait for the copy, but **steering does**. Set the replicated flag only after
+the copy verifies, and route a hash to bunny only once that flag is set. Reversing this order 404s
+freshly-approved content for its first viewers. The implementation contract for that ordering — the
+queued job, the flag, and the reconciler that asserts replica presence for `Active` hashes and
+absence for everything else — is the bunny rollout plan
+(`2026-08-07-bunny-delivery-rollout-plan.md`); this document selects the origin and does not restate
+or override it.
 
 Do not configure a pull-through or automatic rehydration path from preserved GCS objects into B2. A
 deleted replica must not be silently recreated after a moderation action. The writer gets a
@@ -112,8 +119,9 @@ bucket-scoped credential with the explicit upload and version-delete capabilitie
 gets a separate bucket-scoped read-only credential. Neither credential belongs in source control or
 client-visible configuration.
 
-No queue, no reconciler, no replication framework, no BUD-04 `PUT /mirror` path. A periodic repair
-command covers gaps until measurement shows it does not.
+No generic replication framework and no BUD-04 `PUT /mirror` path. The queue is the existing
+derivative-status queue and the reconciler is a periodic repair pass over one flag — reuse, not new
+machinery.
 
 Recheck policy immediately before copying. A delayed job must never publish a hash that has since
 been tombstoned or restricted.

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -4,7 +4,7 @@
 # Blossom Multi-Provider Delivery Plan
 
 **Date:** 2026-08-07 (rewritten to cut scope)
-**Status:** Draft — one decision blocks the rest
+**Status:** Decision recorded — use Backblaze B2 as the second-CDN origin; pilot remains unapproved
 **Scope:** Public read path only. Not authorization to deploy.
 **Related:** `../specs/2026-08-06-cdn-delivery-steering-design.md`,
 `../specs/2026-08-06-media-delivery-cost-architecture-review.md`
@@ -34,27 +34,43 @@ the whole pilot. Everything else in the earlier draft is deferred at the bottom 
   Stream is out of scope. If a proposal starts moving processing back to a CDN vendor, it has
   stopped being this plan.
 
-## The decision that blocks everything else
+## Origin decision — private Backblaze B2
 
-The second CDN needs an origin it can read at delivery rate. Fastly Object Storage's *public* S3
-endpoint is documented at "~150Mbps and limited to a total of 100 requests per second"
-([Fastly product docs](https://docs.fastly.com/products/object-storage)) — about 1.6 TB/day, against
-a ~37 TB/day origin read requirement at 1M DAU. Reads from inside Fastly's network (Compute,
-Deliver) are exempt, so this does not affect the sibling FOS-behind-Fastly plan. It only bites when
-a *non-Fastly* CDN reads the bucket.
+**Use a private Backblaze B2 bucket as the approved-only replica origin for bunny.** GCS remains
+Divine's private authoritative store. Fastly Object Storage remains a separate, Fastly-only delivery
+mirror. Do not put a non-Fastly CDN in front of FOS unless Fastly quotes and contractually supports
+the required public-endpoint capacity.
 
-The same docs say "If your needs exceed these limits, reach out to sales@fastly.com," so this is a
-commercial question, not a hard ceiling — but **a raise nobody has quoted is not a capacity plan.**
-Until Fastly gives a sustained number in writing (cost review open question 16), assume FOS cannot
-be the second CDN's origin. Two workable shapes:
+Why B2 instead of letting bunny read GCS directly:
 
-- **(a)** second CDN reads GCS directly — works today, but GCS egress returns on every cache miss;
-- **(b)** R2 as the replica origin, $0 egress to any consumer — what the cost review recommends
-  first (§8.1 step 5).
+- Backblaze lists bunny as a partner CDN with unlimited free egress and prices B2 at $6.95/TB-month
+  with free Class A/B/C transactions
+  ([B2 pricing](https://www.backblaze.com/cloud-storage/pricing)). GCS charges network egress on
+  every bunny cache miss, which preserves the cost line this pilot exists to remove.
+- B2 has a private S3-compatible endpoint and bucket-scoped application keys. bunny pull zones
+  expose AWS signing configuration
+  (`AWSSigningEnabled`, key, secret, and region) in the
+  [pull-zone API](https://docs.bunny.net/api-reference/core/pull-zone/add-pull-zone), so the pilot
+  can keep the replica private. Prove the B2 region, endpoint, host/path style, and range behavior
+  against a real pull zone before traffic.
+- B2 is always versioned. An S3 `DeleteObject` or `b2_hide_file` can leave older bytes retrievable;
+  takedown must enumerate and permanently delete every file version
+  ([B2 file versions](https://www.backblaze.com/docs/cloud-storage-file-versions)).
+- B2 is a disposable replica. Its availability does not replace GCS durability because rollout can
+  be set to zero and Fastly/GCS remains the authoritative path.
 
-Pick one before building anything. The earlier "Bunny primary + Fastly Object Storage standby"
-shape is not buildable as written: it names FOS as the standby origin *and* assumes a second CDN in
-front of it.
+The initial GCS-to-B2 copy incurs one-time GCS egress; measure that separately from steady-state
+delivery cost. Confirm on the production billing account that bunny-origin reads receive the
+advertised partner-CDN egress treatment before ramping traffic.
+
+GCS remains acceptable only as a short-lived non-production diagnostic origin if needed to test
+bunny's AWS-signing compatibility. It is not the production choice. The earlier "Bunny primary +
+Fastly Object Storage standby" shape conflated two independent mirrors; the settled topology is:
+
+```text
+GCS private authority -> FOS private mirror -> Fastly
+                      +-> B2 approved-only mirror -> bunny
+```
 
 ## The scope rule that removes most of the work
 
@@ -67,16 +83,22 @@ That single rule deletes, from the earlier draft:
 - the playback-authorization API and short-lived signed CDN URLs;
 - separate public and protected zones per provider;
 - provider-side age and geography enforcement;
-- most of the takedown sequence — a restricted hash was never on the second provider to begin with.
 
 If restricted content ever needs multi-provider delivery, that is a separate plan with its own
-justification.
+justification. This rule does **not** remove the takedown obligation for content that was Active,
+replicated, and later banned or deleted.
 
 ## Replication
 
-After a blob is approved and public, best-effort copy it to the second provider from the existing
-pipeline. Verify length and SHA-256. Record which providers hold it as one field on the existing
-metadata record. Do not block publication on the copy.
+After a blob is approved and public, explicitly copy it to B2 from the existing pipeline. Verify
+length and SHA-256. Record which providers hold it as one field on the existing metadata record.
+Do not block publication on the copy.
+
+Do not configure a pull-through or automatic rehydration path from preserved GCS objects into B2. A
+deleted replica must not be silently recreated after a moderation action. The writer gets a
+bucket-scoped credential with the explicit upload and version-delete capabilities it needs; bunny
+gets a separate bucket-scoped read-only credential. Neither credential belongs in source control or
+client-visible configuration.
 
 No queue, no reconciler, no replication framework, no BUD-04 `PUT /mirror` path. A periodic repair
 command covers gaps until measurement shows it does not.
@@ -87,37 +109,55 @@ been tombstoned or restricted.
 ## Steering
 
 Server-side only, per the steering design: a `select_delivery_host()` call at the descriptor seam.
-Ineligible content never gets the second host. The percentage lives in the config store; rollback is
-setting it to 0. No mobile or web client change.
+Ineligible content never gets the second host. The percentage lives in the config store. Setting it
+to 0 stops issuing new bunny URLs without a deploy.
+
+That is **roll-forward control, not request-level failover**. A client that already holds a bunny
+URL continues using it until it refreshes the descriptor. The pilot must measure and bound that URL
+lifetime. Automatic retry from bunny to Fastly requires a client-visible fallback URL or a separate
+provider failover mechanism and is deferred; this plan must not claim it already exists.
 
 For HLS, the manifest and its segments come from one host for a given playback session. Do not
 alternate providers per segment.
 
 ## Takedown
 
-The existing flow is unchanged — tombstone, status update, surrogate-key purge. Add two steps:
+Eligibility prevents never-approved content from reaching B2, but it cannot revoke a bunny URL
+already issued to a client. The cache purge and replica delete are therefore load-bearing for
+takedown correctness.
 
-1. purge the second provider's cache for that hash;
-2. delete the replica.
+Run one idempotent, retryable takedown job in this order:
 
-Both retry. Neither is load-bearing for correctness: eligibility is checked at steering time, so a
-tombstoned hash stops being steered to the second provider immediately, whether or not the replica
-delete has landed. Alert if a replica delete stays unconfirmed.
+1. commit the tombstone/status change so no new bunny URLs are issued;
+2. list every B2 file version belonging to the hash (root, extension-suffixed objects, and
+   hash-prefixed derivatives) and call `b2_delete_file_version` for each version and hide marker;
+3. purge the hash from every bunny delivery zone;
+4. purge the Fastly surrogate key;
+5. verify representative URLs deny on both providers and `b2_list_file_versions` returns zero
+   matching versions.
+
+Do not report takedown completion until deletion and every cache purge are confirmed. Retry and alert
+on partial completion. If the required legal SLA is shorter than this fan-out can guarantee, add an
+edge deny-list before increasing rollout; descriptor steering alone is insufficient.
 
 ## Pilot
 
 20–100 representative approved public objects.
 
-1. Non-production bucket/zone and credentials at the second provider.
+1. Private non-production B2 bucket, separate scoped writer and read-only origin
+   credentials, and a bunny pull zone with AWS signing enabled.
 2. Copy and verify the sample objects.
 3. Steer an explicit test-hash allowlist, then 1% of eligible public traffic.
 4. Measure against Fastly on the same content: startup latency, rebuffering, cache hit rate, miss
    latency, origin bytes, billed units.
-5. Exercise 404, 5xx, and timeout fallback to the existing path.
+5. Exercise B2 404, 5xx, and timeout behavior. Verify that setting rollout to 0 stops new bunny
+   descriptors, and measure how long already-issued URLs remain in use. Do not label this automatic
+   failover.
 6. Tombstone one test hash; confirm it is unreachable on both paths.
 7. Decide.
 
-Rollback at every step is setting the steering percentage to 0.
+Rollback at every step begins by setting the steering percentage to 0. Existing bunny URLs remain
+valid until descriptor refresh or explicit purge, so rollback verification must include both.
 
 ## Go/no-go
 
@@ -125,6 +165,9 @@ Rollback at every step is setting the steering percentage to 0.
 - no playback regression in the top regions (cost review §1, GA4 geography);
 - measured cost per delivered GB beats Fastly's rate on the same content;
 - tombstone honored on both paths;
+- B2 remains private and bunny origin authentication works without public bucket access;
+- partner-CDN egress is confirmed in actual B2 billing;
+- the measured descriptor-refresh window is acceptable for operational rollback;
 - a vendor quote covering campaign peak, in writing.
 
 Do not restate cost projections here. The scaling tables live in the cost review (§4).
@@ -133,9 +176,9 @@ Do not restate cost projections here. The scaling tables live in the cost review
 
 Each of these needs its own justification. None belong in the pilot.
 
-- **Client-side BUD-03 fallback and kind `10063` publication.** Server-side steering already gives
-  provider choice with no app release. Client fallback only earns its cost against a *total* Fastly
-  outage — decide separately, after the pilot shows the second provider works at all.
+- **Client-side BUD-03 fallback and kind `10063` publication.** Server-side steering chooses a
+  provider but does not retry a failed request on another provider. Decide separately after the
+  pilot whether automatic per-request failover earns the client complexity.
 - Protected and age-gated content on the second provider (see the scope rule).
 - Durable replication queue, readiness reconciliation, dashboards.
 - A generic replication abstraction. Provider APIs called directly are fine for one provider.
@@ -146,7 +189,8 @@ Each of these needs its own justification. None belong in the pilot.
 
 ## Open questions
 
-1. **Which origin does the second CDN read — GCS or R2?** Blocks everything.
+1. Does bunny's AWS-signing mode interoperate with the private B2 S3 endpoint, range requests, and
+   the required region and host/path style?
 2. Will Fastly quote a sustained public-endpoint throughput above ~150 Mbps for a non-Fastly CDN?
    A "yes" with a number reopens FOS as the replica origin; silence means assume no.
 3. Does the current derivative and HLS layout copy cleanly to another provider?

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -179,8 +179,8 @@ edge deny-list before increasing rollout; descriptor steering alone is insuffici
 4. Measure against Fastly on the same content: startup latency, rebuffering, cache hit rate, miss
    latency, origin bytes, billed units.
 5. Exercise B2 404, 5xx, and timeout behavior. Verify that setting rollout to 0 stops new bunny
-   descriptors, and measure how long already-issued URLs remain in use. Do not label this automatic
-   failover.
+   descriptors, measure how long already-issued URLs remain in use, and exercise the DNS move that
+   retires them. Do not label either one automatic failover.
 6. Tombstone one test hash; confirm it is unreachable on both paths.
 7. Decide.
 
@@ -191,7 +191,7 @@ verification must exercise both levers — the config flip and the hostname move
 ## Go/no-go
 
 - byte-identical content and correct range behavior from the second provider;
-- no playback regression in the top regions (cost review §1, GA4 geography);
+- no playback regression in the top regions (cost review §2, GA4 geographic distribution);
 - measured cost per delivered GB beats Fastly's rate on the same content;
 - tombstone honored on both paths;
 - B2 remains private and bunny origin authentication works without public bucket access;

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -56,7 +56,12 @@ Why B2 instead of letting bunny read GCS directly:
   (`AWSSigningEnabled`, key, secret, and region) in the
   [pull-zone API](https://docs.bunny.net/api-reference/core/pull-zone/add-pull-zone), so the pilot
   can keep the replica private. Prove the B2 region, endpoint, host/path style, and range behavior
-  against a real pull zone before traffic.
+  against a real pull zone before traffic. The browser-visible behavior was validated on a *public*
+  probe bucket, so a private signed origin has to re-prove it: an explicit CORS rule covering range
+  and conditional headers and exposing `content-range` / `accept-ranges`; `Content-Type` carried
+  from the source, because an `application/octet-stream` default makes `<track>` subtitles fail
+  silently while video still plays; and cache-control set at upload so Fastly and bunny do not
+  disagree on TTL for the same object. The rollout plan has the specifics.
 - B2 is always versioned. An S3 `DeleteObject` or `b2_hide_file` can leave older bytes retrievable;
   takedown must enumerate and permanently delete every file version
   ([B2 file versions](https://www.backblaze.com/docs/cloud-storage-file-versions)).

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -44,10 +44,13 @@ the required public-endpoint capacity.
 
 Why B2 instead of letting bunny read GCS directly:
 
-- Backblaze lists bunny as a partner CDN with unlimited free egress and prices B2 at $6.95/TB-month
-  with free Class A/B/C transactions
-  ([B2 pricing](https://www.backblaze.com/cloud-storage/pricing)). GCS charges network egress on
-  every bunny cache miss, which preserves the cost line this pilot exists to remove.
+- B2 is $6.95/TB-month with free Class A/B/C transactions
+  ([B2 pricing](https://www.backblaze.com/cloud-storage/pricing)), and Backblaze *claims* unlimited
+  free egress through partner CDNs including bunny
+  ([CDN partners](https://www.backblaze.com/cloud-storage/solutions/cdn)). Treat the partner-CDN
+  rate as **unverified**: the vendor notes tag it `[U]` and the mechanism is undocumented. The
+  downside case if it does not apply is $0.01/GB above the 3× storage allowance, which is still
+  below GCS network egress on every bunny cache miss — the cost line this pilot exists to remove.
 - B2 has a private S3-compatible endpoint and bucket-scoped application keys. bunny pull zones
   expose AWS signing configuration
   (`AWSSigningEnabled`, key, secret, and region) in the
@@ -59,6 +62,14 @@ Why B2 instead of letting bunny read GCS directly:
   ([B2 file versions](https://www.backblaze.com/docs/cloud-storage-file-versions)).
 - B2 is a disposable replica. Its availability does not replace GCS durability because rollout can
   be set to zero and Fastly/GCS remains the authoritative path.
+
+Why B2 and not R2, which the cost review ranks first (§8.1 step 5): on paper R2's $0 egress to any
+consumer is the stronger position, and that ranking still stands on cost alone. B2 wins on evidence.
+It has been stood up and drilled end-to-end as a real bunny pull-zone origin — delivery latency
+within 6% of the alternatives, and the takedown semantics measured live — while R2 has no bucket and
+no token (`../../cdn-evaluation-status.md`). Choosing the measured option for a pilot whose whole
+purpose is measurement is the cheaper mistake to unwind: this is a disposable replica, and if
+partner-CDN egress does not materialise on the billing account, R2 is the first fallback to test.
 
 The initial GCS-to-B2 copy incurs one-time GCS egress; measure that separately from steady-state
 delivery cost. Confirm on the production billing account that bunny-origin reads receive the

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -83,7 +83,7 @@ That single rule deletes, from the earlier draft:
 
 - the playback-authorization API and short-lived signed CDN URLs;
 - separate public and protected zones per provider;
-- provider-side age and geography enforcement;
+- provider-side age and geography enforcement.
 
 If restricted content ever needs multi-provider delivery, that is a separate plan with its own
 justification. This rule does **not** remove the takedown obligation for content that was Active,

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -119,9 +119,10 @@ bucket-scoped credential with the explicit upload and version-delete capabilitie
 gets a separate bucket-scoped read-only credential. Neither credential belongs in source control or
 client-visible configuration.
 
-No generic replication framework and no BUD-04 `PUT /mirror` path. The queue is the existing
-derivative-status queue and the reconciler is a periodic repair pass over one flag — reuse, not new
-machinery.
+No generic replication framework and no BUD-04 `PUT /mirror` path. Enqueue on Cloud Tasks, following
+the pattern of the existing derivative-status queue rather than sharing that queue — its serialized
+dispatch is part of a generation-ordering contract replication has no generation for. The reconciler
+is a periodic repair pass over one flag, not new machinery.
 
 Recheck policy immediately before copying. A delayed job must never publish a hash that has since
 been tombstoned or restricted.
@@ -173,7 +174,8 @@ edge deny-list before increasing rollout; descriptor steering alone is insuffici
 20–100 representative approved public objects.
 
 1. Private non-production B2 bucket, separate scoped writer and read-only origin
-   credentials, and a bunny pull zone with AWS signing enabled.
+   credentials, a bunny pull zone with AWS signing enabled, and a Divine-owned delivery hostname
+   with a short TTL on that zone — step 5 cannot exercise the DNS move without it.
 2. Copy and verify the sample objects.
 3. Steer an explicit test-hash allowlist, then 1% of eligible public traffic.
 4. Measure against Fastly on the same content: startup latency, rebuffering, cache hit rate, miss
@@ -209,7 +211,8 @@ Each of these needs its own justification. None belong in the pilot.
   provider but does not retry a failed request on another provider. Decide separately after the
   pilot whether automatic per-request failover earns the client complexity.
 - Protected and age-gated content on the second provider (see the scope rule).
-- Durable replication queue, readiness reconciliation, dashboards.
+- Replication dashboards. The readiness flag and its repair pass are not deferred — steering
+  correctness depends on them.
 - A generic replication abstraction. Provider APIs called directly are fine for one provider.
 - A third provider, or geographic steering.
 - `backup.media.divine.video` as a separate published hostname. `media.divine.video` stays the

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -6,8 +6,9 @@
 **Date:** 2026-08-07 (rewritten to cut scope)
 **Status:** Decision recorded — use Backblaze B2 as the second-CDN origin; pilot remains unapproved
 **Scope:** Public read path only. Not authorization to deploy.
-**Related:** `../specs/2026-08-06-cdn-delivery-steering-design.md`,
-`../specs/2026-08-06-media-delivery-cost-architecture-review.md`
+**Related:** `../specs/2026-08-06-cdn-delivery-steering-design.md`. The cost review this document
+cites by section is commercial analysis and is deliberately not in this public repository; it lives
+in `divine-context` under `repo-context/divine-blossom-media-delivery-cost-review-2026-08.md`.
 
 ## The question this answers
 

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -132,10 +132,18 @@ Server-side only, per the steering design: a `select_delivery_host()` call at th
 Ineligible content never gets the second host. The percentage lives in the config store. Setting it
 to 0 stops issuing new bunny URLs without a deploy.
 
-That is **roll-forward control, not request-level failover**. A client that already holds a bunny
-URL continues using it until it refreshes the descriptor. The pilot must measure and bound that URL
-lifetime. Automatic retry from bunny to Fastly requires a client-visible fallback URL or a separate
-provider failover mechanism and is deferred; this plan must not claim it already exists.
+That is **roll-forward control, not request-level failover**. A client that already holds a
+second-provider URL continues using it until it refreshes the descriptor. The pilot must measure and
+bound that URL lifetime.
+
+The retroactive lever is DNS, and it only exists if the delivery URLs are on a Divine-owned
+hostname. Descriptors must therefore never emit a vendor hostname, per the rollout plan's stage 0a
+(`v.divine.video` as a custom hostname on the delivery zone). Repointing that record moves
+already-published URLs back to Fastly; a cache purge does not, because purging only forces bunny to
+refetch from B2 and it keeps serving.
+
+Automatic retry from bunny to Fastly requires a client-visible fallback URL or a separate provider
+failover mechanism and is deferred; this plan must not claim it already exists.
 
 For HLS, the manifest and its segments come from one host for a given playback session. Do not
 alternate providers per segment.
@@ -176,8 +184,9 @@ edge deny-list before increasing rollout; descriptor steering alone is insuffici
 6. Tombstone one test hash; confirm it is unreachable on both paths.
 7. Decide.
 
-Rollback at every step begins by setting the steering percentage to 0. Existing bunny URLs remain
-valid until descriptor refresh or explicit purge, so rollback verification must include both.
+Rollback at every step begins by setting the steering percentage to 0, which stops new descriptors.
+Already-published URLs keep resolving to bunny until they are repointed by DNS, so rollback
+verification must exercise both levers — the config flip and the hostname move.
 
 ## Go/no-go
 

--- a/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
+++ b/docs/superpowers/plans/2026-08-07-blossom-multi-provider-delivery-policy.md
@@ -61,7 +61,10 @@ Why B2 instead of letting bunny read GCS directly:
   and conditional headers and exposing `content-range` / `accept-ranges`; `Content-Type` carried
   from the source, because an `application/octet-stream` default makes `<track>` subtitles fail
   silently while video still plays; and cache-control set at upload so Fastly and bunny do not
-  disagree on TTL for the same object. The rollout plan has the specifics.
+  disagree on TTL for the same object. The rollout plan has the specifics, but its CORS rule was
+  written against B2's native download operations, and a B2 CORS rule applies only to the operations
+  it lists. Derive and record the S3-endpoint equivalent as part of the pilot rather than copying
+  that rule — signing can prove out while browser range and VTT requests still fail CORS.
 - B2 is always versioned. An S3 `DeleteObject` or `b2_hide_file` can leave older bytes retrievable;
   takedown must enumerate and permanently delete every file version
   ([B2 file versions](https://www.backblaze.com/docs/cloud-storage-file-versions)).

--- a/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
+++ b/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
@@ -89,11 +89,14 @@ Do not mix strategies within one experiment; the results stop being interpretabl
 ### Rollback
 
 `bunny_traffic_pct` lives in a Fastly Config Store, so changing it takes effect without a deploy.
-`0` is a full rollback. This is the primary safety mechanism and must be tested before the first
-non-zero rollout.
+`0` stops new descriptors being issued with the second host, and must be tested before the first
+non-zero rollout. It is roll-forward control, not a retroactive rollback: a client already holding a
+second-provider URL keeps using it until it refreshes the descriptor, so rollback verification has to
+cover that window too.
 
-Secondary lever: DNS weighting on the delivery hostname. Coarse and TTL-bound, but independent of
-Compute, so it still works if Compute is the thing that is broken.
+The retroactive lever is DNS on the delivery hostname — it moves already-published URLs back to
+Fastly. Coarse and TTL-bound, but independent of Compute, so it still works if Compute is the thing
+that is broken.
 
 ### Eligibility — the replica is the access control
 

--- a/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
+++ b/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
@@ -31,13 +31,14 @@ and any change to how the app fetches or plays video.
 
 | Origin | Viable? | Note |
 |---|---|---|
-| Cloudflare R2 | Yes | $0 egress to any consumer via S3 API |
-| Backblaze B2 | Yes | $0 via partner-CDN program (unverified) or $0.01/GB over the 3× allowance |
+| **Backblaze B2** | **Selected** | $0 via partner-CDN program (unverified) or $0.01/GB over the 3× allowance |
+| Cloudflare R2 | Yes — fallback | $0 egress to any consumer via S3 API; not stood up |
 | GCS | Works | but GCS egress returns on bunny's cache misses |
 | **Fastly Object Storage** | **No** | **public S3 endpoint capped at ~150 Mbps / 100 req/s per bucket** |
 
-This is the decision that has to be made first. Adopting Fastly Object Storage as the delivery
-replica forecloses this entire design.
+This decision is recorded in the multi-provider delivery plan: B2, private, approved-only. R2 is the
+first fallback if partner-CDN egress does not appear on the billing account. Adopting Fastly Object
+Storage as the delivery replica would foreclose this entire design.
 
 ## Recommended approach
 

--- a/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
+++ b/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
@@ -54,6 +54,10 @@ fn select_delivery_host(req: &Request, meta: &BlobMetadata) -> &'static str {
     if !is_publicly_cacheable(meta) {
         return FASTLY_HOST;
     }
+    // Not yet copied and verified into the replica: bunny would 404 it.
+    if !meta.replicated {
+        return FASTLY_HOST;
+    }
     let pct: u32 = config_store_get("bunny_traffic_pct").unwrap_or(0);
     if bucket_of(&meta.sha256) < pct { BUNNY_HOST } else { FASTLY_HOST }
 }
@@ -103,9 +107,14 @@ broken.
 
 ### Eligibility — the replica is the access control
 
-Only `Active`, public, non-restricted blobs are steerable. Everything else — `Pending`,
-`Restricted`, `AgeRestricted`, admin bypass, tombstoned, legal hold — stays on the Fastly Compute
-path.
+Only `Active`, public, non-restricted blobs are steerable, **and only once the replica copy has been
+verified**. Everything else — `Pending`, `Restricted`, `AgeRestricted`, admin bypass, tombstoned,
+legal hold — stays on the Fastly Compute path.
+
+Eligibility and readiness are separate conditions and both are required. Absence from the replica
+denies restricted content, which is the access-control property below; but an approved blob that has
+not finished copying is also absent, and steering it would 404 the newest content at its worst
+moment. Route on the verified flag, not on approval alone.
 
 **Enforce this by replication policy, not by logic at the second CDN.** Replicate to the delivery
 store only on moderation-approval, never on upload. A gated blob is then simply not in the replica:

--- a/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
+++ b/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
@@ -11,7 +11,9 @@
 ## Goal
 
 Be able to serve a controllable fraction of media bytes from a second CDN (bunny.net) instead of
-Fastly, compare the two on real traffic, and roll back instantly — without any client change.
+Fastly, compare the two on real traffic, and roll back without a deploy or any client change. See
+Rollback below for what "roll back" reaches: a config flip stops new descriptors, and DNS on the
+delivery hostname is what moves already-published URLs.
 
 ## Scope
 
@@ -95,8 +97,9 @@ second-provider URL keeps using it until it refreshes the descriptor, so rollbac
 cover that window too.
 
 The retroactive lever is DNS on the delivery hostname — it moves already-published URLs back to
-Fastly. Coarse and TTL-bound, but independent of Compute, so it still works if Compute is the thing
-that is broken.
+Fastly. This works only while descriptors emit a Divine-owned hostname rather than a vendor one.
+Coarse and TTL-bound, but independent of Compute, so it still works if Compute is the thing that is
+broken.
 
 ### Eligibility — the replica is the access control
 

--- a/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
+++ b/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
@@ -72,7 +72,9 @@ fn bucket_of(sha256: &str) -> u32 {
 }
 ```
 
-`is_publicly_cacheable` is a proposed helper, not an existing `BlobMetadata` method.
+`is_publicly_cacheable` is a proposed helper, not an existing `BlobMetadata` method, and
+`meta.replicated` is a proposed field, not one that exists today. The bunny rollout plan describes
+where replication sets it.
 
 Why here: it is one function, it already governs every URL handed out, and the decision has full
 context available — moderation status, client geo, content type.

--- a/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
+++ b/docs/superpowers/specs/2026-08-06-cdn-delivery-steering-design.md
@@ -247,8 +247,8 @@ cost.
 
 ## Open questions
 
-- Does bunny's pull-zone origin authentication work against R2 and B2 signed access, or does it
-  require public bucket reads?
+- Does bunny's AWS-signing mode work against the private B2 S3 endpoint, or does it require public
+  bucket reads? R2 remains untested fallback.
 - What is bunny's purge API latency and rate limit, and is it sufficient for a takedown SLA?
 - Does splitting traffic across two CDNs degrade either one's cache hit ratio enough to matter at
   low percentages? (Hash bucketing should prevent this; verify rather than assume.)


### PR DESCRIPTION
## Summary

- select a private Backblaze B2 bucket as the approved-only origin for the second CDN
- keep GCS authoritative and Fastly Object Storage scoped to the Fastly delivery path
- require permanent deletion of every B2 file version plus cache purges for takedowns
- record why B2 was chosen over R2, and mark the partner-CDN egress rate unverified with its downside case
- steer a hash to the second CDN only after its replica copy verifies, so freshly approved content is not steered before it exists
- name DNS on a Divine-owned delivery hostname as the retroactive rollback lever; setting rollout to zero stops new URLs but does not retire issued ones, and it is not automatic request failover

The adjacent docs are updated in the same change so the repo gives one answer: the steering design's selector, eligibility rule, origin table, and rollback section; the vendor notes' open question, narrowed to bunny's AWS-signing path to a private bucket; the status entry point, which now indexes this decision; and the ACL validation record, which no longer reads as ruling out a private origin.

The pilot must re-prove the browser-visible behavior — CORS for range and subtitle reads, `Content-Type` carry-through, cache-control alignment — because the validated probe bucket was public.

## Motivation

Resolve the origin decision that blocked the multi-provider pilot while preserving the moderation boundary and the deletion behavior proven by the existing takedown drill.

## Linked issue

Related to #177. Closes no issue.

## Manual validation

- `git diff --check origin/main...HEAD`
- compared the plan against the existing B2 takedown drill, the vendor capability notes, and the bunny rollout plan on main
- `cargo check --tests --locked`, `cargo test -p blossom-core --locked`, the upload and transcoder suites, and `cargo clippy --locked --all-targets --all-features`
- the declared Python suites: 23 tests in `cloud-run-transcoder`, 71 in `scripts/tests`
- documentation only; no runtime or visual change
