### PR TITLE
docs(runbooks): document rollback traffic pinning and exported-env trap

### DIFF
--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -68,14 +68,24 @@ GCP_PROJECT_ID=rich-compiler-479518-d2 ./scripts/deploy-cloud-function.sh
 Only `cloud-run-transcoder/deploy.sh` currently uses `--update-env-vars` and
 `--update-secrets`, so unnamed keys are preserved for transcoder deploys. Keys it
 *does* name are overwritten with the script's defaults, which may not match what
-is running. Compare before you deploy, and read names rather than values:
+is running. Compare against the revision serving traffic, not the service's
+`spec.template`, and read names rather than values:
 
 ```bash
-gcloud run services describe divine-transcoder \
+REVISION="$(gcloud run services describe divine-transcoder \
   --project rich-compiler-479518-d2 --region us-central1 --format=json \
   | python3 -c "
 import json,sys
-c=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]
+traffic=json.load(sys.stdin).get('status',{}).get('traffic',[])
+serving=[t for t in traffic if t.get('percent')]
+print(max(serving,key=lambda t:t['percent']).get('revisionName','') if serving else '')
+")"
+
+gcloud run revisions describe "$REVISION" \
+  --project rich-compiler-479518-d2 --region us-central1 --format=json \
+  | python3 -c "
+import json,sys
+c=json.load(sys.stdin)['spec']['containers'][0]
 print('image:', c['image'])
 print('env:', sorted(e['name'] for e in c.get('env',[]) if 'value' in e))
 print('secrets:', sorted(e['name'] for e in c.get('env',[]) if 'valueFrom' in e))
@@ -109,13 +119,16 @@ half hours.
 Do not export deploy-time variables (`GCS_BUCKET`, `PROJECT_ID`, and friends)
 from a shell profile. Set them inline on the one command that needs them.
 
-As a backstop, the transcoder and upload deploy scripts run
+After #195 merges, the transcoder and upload deploy scripts will run
 `scripts/require-env-match.sh` after resolving their variables and before
-building anything. It compares the fully resolved values against the revision
-currently serving traffic and aborts the deploy when they differ; re-run with
-`CONFIRM_ENV_CHANGES=1` when the change is intended. The comparison has to use
-resolved values: a check that parses the default out of the script text cannot
-catch this failure mode, because the whole failure is the default not applying.
+building anything. It compares a named subset of fully resolved values against
+the revision currently serving traffic and aborts the deploy when they differ;
+re-run with `CONFIRM_ENV_CHANGES=1` when the change is intended. The check is a
+backstop, not a substitute for passing `PROJECT_ID` explicitly: it uses the
+resolved project to find the live service, and it skips when the service or
+serving revision cannot be read. The comparison has to use resolved values: a
+check that parses the default out of the script text cannot catch this failure
+mode, because the whole failure is the default not applying.
 
 ## Staged rollout when the edge and a backend change together
 
@@ -133,12 +146,23 @@ be `false` while the transcoder is still an image that does not send
 ## Verifying a transcoder deploy landed
 
 The transcoder does not report its version anywhere the edge can see. Confirm
-from the Cloud Run side that the image tag matches the commit you deployed:
+from the Cloud Run side that the image tag on the revision serving traffic
+matches the commit you deployed:
 
 ```bash
-gcloud run services describe divine-transcoder \
+REVISION="$(gcloud run services describe divine-transcoder \
+  --project rich-compiler-479518-d2 --region us-central1 --format=json \
+  | python3 -c "
+import json,sys
+traffic=json.load(sys.stdin).get('status',{}).get('traffic',[])
+serving=[t for t in traffic if t.get('percent')]
+print(max(serving,key=lambda t:t['percent']).get('revisionName','') if serving else '')
+")"
+
+printf 'serving revision: %s\n' "$REVISION"
+gcloud run revisions describe "$REVISION" \
   --project rich-compiler-479518-d2 --region us-central1 \
