### PR TITLE
fix(cache): give rendition HEAD responses the derivative cache policy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2531,6 +2531,10 @@ fn handle_head_quality_variant(path: &str) -> Result<Response> {
     let mut resp = Response::from_status(StatusCode::OK);
     resp.set_header("Content-Type", content_type);
     resp.set_header("Accept-Ranges", "bytes");
+    // Non-owner gating above means a 200 here is always public content, so the
+    // same derivative policy as GET applies: repairable renditions must not be
+    // pinned immutable in browser caches.
+    add_derivative_cache_headers(&mut resp, &hash);
     add_cors_headers(&mut resp);
     Ok(resp)
 }


### PR DESCRIPTION
## Summary

`handle_head_quality_variant` never set `Cache-Control`, which the old fetch VCL masked by overriding every 200 to `public, max-age=31536000, immutable`. Since #186, the VCL preserves origin policy and falls back to immutable only when the origin is silent — so this one remaining rendition path would still produce an immutable-pinned response, the bug class #186 removed from every other derivative route.

## Motivation

Complete the #186 call-site set. The handler resolves non-owner gating before responding, so a 200 here is always public content and the derivative policy (`public, max-age=86400` + long purgeable edge TTL) applies.

## Linked issue

Follow-up to #186 (found during its post-deploy verification).

## Validation

- `cargo check --tests --locked` and `cargo clippy --locked --all-targets --all-features` pass (no new warnings).
- The behaviour difference is not observable through the live edge on a warm object (Fastly answers HEAD from the cached GET response), so verification is: post-deploy, HEAD and GET on a cold derivative agree on `public, max-age=86400`, e.g. via `curl -sI` with a cache-bypass header against `media.divine.video` after the next purge.
- No visual change; one response header on HEAD `/{hash}/{quality}.mp4`.