-  --format='value(spec.template.spec.containers[0].image)'
+  --format='value(spec.containers[0].image)'
 ```
 
 ## A traffic rollback pins the service
@@ -166,4 +190,4 @@ gcloud run services describe divine-transcoder \
 
 The same pinning is why the pre-deploy environment check compares against the
 serving revision rather than the service's `spec.template`: after a rollback,
-the template describes the revision that was just reverted.
+the spec still describes the newest rolled-back revision.

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -97,6 +97,26 @@ silently drop live settings the deploy path does not name. PR #153 fixed this
 for the transcoder script only; the other deploy paths still need the same
 treatment; see issue #171.
 
+## Exported shell variables override script defaults
+
+The deploy scripts resolve every setting as `VAR="${VAR:-production-default}"`,
+so an exported shell variable silently wins over the production default. On
+2026-08-07 a shell with `GCS_BUCKET=divine-blossom-media-staging` exported
+pointed the production transcoder at the staging bucket, where its service
+account has no read access; every transcode failed with 403 for four and a
+half hours.
+
+Do not export deploy-time variables (`GCS_BUCKET`, `PROJECT_ID`, and friends)
+from a shell profile. Set them inline on the one command that needs them.
+
+As a backstop, the transcoder and upload deploy scripts run
+`scripts/require-env-match.sh` after resolving their variables and before
+building anything. It compares the fully resolved values against the revision
+currently serving traffic and aborts the deploy when they differ; re-run with
+`CONFIRM_ENV_CHANGES=1` when the change is intended. The comparison has to use
+resolved values: a check that parses the default out of the script text cannot
+catch this failure mode, because the whole failure is the default not applying.
+
 ## Staged rollout when the edge and a backend change together
 
 The edge is already live by the time you start deploying the backend, so the
@@ -120,3 +140,30 @@ gcloud run services describe divine-transcoder \
   --project rich-compiler-479518-d2 --region us-central1 \
   --format='value(spec.template.spec.containers[0].image)'
 ```
+
+## A traffic rollback pins the service
+
+`gcloud run services update-traffic --to-revisions=<revision>=100` rolls back
+by pointing traffic at an explicit revision, and in doing so stops the service
+from migrating to the latest revision. A later `gcloud run deploy` then creates
+the new revision at 0% traffic while reporting success — the rollback target
+keeps serving.
+
+After any rollback, restore migration to latest explicitly:
+
+```bash
+gcloud run services update-traffic divine-transcoder \
+  --project rich-compiler-479518-d2 --region us-central1 --to-latest
+```
+
+Until that runs, check where traffic actually is after every deploy:
+
+```bash
+gcloud run services describe divine-transcoder \
+  --project rich-compiler-479518-d2 --region us-central1 \
+  --format='json(status.traffic)'
+```
+
+The same pinning is why the pre-deploy environment check compares against the
+serving revision rather than the service's `spec.template`: after a rollback,
+the template describes the revision that was just reverted.

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -119,16 +119,16 @@ half hours.
 Do not export deploy-time variables (`GCS_BUCKET`, `PROJECT_ID`, and friends)
 from a shell profile. Set them inline on the one command that needs them.
 
-After #195 merges, the transcoder and upload deploy scripts will run
-`scripts/require-env-match.sh` after resolving their variables and before
-building anything. It compares a named subset of fully resolved values against
-the revision currently serving traffic and aborts the deploy when they differ;
-re-run with `CONFIRM_ENV_CHANGES=1` when the change is intended. The check is a
-backstop, not a substitute for passing `PROJECT_ID` explicitly: it uses the
-resolved project to find the live service, and it skips when the service or
-serving revision cannot be read. The comparison has to use resolved values: a
-check that parses the default out of the script text cannot catch this failure
-mode, because the whole failure is the default not applying.
+Nothing in this repository checks a deploy's resolved variables against what is
+running, so there is no automated backstop for this trap today. The manual
+comparison in the section above is the only thing between an exported variable
+and a production misconfiguration. Run it.
+
+Whoever adds such a guard: it has to compare *fully resolved* values, it has to
+compare them against the revision currently serving traffic, and it has to run
+after the script resolves its variables and before it builds anything. A check
+that parses the defaults out of the script text cannot catch this failure mode,
+because the whole failure is the default not applying.
 
 ## Staged rollout when the edge and a backend change together
 

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -68,29 +68,30 @@ GCP_PROJECT_ID=rich-compiler-479518-d2 ./scripts/deploy-cloud-function.sh
 Only `cloud-run-transcoder/deploy.sh` currently uses `--update-env-vars` and
 `--update-secrets`, so unnamed keys are preserved for transcoder deploys. Keys it
 *does* name are overwritten with the script's defaults, which may not match what
-is running. Compare against the revision serving traffic, not the service's
-`spec.template`, and read names rather than values:
+is running.
+
+`gcloud run deploy` creates or updates the *service*, and `--update-env-vars`
+merges its pairs onto the service's `spec.template`. The template is therefore
+the baseline the next deploy merges onto, and it is what this check has to read.
+Read names rather than values:
 
 ```bash
-REVISION="$(gcloud run services describe divine-transcoder \
+gcloud run services describe divine-transcoder \
   --project rich-compiler-479518-d2 --region us-central1 --format=json \
   | python3 -c "
 import json,sys
-traffic=json.load(sys.stdin).get('status',{}).get('traffic',[])
-serving=[t for t in traffic if t.get('percent')]
-print(max(serving,key=lambda t:t['percent']).get('revisionName','') if serving else '')
-")"
-
-gcloud run revisions describe "$REVISION" \
-  --project rich-compiler-479518-d2 --region us-central1 --format=json \
-  | python3 -c "
-import json,sys
-c=json.load(sys.stdin)['spec']['containers'][0]
+c=json.load(sys.stdin)['spec']['template']['spec']['containers'][0]
 print('image:', c['image'])
 print('env:', sorted(e['name'] for e in c.get('env',[]) if 'value' in e))
 print('secrets:', sorted(e['name'] for e in c.get('env',[]) if 'valueFrom' in e))
 "
 ```
+
+The template is not necessarily what production is running: after a traffic
+rollback the two diverge. See [A traffic rollback pins the
+service](#a-traffic-rollback-pins-the-service) for that case, and read the
+serving revision when the question is what production is answering with rather
+than what the next deploy will merge onto.
 
 Do not assume that safety applies to the other deploy paths yet:
 
@@ -109,9 +110,13 @@ treatment; see issue #171.
 
 ## Exported shell variables override script defaults
 
-The deploy scripts resolve every setting as `VAR="${VAR:-production-default}"`,
-so an exported shell variable silently wins over the production default. On
-2026-08-07 a shell with `GCS_BUCKET=divine-blossom-media-staging` exported
+The three hand-run Cloud Run deploy scripts resolve most settings as
+`VAR="${VAR:-production-default}"`, so an exported shell variable silently wins
+over the production default. (`scripts/deploy-cloud-function.sh` is the exception
+noted above: it requires `GCP_PROJECT_ID`, and its bucket variable is
+`GCS_BUCKET_NAME`, not `GCS_BUCKET`.)
+
+On 2026-08-07 a shell with `GCS_BUCKET=divine-blossom-media-staging` exported
 pointed the production transcoder at the staging bucket, where its service
 account has no read access; every transcode failed with 403 for four and a
 half hours.
@@ -120,15 +125,28 @@ Do not export deploy-time variables (`GCS_BUCKET`, `PROJECT_ID`, and friends)
 from a shell profile. Set them inline on the one command that needs them.
 
 Nothing in this repository checks a deploy's resolved variables against what is
-running, so there is no automated backstop for this trap today. The manual
-comparison in the section above is the only thing between an exported variable
-and a production misconfiguration. Run it.
+running, so there is no automated backstop for this trap today. The
+configuration check above will not catch it either: that check deliberately
+reads names and not values, so a `GCS_BUCKET` aimed at the staging bucket looks
+identical to one aimed at production.
 
-Whoever adds such a guard: it has to compare *fully resolved* values, it has to
-compare them against the revision currently serving traffic, and it has to run
-after the script resolves its variables and before it builds anything. A check
-that parses the defaults out of the script text cannot catch this failure mode,
-because the whole failure is the default not applying.
+What does catch it is checking your own shell before you deploy. Test whether
+each deploy-time variable is exported at all, without printing any value:
+
+```bash
+for v in GCS_BUCKET PROJECT_ID GCP_PROJECT_ID REGION SERVICE_NAME IMAGE_TAG; do
+  printenv "$v" >/dev/null && echo "$v is exported — unset it, or pass it inline"
+done
+```
+
+Whoever adds an automated guard: it has to compare *fully resolved* values, and
+it has to run after the script resolves its variables and before it builds
+anything. A check that parses the defaults out of the script text cannot catch
+this failure mode, because the whole failure is the default not applying. Its
+comparison baseline is the revision currently serving traffic, not
+`spec.template` — the question such a guard asks is "am I about to change what
+production is running?", which is the serving revision's question, not the merge
+baseline's.
 
 ## Staged rollout when the edge and a backend change together
 
@@ -159,10 +177,14 @@ serving=[t for t in traffic if t.get('percent')]
 print(max(serving,key=lambda t:t['percent']).get('revisionName','') if serving else '')
 ")"
 
-printf 'serving revision: %s\n' "$REVISION"
-gcloud run revisions describe "$REVISION" \
-  --project rich-compiler-479518-d2 --region us-central1 \
-  --format='value(spec.containers[0].image)'
+if [ -z "$REVISION" ]; then
+  echo 'no revision is serving traffic'
+else
+  printf 'serving revision: %s\n' "$REVISION"
+  gcloud run revisions describe "$REVISION" \
+    --project rich-compiler-479518-d2 --region us-central1 \
+    --format='value(spec.containers[0].image)'
+fi
 ```
 
 ## A traffic rollback pins the service
@@ -188,6 +210,11 @@ gcloud run services describe divine-transcoder \
   --format='json(status.traffic)'
 ```
 
-The same pinning is why the pre-deploy environment check compares against the
-serving revision rather than the service's `spec.template`: after a rollback,
-the spec still describes the newest rolled-back revision.
+This pinning is also why the two checks above read different places. After a
+rollback, the service's `spec.template` describes the newest revision *created*,
+which is not the one serving traffic. The pre-deploy configuration check reads
+`spec.template`, because that is the baseline the next deploy merges onto. The
+deploy-landed check reads the serving revision, because that is what production
+is answering with. Do not substitute one for the other — during a pinned window
+they give different answers, and each is the wrong answer to the other's
+question.

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -130,23 +130,38 @@ configuration check above will not catch it either: that check deliberately
 reads names and not values, so a `GCS_BUCKET` aimed at the staging bucket looks
 identical to one aimed at production.
 
-What does catch it is checking your own shell before you deploy. Test whether
-each deploy-time variable is exported at all, without printing any value:
+What does catch it is checking your own shell before you deploy. Read the
+variable names straight out of the scripts so the list cannot drift, and test
+whether each one is exported without printing any value. Run this from the
+repository root:
 
 ```bash
-for v in GCS_BUCKET PROJECT_ID GCP_PROJECT_ID REGION SERVICE_NAME IMAGE_TAG; do
-  printenv "$v" >/dev/null && echo "$v is exported — unset it, or pass it inline"
+for script in cloud-run-transcoder/deploy.sh cloud-run-upload/deploy.sh \
+              cloud-run-asr-parakeet/deploy.sh; do
+  for v in $(sed -n 's/^\([A-Z_][A-Z0-9_]*\)="\${\1:-.*/\1/p' "$script"); do
+    printenv "$v" >/dev/null && echo "$v is exported — $script would use your value"
+  done
 done
 ```
 
+`GCS_BUCKET` is not the only variable that can bite this way. The transcoder
+script alone resolves 27 settings from the environment, and several have names
+generic enough to be sitting exported in a working shell for unrelated reasons —
+an exported `MAX_INSTANCES` or `CONCURRENCY` silently reshapes production
+capacity exactly the way the exported `GCS_BUCKET` silently redirected storage.
+Deriving the list is what keeps this check honest as the scripts grow.
+
 Whoever adds an automated guard: it has to compare *fully resolved* values, and
 it has to run after the script resolves its variables and before it builds
-anything. A check that parses the defaults out of the script text cannot catch
-this failure mode, because the whole failure is the default not applying. Its
-comparison baseline is the revision currently serving traffic, not
-`spec.template` — the question such a guard asks is "am I about to change what
-production is running?", which is the serving revision's question, not the merge
-baseline's.
+anything. A check that parses the *defaults* out of the script text cannot catch
+this failure mode, because the whole failure is the default not applying.
+(Reading variable *names* out of the script, as the shell check above does, is a
+different and safe operation: what it looks for lives in the operator's
+environment, not in the script's text.)
+
+Such a guard's comparison baseline is the revision currently serving traffic, not
+`spec.template` — the question it asks is "am I about to change what production
+is running?", which is the serving revision's question, not the merge baseline's.
 
 ## Staged rollout when the edge and a backend change together
 

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -112,9 +112,12 @@ treatment; see issue #171.
 
 The three hand-run Cloud Run deploy scripts resolve most settings as
 `VAR="${VAR:-production-default}"`, so an exported shell variable silently wins
-over the production default. (`scripts/deploy-cloud-function.sh` is the exception
-noted above: it requires `GCP_PROJECT_ID`, and its bucket variable is
-`GCS_BUCKET_NAME`, not `GCS_BUCKET`.)
+over the production default. `scripts/deploy-cloud-function.sh` resolves its
+project differently — it requires `GCP_PROJECT_ID` and exits if it is unset — but
+it is not exempt from the trap: its bucket and region come from exported
+`GCS_BUCKET_NAME` and `GCS_REGION`. A different variable name is not immunity,
+it is the same trap wearing a different name, and it lands on the one service
+with two competing deploy paths.
 
 On 2026-08-07 a shell with `GCS_BUCKET=divine-blossom-media-staging` exported
 pointed the production transcoder at the staging bucket, where its service
@@ -137,12 +140,18 @@ repository root:
 
 ```bash
 for script in cloud-run-transcoder/deploy.sh cloud-run-upload/deploy.sh \
-              cloud-run-asr-parakeet/deploy.sh; do
-  for v in $(sed -n 's/^\([A-Z_][A-Z0-9_]*\)="\${\1:-.*/\1/p' "$script"); do
+              cloud-run-asr-parakeet/deploy.sh scripts/deploy-cloud-function.sh; do
+  for v in $(sed -n 's/^[A-Z_][A-Z0-9_]*="\{0,1\}\${\([A-Z_][A-Z0-9_]*\):-.*/\1/p' "$script"); do
     printenv "$v" >/dev/null && echo "$v is exported — $script would use your value"
   done
 done
 ```
+
+That captures the name on the *right* of the `:-`, which is the name `printenv`
+is being asked about. It matters: `scripts/deploy-cloud-function.sh` assigns
+`BUCKET_NAME="${GCS_BUCKET_NAME:-blossom-media}"`, where the two sides differ, so
+a pattern keyed to the left-hand name would miss exactly the variable that can
+misdirect `process-blob`.
 
 `GCS_BUCKET` is not the only variable that can bite this way. The transcoder
 script alone resolves 27 settings from the environment, and several have names


### PR DESCRIPTION
## Summary

Adds deployment traps from the 2026-08-07 transcoder outage to `docs/runbooks/deployment.md`:

1. **Exported shell variables override script defaults.** The hand-run deploy scripts resolve settings as `VAR="${VAR:-production-default}"`, so an exported `GCS_BUCKET=divine-blossom-media-staging` silently pointed the production transcoder at the staging bucket (4.5h of failed transcodes). There is no automated backstop for this today, and the runbook says so rather than implying one. It adds a shell check that derives the affected variable names from the deploy scripts themselves and reports which of them are exported, without printing any value.
2. **The two Cloud Run configuration checks read different places, on purpose.** The pre-deploy check reads the service's `spec.template`, because that is the baseline the next `gcloud run deploy` merges onto. The deploy-verification command reads the revision currently serving traffic, because that is what production is answering with. The two coincide normally and diverge after a rollback, so the runbook names which question each one answers.
3. **A traffic rollback pins the service.** `update-traffic --to-revisions` stops migration to latest, so a later deploy reports success while the new revision serves 0% traffic. Documents `--to-latest` as the required follow-up and a traffic-check command for the pinned window.

## Motivation

These traps surfaced during the Aug 7 incident response and were not yet documented in the deployment runbook.

## Related Issue

- Context: #179 and #182, both of which bit the incident response described here.
- Related follow-ups: #180, #181, #183.

## Validation

Docs-only change. No visual or behavioral surface.

- [x] `cargo check --tests --locked`
- [x] `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked`
- [x] `cargo clippy --locked --all-targets --all-features`
- [x] relevant service-local checks for touched Cloud Run or Python code

## Manual Test Plan / Notes

Fact-checked against the tree:

- the `GCS_BUCKET` default in `cloud-run-transcoder/deploy.sh`
- that `gcloud run deploy` creates or updates the *service* and `--update-env-vars` merges onto its `spec.template`, which is what makes the template the right pre-deploy baseline and the serving revision the right deploy-verification baseline
- that `scripts/deploy-cloud-function.sh` carries the same exported-variable trap under `GCS_BUCKET_NAME` and `GCS_REGION`, so the shell check covers it too

Every embedded snippet was executed rather than only read:

- the `spec.template` reader and the serving-revision resolver, against synthetic Cloud Run v1 payloads covering a 100% revision, a pinned rollback, a tag-only traffic entry, and an empty traffic list
- the exported-variable check with a bucket variable and a secret variable exported — it names both and prints neither value, and it is silent under `env -i`
- `git diff --check`

Not tested: the snippets have not been run against a live Cloud Run service, only against payloads matching the v1 API shapes.

## Visuals / API Examples

- [x] No visual change

## Public Artifact Review

- [x] Titles, descriptions, branch names, and screenshots avoid partner, customer, brand, campaign, or other sensitive external names unless explicitly approved
