### PR TITLE
feat(observability): durable structured logging for edge-proxied uploads

### DIFF
--- a/blossom-core/src/error.rs
+++ b/blossom-core/src/error.rs
@@ -39,6 +39,27 @@ impl BlossomError {
         }
     }
 
+    /// Stable, message-free label for this error variant.
+    ///
+    /// Log sinks group on this, so it is spelled out rather than derived from
+    /// `Debug`: a variant rename must not silently repartition existing data.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            BlossomError::AuthRequired(_) => "auth_required",
+            BlossomError::AuthInvalid(_) => "auth_invalid",
+            BlossomError::Forbidden(_) => "forbidden",
+            BlossomError::NotFound(_) => "not_found",
+            BlossomError::Conflict(_) => "conflict",
+            BlossomError::BadRequest(_) => "bad_request",
+            BlossomError::Gone(_) => "gone",
+            BlossomError::RangeNotSatisfiable(_) => "range_not_satisfiable",
+            BlossomError::UnprocessableEntity(_) => "unprocessable_entity",
+            BlossomError::StorageError(_) => "storage_error",
+            BlossomError::MetadataError(_) => "metadata_error",
+            BlossomError::Internal(_) => "internal",
+        }
+    }
+
     pub fn message(&self) -> &str {
         match self {
             BlossomError::AuthRequired(msg) => msg,
@@ -121,6 +142,39 @@ mod tests {
             BlossomError::Internal("".into()).status_code(),
             StatusCode::INTERNAL_SERVER_ERROR
         );
+    }
+
+    #[test]
+    fn kind_labels_are_stable_snake_case() {
+        // These land in a log sink and get grouped on, so they must not drift
+        // with Rust naming or Debug formatting.
+        assert_eq!(BlossomError::AuthRequired("".into()).kind(), "auth_required");
+        assert_eq!(BlossomError::AuthInvalid("".into()).kind(), "auth_invalid");
+        assert_eq!(BlossomError::Forbidden("".into()).kind(), "forbidden");
+        assert_eq!(BlossomError::NotFound("".into()).kind(), "not_found");
+        assert_eq!(BlossomError::Conflict("".into()).kind(), "conflict");
+        assert_eq!(BlossomError::BadRequest("".into()).kind(), "bad_request");
+        assert_eq!(BlossomError::Gone("".into()).kind(), "gone");
+        assert_eq!(
+            BlossomError::RangeNotSatisfiable("".into()).kind(),
+            "range_not_satisfiable"
+        );
+        assert_eq!(
+            BlossomError::UnprocessableEntity("".into()).kind(),
+            "unprocessable_entity"
+        );
+        assert_eq!(BlossomError::StorageError("".into()).kind(), "storage_error");
+        assert_eq!(
+            BlossomError::MetadataError("".into()).kind(),
+            "metadata_error"
+        );
+        assert_eq!(BlossomError::Internal("".into()).kind(), "internal");
+    }
+
+    #[test]
+    fn kind_does_not_leak_the_message() {
+        let err = BlossomError::AuthInvalid("Nostr eyJzZWNyZXQiOiJ4In0=".into());
+        assert_eq!(err.kind(), "auth_invalid");
     }
 
     #[test]

--- a/blossom-core/src/lib.rs
+++ b/blossom-core/src/lib.rs
@@ -5,3 +5,4 @@ pub mod rate_limit;
 pub mod read_through;
 pub mod transcribe;
 pub mod types;
+pub mod upload_log;

--- a/blossom-core/src/upload_log.rs
+++ b/blossom-core/src/upload_log.rs
@@ -3,7 +3,7 @@
 
 /// Bumped whenever the emitted field set changes incompatibly. The sink's
 /// schema is owned by a different repo, so consumers need a version to key on.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Upper bound on any free-text field copied into a log line. Error text is
 /// partly attacker-influenced, and an unbounded message is both a cost and a
@@ -44,15 +44,14 @@ impl UploadRoute {
 pub enum UploadOutcome {
     /// Edge returned a success status.
     Ok,
-    /// The proxy send itself failed: the request never reached origin, so no
-    /// origin-side log or metric will ever account for it.
+    /// The proxy send did not yield a complete origin response.
     SendFailed,
     /// Origin replied, with a non-success status.
     OriginStatusError,
-    /// Edge returned a 4xx of its own. Check `origin_reached` to tell an
+    /// Edge returned a 4xx of its own. Check `origin_responded` to tell an
     /// edge-side precondition failure from a rejection relayed from origin.
     ValidationRejected,
-    /// Edge returned a 5xx of its own. With `origin_reached = true` this is a
+    /// Edge returned a 5xx of its own. With `origin_responded = true` this is a
     /// post-origin failure: the upload landed but the edge failed afterwards.
     EdgeError,
 }
@@ -83,10 +82,11 @@ pub struct UploadLogRecord {
     pub content_type: Option<String>,
     /// Whether a request body was streamed through the edge to origin.
     pub proxied_body: bool,
-    /// Whether an origin request was attempted and answered.
-    pub origin_reached: bool,
+    /// Whether origin returned a complete HTTP response.
+    pub origin_responded: bool,
     pub origin_status: Option<u16>,
-    /// The error from `.send()`. Populated only when origin was never reached.
+    /// The error from `.send()`. This does not establish whether origin
+    /// received or processed some or all of the request.
     pub send_error: Option<String>,
     /// Wall time around the origin send, present whenever a send was attempted
     /// — including when it failed.
@@ -109,7 +109,7 @@ impl UploadLogRecord {
             content_length: None,
             content_type: None,
             proxied_body: false,
-            origin_reached: false,
+            origin_responded: false,
             origin_status: None,
             send_error: None,
             proxy_duration_ms: None,
@@ -149,7 +149,7 @@ impl UploadLogRecord {
 pub enum OriginSendResult<'a> {
     /// Origin answered, with this status.
     Replied(u16),
-    /// The send itself failed; origin never saw the request.
+    /// The send did not yield a complete response.
     Failed(&'a str),
 }
 
@@ -166,11 +166,11 @@ pub fn record_send_attempt(
     record.proxy_duration_ms = Some(duration_ms);
     match result {
         OriginSendResult::Replied(status) => {
-            record.origin_reached = true;
+            record.origin_responded = true;
             record.origin_status = Some(status);
         }
         OriginSendResult::Failed(error) => {
-            record.origin_reached = false;
+            record.origin_responded = false;
             record.origin_status = None;
             record.send_error = Some(error.to_string());
         }
@@ -187,7 +187,7 @@ pub fn record_response(record: &mut UploadLogRecord, status: u16) {
 /// Additive only. An earlier `send_error` or `origin_status` must survive:
 /// both a failed send and an origin rejection get wrapped into a
 /// `BlossomError` before the handler returns, and overwriting here would erase
-/// the distinction between "origin never saw it", "origin refused it", and
+/// the distinction between "no complete response", "origin refused it", and
 /// "the edge itself broke".
 pub fn record_failure(record: &mut UploadLogRecord, error: &crate::error::BlossomError) {
     record.response_status = error.status_code().as_u16();
@@ -209,7 +209,7 @@ pub fn format_upload_log(record: &UploadLogRecord) -> String {
         "content_length": record.content_length,
         "content_type": sanitize_opt(record.content_type.as_deref()),
         "proxied_body": record.proxied_body,
-        "origin_reached": record.origin_reached,
+        "origin_responded": record.origin_responded,
         "origin_status": record.origin_status,
         "send_error": sanitize_opt(record.send_error.as_deref()),
         "proxy_duration_ms": record.proxy_duration_ms,
@@ -267,7 +267,7 @@ mod tests {
             content_length: Some(1_048_576),
             content_type: Some("video/mp4".into()),
             proxied_body: true,
-            origin_reached: true,
+            origin_responded: true,
             origin_status: Some(200),
             send_error: None,
             proxy_duration_ms: Some(4200),
@@ -298,10 +298,9 @@ mod tests {
 
     #[test]
     fn send_failure_is_classified_send_failed() {
-        // The invisible case: the request never reached origin, so no origin
-        // log and no origin-side metric will ever mention it.
+        // The edge did not receive a complete origin response.
         let mut r = record();
-        r.origin_reached = false;
+        r.origin_responded = false;
         r.origin_status = None;
         r.send_error = Some("connection closed by peer".into());
         r.response_status = 500;
@@ -311,7 +310,7 @@ mod tests {
 
         assert_eq!(v["outcome"], "send_failed");
         assert_eq!(v["send_error"], "connection closed by peer");
-        assert_eq!(v["origin_reached"], false);
+        assert_eq!(v["origin_responded"], false);
         assert!(v["origin_status"].is_null());
     }
 
@@ -322,7 +321,7 @@ mod tests {
         let mut r = record();
         r.send_error = Some("timeout".into());
         r.origin_status = None;
-        r.origin_reached = false;
+        r.origin_responded = false;
         r.proxy_duration_ms = Some(120_000);
         r.duration_ms = 120_050;
         r.response_status = 500;
@@ -345,13 +344,13 @@ mod tests {
 
         assert_eq!(v["outcome"], "origin_status_error");
         assert_eq!(v["origin_status"], 413);
-        assert_eq!(v["origin_reached"], true);
+        assert_eq!(v["origin_responded"], true);
     }
 
     #[test]
     fn client_error_before_origin_is_classified_validation_rejected() {
         let mut r = record();
-        r.origin_reached = false;
+        r.origin_responded = false;
         r.origin_status = None;
         r.proxy_duration_ms = None;
         r.proxied_body = false;
@@ -369,7 +368,7 @@ mod tests {
     #[test]
     fn server_error_before_origin_is_classified_edge_error() {
         let mut r = record();
-        r.origin_reached = false;
+        r.origin_responded = false;
         r.origin_status = None;
         r.response_status = 502;
         r.error_kind = Some("storage_error");
@@ -382,7 +381,7 @@ mod tests {
     #[test]
     fn edge_failure_after_successful_origin_reply_is_distinguishable() {
         // Origin accepted the upload but the edge failed afterwards (bad
-        // response parse, metadata write). Without origin_reached this is
+        // response parse, metadata write). Without origin_responded this is
         // indistinguishable from a pre-origin edge failure.
         let mut r = record();
         r.origin_status = Some(200);
@@ -392,7 +391,7 @@ mod tests {
         let v = parse(&format_upload_log(&r));
 
         assert_eq!(v["outcome"], "edge_error");
-        assert_eq!(v["origin_reached"], true);
+        assert_eq!(v["origin_responded"], true);
         assert_eq!(v["origin_status"], 200);
     }
 
@@ -505,18 +504,18 @@ mod tests {
         record_send_attempt(&mut r, OriginSendResult::Failed("connection reset"), 900);
 
         assert_eq!(r.send_error.as_deref(), Some("connection reset"));
-        assert!(!r.origin_reached);
+        assert!(!r.origin_responded);
         assert_eq!(r.origin_status, None);
         assert_eq!(r.proxy_duration_ms, Some(900));
         assert_eq!(r.outcome(), UploadOutcome::SendFailed);
     }
 
     #[test]
-    fn recording_a_reply_marks_origin_reached() {
+    fn recording_a_reply_marks_origin_responded() {
         let mut r = fresh();
         record_send_attempt(&mut r, OriginSendResult::Replied(201), 1500);
 
-        assert!(r.origin_reached);
+        assert!(r.origin_responded);
         assert_eq!(r.origin_status, Some(201));
         assert_eq!(r.send_error, None);
         assert_eq!(r.proxy_duration_ms, Some(1500));
@@ -594,6 +593,6 @@ mod tests {
 
         assert_eq!(r.outcome(), UploadOutcome::OriginStatusError);
         assert_eq!(r.origin_status, Some(413));
-        assert!(r.origin_reached);
+        assert!(r.origin_responded);
     }
 }

--- a/blossom-core/src/upload_log.rs
+++ b/blossom-core/src/upload_log.rs
@@ -1,0 +1,599 @@
+// ABOUTME: Structured log record for edge-proxied upload requests and its JSON formatter
+// ABOUTME: Pure logic so upload observability is unit-tested without Viceroy
+
+/// Bumped whenever the emitted field set changes incompatibly. The sink's
+/// schema is owned by a different repo, so consumers need a version to key on.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Upper bound on any free-text field copied into a log line. Error text is
+/// partly attacker-influenced, and an unbounded message is both a cost and a
+/// readability problem on a line-delimited sink.
+pub const MAX_MESSAGE_LEN: usize = 200;
+
+/// Placeholder substituted for anything following an auth scheme keyword.
+const REDACTED: &str = "[redacted]";
+
+/// Auth scheme keywords whose following token is a credential.
+const CREDENTIAL_SCHEMES: [&str; 2] = ["nostr", "bearer"];
+
+/// The edge-proxied upload routes. Resumable *chunk* appends are deliberately
+/// absent: clients send those straight to the upload service, so they never
+/// traverse this service and are already visible in origin logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UploadRoute {
+    /// `PUT /upload` — the whole request body is proxied through the edge.
+    DirectPut,
+    /// `POST /upload/init` — small resumable control-plane call.
+    ResumableInit,
+    /// `POST /upload/{id}/complete` — small resumable control-plane call.
+    ResumableComplete,
+}
+
+impl UploadRoute {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UploadRoute::DirectPut => "direct_put",
+            UploadRoute::ResumableInit => "resumable_init",
+            UploadRoute::ResumableComplete => "resumable_complete",
+        }
+    }
+}
+
+/// What happened to an upload attempt, from the edge's point of view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UploadOutcome {
+    /// Edge returned a success status.
+    Ok,
+    /// The proxy send itself failed: the request never reached origin, so no
+    /// origin-side log or metric will ever account for it.
+    SendFailed,
+    /// Origin replied, with a non-success status.
+    OriginStatusError,
+    /// Edge returned a 4xx of its own. Check `origin_reached` to tell an
+    /// edge-side precondition failure from a rejection relayed from origin.
+    ValidationRejected,
+    /// Edge returned a 5xx of its own. With `origin_reached = true` this is a
+    /// post-origin failure: the upload landed but the edge failed afterwards.
+    EdgeError,
+}
+
+impl UploadOutcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UploadOutcome::Ok => "ok",
+            UploadOutcome::SendFailed => "send_failed",
+            UploadOutcome::OriginStatusError => "origin_status_error",
+            UploadOutcome::ValidationRejected => "validation_rejected",
+            UploadOutcome::EdgeError => "edge_error",
+        }
+    }
+}
+
+/// One edge upload attempt. Deliberately carries no request body, no
+/// `Authorization` header, and no pubkey — see `sanitize` for the guard on
+/// free-text fields that could otherwise smuggle a credential in.
+#[derive(Debug, Clone)]
+pub struct UploadLogRecord {
+    pub route: UploadRoute,
+    /// Correlation ID, also forwarded to origin as `X-Request-Id`.
+    pub req_id: String,
+    /// Declared `Content-Length`, not a measured body size — instrumenting
+    /// must never buffer the body to count it.
+    pub content_length: Option<u64>,
+    pub content_type: Option<String>,
+    /// Whether a request body was streamed through the edge to origin.
+    pub proxied_body: bool,
+    /// Whether an origin request was attempted and answered.
+    pub origin_reached: bool,
+    pub origin_status: Option<u16>,
+    /// The error from `.send()`. Populated only when origin was never reached.
+    pub send_error: Option<String>,
+    /// Wall time around the origin send, present whenever a send was attempted
+    /// — including when it failed.
+    pub proxy_duration_ms: Option<u64>,
+    /// Wall time for the whole request as seen by the edge handler.
+    pub duration_ms: u64,
+    pub response_status: u16,
+    pub error_kind: Option<&'static str>,
+    pub error_message: Option<String>,
+    pub client_ip_present: bool,
+    pub client_geo_country: Option<String>,
+}
+
+impl UploadLogRecord {
+    /// A record for a request that has not done anything yet.
+    pub fn new(route: UploadRoute, req_id: String) -> Self {
+        UploadLogRecord {
+            route,
+            req_id,
+            content_length: None,
+            content_type: None,
+            proxied_body: false,
+            origin_reached: false,
+            origin_status: None,
+            send_error: None,
+            proxy_duration_ms: None,
+            duration_ms: 0,
+            response_status: 0,
+            error_kind: None,
+            error_message: None,
+            client_ip_present: false,
+            client_geo_country: None,
+        }
+    }
+
+    /// Classify the attempt. Order matters: a failed send is the case with no
+    /// record anywhere else, so it outranks every other signal.
+    pub fn outcome(&self) -> UploadOutcome {
+        if self.send_error.is_some() {
+            return UploadOutcome::SendFailed;
+        }
+        if let Some(status) = self.origin_status {
+            if !(200..300).contains(&status) {
+                return UploadOutcome::OriginStatusError;
+            }
+        }
+        if (200..400).contains(&self.response_status) {
+            return UploadOutcome::Ok;
+        }
+        if self.response_status < 500 {
+            UploadOutcome::ValidationRejected
+        } else {
+            UploadOutcome::EdgeError
+        }
+    }
+}
+
+/// Outcome of attempting to send the request to origin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OriginSendResult<'a> {
+    /// Origin answered, with this status.
+    Replied(u16),
+    /// The send itself failed; origin never saw the request.
+    Failed(&'a str),
+}
+
+/// Record an origin send attempt and how long it took.
+///
+/// The duration is recorded for both arms on purpose: a send that failed after
+/// two minutes and one that failed instantly are different problems, and only
+/// this field distinguishes them.
+pub fn record_send_attempt(
+    record: &mut UploadLogRecord,
+    result: OriginSendResult<'_>,
+    duration_ms: u64,
+) {
+    record.proxy_duration_ms = Some(duration_ms);
+    match result {
+        OriginSendResult::Replied(status) => {
+            record.origin_reached = true;
+            record.origin_status = Some(status);
+        }
+        OriginSendResult::Failed(error) => {
+            record.origin_reached = false;
+            record.origin_status = None;
+            record.send_error = Some(error.to_string());
+        }
+    }
+}
+
+/// Record the status the edge returned for a successful handler run.
+pub fn record_response(record: &mut UploadLogRecord, status: u16) {
+    record.response_status = status;
+}
+
+/// Record the error the edge returned.
+///
+/// Additive only. An earlier `send_error` or `origin_status` must survive:
+/// both a failed send and an origin rejection get wrapped into a
+/// `BlossomError` before the handler returns, and overwriting here would erase
+/// the distinction between "origin never saw it", "origin refused it", and
+/// "the edge itself broke".
+pub fn record_failure(record: &mut UploadLogRecord, error: &crate::error::BlossomError) {
+    record.response_status = error.status_code().as_u16();
+    record.error_kind = Some(error.kind());
+    record.error_message = Some(error.message().to_string());
+}
+
+/// Render one record as a single-line JSON object.
+///
+/// Every field is always emitted, `null` when absent: the downstream sink is a
+/// fixed-column table, and a key that vanishes on some rows makes
+/// line-delimited ingestion inconsistent.
+pub fn format_upload_log(record: &UploadLogRecord) -> String {
+    let line = serde_json::json!({
+        "schema": SCHEMA_VERSION,
+        "route": record.route.as_str(),
+        "outcome": record.outcome().as_str(),
+        "req_id": sanitize_opt(Some(&record.req_id)),
+        "content_length": record.content_length,
+        "content_type": sanitize_opt(record.content_type.as_deref()),
+        "proxied_body": record.proxied_body,
+        "origin_reached": record.origin_reached,
+        "origin_status": record.origin_status,
+        "send_error": sanitize_opt(record.send_error.as_deref()),
+        "proxy_duration_ms": record.proxy_duration_ms,
+        "duration_ms": record.duration_ms,
+        "response_status": record.response_status,
+        "error_kind": record.error_kind,
+        "error_message": sanitize_opt(record.error_message.as_deref()),
+        "client_ip_present": record.client_ip_present,
+        "client_geo_country": sanitize_opt(record.client_geo_country.as_deref()),
+    });
+
+    line.to_string()
+}
+
+fn sanitize_opt(value: Option<&str>) -> Option<String> {
+    value.map(sanitize)
+}
+
+/// Make a free-text value safe to put on a shared, line-delimited log sink.
+///
+/// Control characters become spaces so a single record cannot be split into
+/// two; anything following an auth scheme keyword is dropped so a credential
+/// echoed back inside an error message never reaches the sink; and the result
+/// is length-capped.
+fn sanitize(value: &str) -> String {
+    let despaced: String = value
+        .chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect();
+
+    let mut parts: Vec<String> = Vec::new();
+    let mut previous_was_scheme = false;
+    for token in despaced.split_whitespace() {
+        if previous_was_scheme {
+            parts.push(REDACTED.to_string());
+        } else {
+            parts.push(token.to_string());
+        }
+        previous_was_scheme = CREDENTIAL_SCHEMES
+            .iter()
+            .any(|scheme| token.eq_ignore_ascii_case(scheme));
+    }
+
+    parts.join(" ").chars().take(MAX_MESSAGE_LEN).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record() -> UploadLogRecord {
+        UploadLogRecord {
+            route: UploadRoute::DirectPut,
+            req_id: "abc123".into(),
+            content_length: Some(1_048_576),
+            content_type: Some("video/mp4".into()),
+            proxied_body: true,
+            origin_reached: true,
+            origin_status: Some(200),
+            send_error: None,
+            proxy_duration_ms: Some(4200),
+            duration_ms: 4300,
+            response_status: 200,
+            error_kind: None,
+            error_message: None,
+            client_ip_present: true,
+            client_geo_country: Some("NZ".into()),
+        }
+    }
+
+    fn parse(line: &str) -> serde_json::Value {
+        serde_json::from_str(line).expect("log line must be valid JSON")
+    }
+
+    #[test]
+    fn ok_upload_is_classified_ok() {
+        let line = format_upload_log(&record());
+        let v = parse(&line);
+
+        assert_eq!(v["outcome"], "ok");
+        assert_eq!(v["route"], "direct_put");
+        assert_eq!(v["origin_status"], 200);
+        assert_eq!(v["content_length"], 1_048_576);
+        assert_eq!(v["duration_ms"], 4300);
+    }
+
+    #[test]
+    fn send_failure_is_classified_send_failed() {
+        // The invisible case: the request never reached origin, so no origin
+        // log and no origin-side metric will ever mention it.
+        let mut r = record();
+        r.origin_reached = false;
+        r.origin_status = None;
+        r.send_error = Some("connection closed by peer".into());
+        r.response_status = 500;
+        r.error_kind = Some("internal");
+
+        let v = parse(&format_upload_log(&r));
+
+        assert_eq!(v["outcome"], "send_failed");
+        assert_eq!(v["send_error"], "connection closed by peer");
+        assert_eq!(v["origin_reached"], false);
+        assert!(v["origin_status"].is_null());
+    }
+
+    #[test]
+    fn send_failure_still_records_duration() {
+        // duration on the failure path is the whole point: it is what tells us
+        // whether edge uploads are dying at Fastly's 120s request ceiling.
+        let mut r = record();
+        r.send_error = Some("timeout".into());
+        r.origin_status = None;
+        r.origin_reached = false;
+        r.proxy_duration_ms = Some(120_000);
+        r.duration_ms = 120_050;
+        r.response_status = 500;
+
+        let v = parse(&format_upload_log(&r));
+
+        assert_eq!(v["outcome"], "send_failed");
+        assert_eq!(v["proxy_duration_ms"], 120_000);
+        assert_eq!(v["duration_ms"], 120_050);
+    }
+
+    #[test]
+    fn non_success_origin_status_is_classified_origin_status_error() {
+        let mut r = record();
+        r.origin_status = Some(413);
+        r.response_status = 413;
+        r.error_kind = Some("bad_request");
+
+        let v = parse(&format_upload_log(&r));
+
+        assert_eq!(v["outcome"], "origin_status_error");
+        assert_eq!(v["origin_status"], 413);
+        assert_eq!(v["origin_reached"], true);
+    }
+
+    #[test]
+    fn client_error_before_origin_is_classified_validation_rejected() {
+        let mut r = record();
+        r.origin_reached = false;
+        r.origin_status = None;
+        r.proxy_duration_ms = None;
+        r.proxied_body = false;
+        r.response_status = 400;
+        r.error_kind = Some("bad_request");
+        r.error_message = Some("Content-Length required".into());
+
+        let v = parse(&format_upload_log(&r));
+
+        assert_eq!(v["outcome"], "validation_rejected");
+        assert_eq!(v["error_message"], "Content-Length required");
+        assert!(v["proxy_duration_ms"].is_null());
+    }
+
+    #[test]
+    fn server_error_before_origin_is_classified_edge_error() {
+        let mut r = record();
+        r.origin_reached = false;
+        r.origin_status = None;
+        r.response_status = 502;
+        r.error_kind = Some("storage_error");
+
+        let v = parse(&format_upload_log(&r));
+
+        assert_eq!(v["outcome"], "edge_error");
+    }
+
+    #[test]
+    fn edge_failure_after_successful_origin_reply_is_distinguishable() {
+        // Origin accepted the upload but the edge failed afterwards (bad
+        // response parse, metadata write). Without origin_reached this is
+        // indistinguishable from a pre-origin edge failure.
+        let mut r = record();
+        r.origin_status = Some(200);
+        r.response_status = 500;
+        r.error_kind = Some("internal");
+
+        let v = parse(&format_upload_log(&r));
+
+        assert_eq!(v["outcome"], "edge_error");
+        assert_eq!(v["origin_reached"], true);
+        assert_eq!(v["origin_status"], 200);
+    }
+
+    #[test]
+    fn resumable_routes_render_their_own_labels() {
+        let mut r = record();
+        r.route = UploadRoute::ResumableInit;
+        assert_eq!(parse(&format_upload_log(&r))["route"], "resumable_init");
+
+        r.route = UploadRoute::ResumableComplete;
+        assert_eq!(parse(&format_upload_log(&r))["route"], "resumable_complete");
+    }
+
+    #[test]
+    fn absent_optional_fields_render_as_null_not_missing() {
+        // The ClickHouse schema is fixed-column; a key that disappears on some
+        // rows makes JSONEachRow ingestion inconsistent.
+        let mut r = record();
+        r.content_length = None;
+        r.content_type = None;
+        r.client_geo_country = None;
+
+        let v = parse(&format_upload_log(&r));
+
+        assert!(v.get("content_length").is_some_and(|f| f.is_null()));
+        assert!(v.get("content_type").is_some_and(|f| f.is_null()));
+        assert!(v.get("client_geo_country").is_some_and(|f| f.is_null()));
+    }
+
+    #[test]
+    fn nostr_credentials_are_redacted_from_messages() {
+        let mut r = record();
+        r.response_status = 401;
+        r.error_kind = Some("auth_invalid");
+        r.error_message = Some(
+            "rejected header Nostr eyJpZCI6ImFiYyIsInNpZyI6ImRlYWRiZWVmIn0= for upload".into(),
+        );
+
+        let line = format_upload_log(&r);
+
+        assert!(!line.contains("eyJpZCI6"), "auth token leaked into log: {line}");
+        assert!(line.contains("[redacted]"));
+    }
+
+    #[test]
+    fn bearer_credentials_are_redacted_from_messages() {
+        let mut r = record();
+        r.send_error = Some("upstream rejected Bearer sk-live-abcdef123456".into());
+
+        let line = format_upload_log(&r);
+
+        assert!(!line.contains("sk-live-abcdef123456"));
+        assert!(line.contains("[redacted]"));
+    }
+
+    #[test]
+    fn long_messages_are_truncated() {
+        let mut r = record();
+        r.error_message = Some("x".repeat(5000));
+
+        let v = parse(&format_upload_log(&r));
+        let msg = v["error_message"].as_str().unwrap();
+
+        assert!(msg.len() <= MAX_MESSAGE_LEN + 1, "message not truncated: {}", msg.len());
+    }
+
+    #[test]
+    fn control_characters_are_stripped_from_messages() {
+        // Error text can carry attacker-influenced bytes; a raw newline would
+        // split one record into two on a line-delimited sink.
+        let mut r = record();
+        r.error_message = Some("bad\ninput\r\nhere\u{1b}[31m".into());
+
+        let v = parse(&format_upload_log(&r));
+        let msg = v["error_message"].as_str().unwrap();
+
+        assert!(!msg.contains('\n'));
+        assert!(!msg.contains('\r'));
+        assert!(!msg.contains('\u{1b}'));
+    }
+
+    #[test]
+    fn log_line_is_a_single_line() {
+        let mut r = record();
+        r.error_message = Some("multi\nline\nerror".into());
+
+        assert_eq!(format_upload_log(&r).lines().count(), 1);
+    }
+
+    #[test]
+    fn schema_version_is_present_for_sink_migrations() {
+        let v = parse(&format_upload_log(&record()));
+        assert_eq!(v["schema"], SCHEMA_VERSION);
+    }
+
+    // --- recording the origin send attempt -------------------------------
+    //
+    // These cover the transitions the edge crate performs on a live request.
+    // They live here because CI runs `cargo test -p blossom-core` only; the
+    // edge crate's tests are type-checked but never executed, so logic left
+    // in src/ is effectively untested.
+
+    fn fresh() -> UploadLogRecord {
+        UploadLogRecord::new(UploadRoute::DirectPut, "abc123".into())
+    }
+
+    #[test]
+    fn recording_a_failed_send_marks_origin_unreached() {
+        let mut r = fresh();
+        record_send_attempt(&mut r, OriginSendResult::Failed("connection reset"), 900);
+
+        assert_eq!(r.send_error.as_deref(), Some("connection reset"));
+        assert!(!r.origin_reached);
+        assert_eq!(r.origin_status, None);
+        assert_eq!(r.proxy_duration_ms, Some(900));
+        assert_eq!(r.outcome(), UploadOutcome::SendFailed);
+    }
+
+    #[test]
+    fn recording_a_reply_marks_origin_reached() {
+        let mut r = fresh();
+        record_send_attempt(&mut r, OriginSendResult::Replied(201), 1500);
+
+        assert!(r.origin_reached);
+        assert_eq!(r.origin_status, Some(201));
+        assert_eq!(r.send_error, None);
+        assert_eq!(r.proxy_duration_ms, Some(1500));
+    }
+
+    #[test]
+    fn a_failed_send_records_duration_even_at_the_timeout_ceiling() {
+        // Fastly's request timeout is 120s. If uploads are dying there, this
+        // is the only field that will show it.
+        let mut r = fresh();
+        record_send_attempt(&mut r, OriginSendResult::Failed("timed out"), 120_000);
+
+        assert_eq!(r.proxy_duration_ms, Some(120_000));
+        assert_eq!(r.outcome(), UploadOutcome::SendFailed);
+    }
+
+    #[test]
+    fn recording_the_error_does_not_clobber_an_earlier_send_failure() {
+        // The edge wraps a send failure into BlossomError::Internal before
+        // returning it. If recording that error overwrote send_error, or if
+        // the 500 status flipped the classification, the one case with no
+        // record anywhere else would be filed as a generic edge error.
+        let mut r = fresh();
+        record_send_attempt(&mut r, OriginSendResult::Failed("connection reset"), 900);
+        record_failure(
+            &mut r,
+            &crate::error::BlossomError::Internal(
+                "Failed to proxy to upload service: connection reset".into(),
+            ),
+        );
+
+        assert_eq!(r.send_error.as_deref(), Some("connection reset"));
+        assert_eq!(r.response_status, 500);
+        assert_eq!(r.error_kind, Some("internal"));
+        assert_eq!(r.outcome(), UploadOutcome::SendFailed);
+    }
+
+    #[test]
+    fn recording_a_failure_derives_status_and_kind_from_the_error() {
+        let mut r = fresh();
+        record_failure(
+            &mut r,
+            &crate::error::BlossomError::BadRequest("Content-Length required".into()),
+        );
+
+        assert_eq!(r.response_status, 400);
+        assert_eq!(r.error_kind, Some("bad_request"));
+        assert_eq!(r.error_message.as_deref(), Some("Content-Length required"));
+        assert_eq!(r.outcome(), UploadOutcome::ValidationRejected);
+    }
+
+    #[test]
+    fn recording_a_success_status_leaves_error_fields_empty() {
+        let mut r = fresh();
+        record_send_attempt(&mut r, OriginSendResult::Replied(200), 10);
+        record_response(&mut r, 200);
+
+        assert_eq!(r.response_status, 200);
+        assert_eq!(r.error_kind, None);
+        assert_eq!(r.error_message, None);
+        assert_eq!(r.outcome(), UploadOutcome::Ok);
+    }
+
+    #[test]
+    fn origin_rejection_survives_being_remapped_to_an_edge_error() {
+        // A 413 from origin is remapped to a BlossomError before returning.
+        // origin_status must still win the classification, otherwise every
+        // origin rejection is miscounted as an edge-side validation failure.
+        let mut r = fresh();
+        record_send_attempt(&mut r, OriginSendResult::Replied(413), 2000);
+        record_failure(
+            &mut r,
+            &crate::error::BlossomError::BadRequest("File too large".into()),
+        );
+
+        assert_eq!(r.outcome(), UploadOutcome::OriginStatusError);
+        assert_eq!(r.origin_status, Some(413));
+        assert!(r.origin_reached);
+    }
+}

--- a/blossom-core/src/upload_log.rs
+++ b/blossom-core/src/upload_log.rs
@@ -73,6 +73,9 @@ impl UploadOutcome {
 /// free-text fields that could otherwise smuggle a credential in.
 #[derive(Debug, Clone)]
 pub struct UploadLogRecord {
+    /// Request occurrence time as Unix epoch milliseconds. Delivery to the sink
+    /// is batched, so subscriber insertion time is not an event timestamp.
+    pub occurred_at_ms: u64,
     pub route: UploadRoute,
     /// Correlation ID, also forwarded to origin as `X-Request-Id`.
     pub req_id: String,
@@ -102,8 +105,9 @@ pub struct UploadLogRecord {
 
 impl UploadLogRecord {
     /// A record for a request that has not done anything yet.
-    pub fn new(route: UploadRoute, req_id: String) -> Self {
+    pub fn new(route: UploadRoute, req_id: String, occurred_at_ms: u64) -> Self {
         UploadLogRecord {
+            occurred_at_ms,
             route,
             req_id,
             content_length: None,
@@ -203,6 +207,7 @@ pub fn record_failure(record: &mut UploadLogRecord, error: &crate::error::Blosso
 pub fn format_upload_log(record: &UploadLogRecord) -> String {
     let line = serde_json::json!({
         "schema": SCHEMA_VERSION,
+        "occurred_at_ms": record.occurred_at_ms,
         "route": record.route.as_str(),
         "outcome": record.outcome().as_str(),
         "req_id": sanitize_opt(Some(&record.req_id)),
@@ -262,6 +267,7 @@ mod tests {
 
     fn record() -> UploadLogRecord {
         UploadLogRecord {
+            occurred_at_ms: 1_700_000_000_123,
             route: UploadRoute::DirectPut,
             req_id: "abc123".into(),
             content_length: Some(1_048_576),
@@ -290,6 +296,7 @@ mod tests {
         let v = parse(&line);
 
         assert_eq!(v["outcome"], "ok");
+        assert_eq!(v["occurred_at_ms"], 1_700_000_000_123_u64);
         assert_eq!(v["route"], "direct_put");
         assert_eq!(v["origin_status"], 200);
         assert_eq!(v["content_length"], 1_048_576);
@@ -495,7 +502,7 @@ mod tests {
     // in src/ is effectively untested.
 
     fn fresh() -> UploadLogRecord {
-        UploadLogRecord::new(UploadRoute::DirectPut, "abc123".into())
+        UploadLogRecord::new(UploadRoute::DirectPut, "abc123".into(), 1_700_000_000_123)
     }
 
     #[test]

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ This directory is the index for repository documentation. Current docs first, hi
 - [OAUTH_SETUP.md](../OAUTH_SETUP.md) — OAuth configuration for admin UI
 - [CHANGELOG.md](../CHANGELOG.md) — release history
 - [docs/api/](api/) — cross-service API contracts (creator-delete, etc.)
-- [docs/runbooks/](runbooks/) — operational runbooks, including deployment and CDN view counting
+- [docs/runbooks/](runbooks/) — operational runbooks, including deployment, CDN view counting, and edge upload observability
 - [docs/cdn-evaluation-status.md](cdn-evaluation-status.md) — **start here** for the CDN and delivery-origin evaluation: current state, results, open questions
 - [docs/cdn-object-storage-vendor-notes.md](cdn-object-storage-vendor-notes.md) — CDN and object-storage vendor capability notes
 - [docs/measurements/](measurements/) — synthetic CDN and delivery measurements

--- a/docs/runbooks/edge-upload-observability.md
+++ b/docs/runbooks/edge-upload-observability.md
@@ -112,8 +112,7 @@ activate that service version. Immediately delete the local key and disarm the
 normal-exit cleanup after it succeeds:
 
 ```bash
-rm -f "$KEY_FILE"
-trap - EXIT
+rm -f "$KEY_FILE" && trap - EXIT
 ```
 
 The EXIT trap remains the abnormal-path backstop until those commands run. Do
@@ -220,10 +219,11 @@ ORDER BY (route, outcome, timestamp);
 ```
 
 The subscriber must normalize messages before `JSONEachRow` insertion. Schema 2
-already carries `occurred_at_ms`. For retained schema-1 messages, which predate
-that field, set `occurred_at_ms` from the Pub/Sub message's server-assigned
-publish time. Do not insert a missing value as zero or use ClickHouse insertion
-time: either choice moves delayed backlog into the wrong query window. Reject
+already carries `occurred_at_ms` and `origin_responded`. For retained schema-1
+messages, set `occurred_at_ms` from the Pub/Sub message's server-assigned publish
+time and rename `origin_reached` to `origin_responded`. Do not insert missing
+values as zero or use ClickHouse insertion time: either choice corrupts the
+normalized record or moves delayed backlog into the wrong query window. Reject
 unknown future schema versions rather than silently applying the schema-1
 fallback.
 

--- a/docs/runbooks/edge-upload-observability.md
+++ b/docs/runbooks/edge-upload-observability.md
@@ -321,8 +321,20 @@ gcloud pubsub subscriptions describe edge-upload-logs-sub \
 ### Fallback while the subscriber does not exist
 
 ```bash
-fastly log-tail --service-id pOvEEWykEbpnylqst1KTrR | grep '^\[UPLOAD\]'
+fastly log-tail --service-id pOvEEWykEbpnylqst1KTrR | grep '\[UPLOAD\]'
 ```
+
+**`log-tail` is lossy. Never count with it.** Measured on 2026-08-13: five
+`POST /upload/{id}/complete` requests issued during an active `log-tail` produced
+**no output at all** — not even the `[BLOSSOM ROUTE]` line that `handle_request`
+emits unconditionally for every request before any routing runs. All five were
+present in Pub/Sub. The tail samples across POPs and drops under load; the
+service handles thousands of requests per minute, of which uploads are a
+handful.
+
+Use `log-tail` to answer "is the guest emitting the shape I expect?", which it
+does well and immediately. Use Pub/Sub to answer "how many?", which `log-tail`
+cannot answer at all. An absence in `log-tail` is not evidence of anything.
 
 ### Sanity-check the volume — and mind the inline path
 
@@ -351,7 +363,21 @@ WHERE route = 'direct_put' AND proxied_body AND timestamp >= today();
 Observed on 2026-08-13: one `PUT /upload` in a five-minute window against 2963
 total routed requests, i.e. roughly 12/hour or ~290/day of direct PUTs at the
 edge. That is consistent with the 241–523/day origin figure, but it is a
-five-minute sample and should not be treated as a rate measurement.
+five-minute sample taken through `log-tail` — which is itself lossy, see below —
+and should not be treated as a rate measurement.
+
+Both branches of the threshold were seen in real traffic the same day, which is
+worth knowing when reading the data:
+
+| observed | `content_length` | `content_type` | `proxied_body` | `origin_status` | `proxy_duration_ms` |
+|---|---|---|---|---|---|
+| proxied because video | 5016 | `video/mp4` | true | 200 | 757 |
+| proxied because video | 5016 | `video/mp4` | true | 200 | 617 |
+| inline, under threshold | 100126 | `image/jpeg` | false | null | null |
+
+Note the 5 KB `video/mp4` files: the video MIME check fires at *any* size, so
+small videos proxy while much larger images do not. Size alone does not predict
+which path a request took — read `proxied_body`.
 
 Other origin-side baselines for comparison: ~96–98% of direct PUTs return 200;
 408s run 1–6/day, 400s 4–10/day, 413s 1–5/day; client aborts mid-upload

--- a/docs/runbooks/edge-upload-observability.md
+++ b/docs/runbooks/edge-upload-observability.md
@@ -1,0 +1,490 @@
+# Edge Upload Observability
+
+Structured logging for upload requests that pass through `media.divine.video`.
+
+Pipeline: Fastly Compute (`fastly-blossom`) → Google Cloud Pub/Sub → *(subscriber
+not yet built)* → ClickHouse
+
+## Why this exists
+
+`media.divine.video` proxied upload request bodies to origin and kept no durable
+record of doing so. Every measurement channel was missing at once:
+
+- Crashlytics suppresses `TIMEOUT` (mobile reports only `OUT_OF_MEMORY` and
+  `UNKNOWN`)
+- `/api/analytics/events` does not exist server-side; mobile and web both ship
+  clients for a route nobody built
+- `divine-upload-server` exposes no `/metrics`
+- this service logged only via `eprintln!`, which reaches `fastly log-tail` and
+  nothing else
+
+Origin-side counters (divine-iac-core PR #1618) show ~94–96% of upload attempts
+succeeding, which does not match the volume of user complaints. The leading
+explanation is that failures at the edge are invisible: anything Fastly rejects
+or times out never reaches origin and therefore appears in no origin metric.
+
+The single most important field is `send_error`. When the proxy `send` to origin
+fails, the request never reached `divine-upload-server`, so it appears in no
+origin access log and in none of PR #1618's log-based metrics. Before this
+change that case had **zero** record anywhere.
+
+## Scope
+
+| flow | route | through Fastly? | logged here? |
+|---|---|---|---|
+| direct `PUT /upload` | via `media.divine.video`, full body proxied | yes | **yes** (`direct_put`) |
+| resumable `POST /upload/init` | via `media.divine.video` | yes | **yes** (`resumable_init`) |
+| resumable `POST /upload/{id}/complete` | via `media.divine.video` | yes | **yes** (`resumable_complete`) |
+| resumable chunk `PUT /sessions/{id}` | client → `upload.divine.video` direct | **no** | no — bypasses the edge entirely |
+
+Chunk appends never traverse this service, so they are already fully visible in
+origin logs and are deliberately out of scope. Corroboration: the edge proxy
+forwards only `Host`, `Authorization`, `Content-Type`, `Content-Length`,
+`X-Request-Id` — notably not `User-Agent`. Origin nginx logs show
+`Dart/3.12 (dart:io)` on chunk PUTs (client direct) and `-` on direct PUTs
+(edge-proxied).
+
+Sampling is not applied. Volume is a few hundred requests per day; every request
+is logged.
+
+## Where the config lives — read this before trusting the data
+
+**The logging endpoint is Fastly service configuration, not code. It is not in
+this repo and not in any version control.**
+
+`fastly.toml` already warns that backends, KV stores, config stores, and secrets
+are dashboard-managed. The logging endpoint is the same. Consequences:
+
+- a service rebuilt from scratch has **no** endpoint, and nothing in CI notices
+- if the endpoint is deleted, Fastly drops writes to the unknown endpoint name
+  **silently** — the guest sees no error, the deploy stays green, and the data
+  just stops
+
+There is no automated backstop for this today. The mitigation in code is that
+every line is also written to stderr, so `fastly log-tail` keeps working as a
+fallback and the loss is discoverable rather than invisible. That is a fallback,
+not a fix: stderr is ephemeral.
+
+To check the endpoint still exists on the active version:
+
+```bash
+fastly logging googlepubsub list --service-id pOvEEWykEbpnylqst1KTrR --version active
+```
+
+### Recreating it from scratch
+
+```bash
+PROJECT=rich-compiler-479518-d2
+SERVICE=pOvEEWykEbpnylqst1KTrR
+
+gcloud pubsub topics create edge-upload-logs --project="$PROJECT"
+
+gcloud pubsub subscriptions create edge-upload-logs-sub \
+  --topic=edge-upload-logs \
+  --ack-deadline=60 \
+  --message-retention-duration=7d \
+  --project="$PROJECT"
+
+gcloud iam service-accounts create fastly-edge-upload-logs \
+  --display-name="Fastly Edge Upload Log Writer" \
+  --project="$PROJECT"
+
+gcloud pubsub topics add-iam-policy-binding edge-upload-logs \
+  --member="serviceAccount:fastly-edge-upload-logs@${PROJECT}.iam.gserviceaccount.com" \
+  --role="roles/pubsub.publisher" \
+  --project="$PROJECT"
+
+gcloud iam service-accounts keys create /tmp/edge-upload-logs-key.json \
+  --iam-account="fastly-edge-upload-logs@${PROJECT}.iam.gserviceaccount.com" \
+  --project="$PROJECT"
+
+python3 -c "import json;k=json.load(open('/tmp/edge-upload-logs-key.json'));open('/tmp/pk.pem','w').write(k['private_key'])"
+
+fastly logging googlepubsub create \
+  --service-id "$SERVICE" \
+  --version active --autoclone \
+  --name edge_upload_logs \
+  --project-id "$PROJECT" \
+  --topic edge-upload-logs \
+  --user "fastly-edge-upload-logs@${PROJECT}.iam.gserviceaccount.com" \
+  --secret-key="$(cat /tmp/pk.pem)" \
+  --non-interactive
+
+rm -f /tmp/edge-upload-logs-key.json /tmp/pk.pem
+```
+
+The endpoint name **must** be `edge_upload_logs`; it is matched by
+`UPLOAD_LOG_ENDPOINT` in `src/upload_log.rs`.
+
+A dedicated service account is used rather than the existing
+`fastly-pubsub-writer` (see `cdn-view-counting.md`), so this key can only publish
+to this one topic.
+
+### Traps
+
+- **`--secret-key` must use the `=` form.** The PEM body begins with `-----`, and
+  the CLI's argument parser reads a space-separated value starting with dashes as
+  a flag. `--secret-key "$(cat pk.pem)"` fails with
+  `expected argument for flag '--secret-key'`; `--secret-key="$(cat pk.pem)"`
+  works.
+- **`fastly logging googlepubsub describe` prints the full private key** to
+  stdout, in both the default and `--json` output. Never paste its output into a
+  PR, an issue, a ticket, or a shared transcript. Use `list` when you only need
+  to confirm the endpoint exists.
+
+  Filtering the output is easy to get wrong: the JSON field is `SecretKey`, not
+  `secret_key`, so a filter keyed on the snake_case name strips nothing and
+  succeeds silently. This has already caused one key rotation. If you must
+  inspect the config, allow-list the fields you want rather than deny-listing
+  the one you don't:
+
+  ```bash
+  fastly logging googlepubsub describe --service-id "$SERVICE" \
+    --version active --name edge_upload_logs --json \
+  | python3 -c "import json,sys;d=json.load(sys.stdin);print(json.dumps({k:d[k] for k in ('Name','Topic','ProjectID','User','Placement','ResponseCondition','ServiceVersion')},indent=2))"
+  ```
+- **Activate the endpoint's version before `fastly compute publish`.**
+  `publish` clones the *active* version. Creating the endpoint with `--autoclone`
+  leaves it on a draft version; publishing before activating that draft clones
+  the older active version instead and silently drops the endpoint.
+- **`fastly compute publish` will try to create a brand-new service** if no
+  service ID resolves. `fastly.toml` carries no `service_id` and CI supplies
+  `FASTLY_SERVICE_ID` from the workflow env, so a hand-run publish needs
+  `--service-id pOvEEWykEbpnylqst1KTrR` passed inline. Without it the command
+  reaches "Creating service" and only fails because the service *name* collides.
+  Pass the ID inline rather than exporting it — see the exported-variable trap in
+  `deployment.md`.
+- **The endpoint carries a default VCL log format template.** It is inert on a
+  Compute service: the Wasm guest writes the line itself and Fastly does not
+  apply the template. Verified on 2026-08-13 — the payloads arriving in Pub/Sub
+  are the guest's raw JSON, with none of the template's fields. Do not edit it
+  expecting the output to change.
+
+- **Delivery is not immediate. Do not conclude it is broken for at least 15
+  minutes.** Fastly batches log delivery, and at this volume the first lines
+  after a config change took several minutes to arrive — a three-minute poll
+  window showed an empty subscription while delivery was in fact working. Two
+  delays stack here: POP propagation of the new service version, and the log
+  batch flush. Confirm with `fastly log-tail` first (see below); that is
+  immediate and tells you whether the *guest* is emitting, which separates a
+  code problem from a delivery problem.
+
+## Sink status — incomplete, read before querying
+
+Fastly publishes to the `edge-upload-logs` topic and the
+`edge-upload-logs-sub` subscription retains messages for **7 days**.
+
+**The ClickHouse half of this pipeline does not exist yet.** There is no
+subscriber and no table. That work lives in `divine-funnelcake`, alongside the
+existing `cdn-view-subscriber`, and is out of scope for the divine-blossom PR
+that shipped the edge instrumentation.
+
+Until it ships:
+
+- data is durable for 7 days in the subscription and no longer
+- messages accumulate as unacked; nothing is consuming them
+- **if the subscriber is not built within 7 days, the oldest data is lost**
+
+Proposed table for whoever picks this up:
+
+```sql
+CREATE TABLE nostr.edge_upload_logs
+(
+    timestamp         DateTime DEFAULT now(),
+    schema            UInt32,
+    route             LowCardinality(String),
+    outcome           LowCardinality(String),
+    req_id            String,
+    content_length    Nullable(UInt64),
+    content_type      LowCardinality(Nullable(String)),
+    proxied_body      Bool,
+    origin_reached    Bool,
+    origin_status     Nullable(UInt16),
+    send_error        Nullable(String),
+    proxy_duration_ms Nullable(UInt64),
+    duration_ms       UInt64,
+    response_status   UInt16,
+    error_kind        LowCardinality(Nullable(String)),
+    error_message     Nullable(String),
+    client_ip_present Bool,
+    client_geo_country LowCardinality(Nullable(String))
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (route, outcome, timestamp);
+```
+
+## Schema
+
+One JSON object per line, one line per request. Emitted by
+`blossom_core::upload_log::format_upload_log`. Every field is always present;
+absent values are `null` rather than omitted, so a fixed-column table can ingest
+the stream without per-row key checks.
+
+| field | type | meaning |
+|---|---|---|
+| `schema` | int | Field-set version. Bumped on incompatible changes. Currently `1`. |
+| `route` | string | `direct_put`, `resumable_init`, `resumable_complete` |
+| `outcome` | string | see below |
+| `req_id` | string | Correlation ID, also sent to origin as `X-Request-Id` |
+| `content_length` | int? | **Declared** size, not measured — the body is never buffered. On `resumable_init` this is the declared *upload* size from the JSON body, not the control message's own length. |
+| `content_type` | string? | Separates video uploads from avatars and thumbnails |
+| `proxied_body` | bool | Whether a request body was streamed through the edge to origin |
+| `origin_reached` | bool | Whether origin was asked and answered |
+| `origin_status` | int? | Origin's HTTP status, when it replied at all |
+| `send_error` | string? | The error from `.send()`. **Populated only when origin was never reached.** |
+| `proxy_duration_ms` | int? | Wall time around the origin send, present whenever a send was attempted — including when it failed |
+| `duration_ms` | int | Wall time for the whole request at the edge |
+| `response_status` | int | What the edge returned to the client |
+| `error_kind` | string? | Stable `BlossomError` variant label, e.g. `bad_request` |
+| `error_message` | string? | Sanitized error text (see below) |
+| `client_ip_present` | bool | Whether a client IP was resolvable |
+| `client_geo_country` | string? | Two-letter country code only |
+
+### Outcomes
+
+| outcome | meaning |
+|---|---|
+| `ok` | Edge returned a success status. On `direct_put` this includes uploads handled entirely at the edge, which have `origin_reached = false` — see the inline-path note under Verification. |
+| `send_failed` | The send to origin failed. **The request never reached origin**, so nothing origin-side accounts for it. |
+| `origin_status_error` | Origin replied with a non-success status |
+| `validation_rejected` | Edge returned a 4xx of its own |
+| `edge_error` | Edge returned a 5xx of its own. With `origin_reached = true` this is a *post-origin* failure: the upload landed but the edge failed afterwards. |
+
+Classification is ordered: a failed send outranks everything, then a non-2xx
+origin status, then the edge's own status. This matters because both a failed
+send and an origin rejection get wrapped into a generic `BlossomError` before the
+handler returns; without the ordering, every origin 413 would be miscounted as an
+edge-side validation failure.
+
+### What is deliberately not logged
+
+- the `Authorization` header, in any form — it carries Nostr auth
+- request or response bodies
+- pubkeys, event IDs, or blob hashes
+- client IP; only presence and country code
+
+Free-text fields (`error_message`, `send_error`, `content_type`, `req_id`,
+`client_geo_country`) are passed through a sanitizer that replaces control
+characters with spaces, caps length at 200 characters, and replaces any token
+following a `Nostr` or `Bearer` scheme keyword with `[redacted]`. The control
+character stripping is not cosmetic: a raw newline in an error message would
+split one record into two on a line-delimited sink.
+
+## Correlation with origin logs
+
+The edge sends its `req_id` to origin as an `X-Request-Id` header on all three
+proxied upload routes. This is a change to what origin receives.
+
+`req_id::for_request` prefers an inbound `X-Request-Id`, falls back to the
+leading segment of `cf-ray`, and otherwise generates one.
+
+**Origin nginx does not log this header yet.** To close the loop, add
+`$http_x_request_id` to the `divine-upload-server` access log format. Until that
+lands, the header is forwarded and available but the join is not possible.
+
+## Verification
+
+### Confirm lines are reaching Pub/Sub
+
+```bash
+gcloud pubsub subscriptions pull edge-upload-logs-sub \
+  --project=rich-compiler-479518-d2 \
+  --limit=10 --format=json | python3 -m json.tool
+```
+
+Without `--auto-ack` this does not consume messages, but it does make them
+invisible for the 60s ack deadline. A second pull run immediately after the
+first therefore returns almost nothing — that is the deadline, not an empty
+subscription. Wait out the deadline before concluding anything from a small
+result.
+
+Because nothing is acking, this is also destructive to no one: the backlog keeps
+growing until the subscriber exists or the 7-day retention expires.
+
+Undelivered count:
+
+```bash
+gcloud pubsub subscriptions describe edge-upload-logs-sub \
+  --project=rich-compiler-479518-d2 \
+  --format="value(numUndeliveredMessages)"
+```
+
+### Fallback while the subscriber does not exist
+
+```bash
+fastly log-tail --service-id pOvEEWykEbpnylqst1KTrR | grep '^\[UPLOAD\]'
+```
+
+### Sanity-check the volume — and mind the inline path
+
+Direct `PUT /upload` reaching *origin* runs 241–523/day. Edge `direct_put` lines
+should be **materially higher**, and not only because of edge failures.
+
+`handle_upload` proxies to the upload service only when the upload is larger
+than 500 KB *or* has a video MIME type (`UPLOAD_SERVICE_THRESHOLD`,
+`src/main.rs`). Everything else is buffered and stored by the edge itself and
+**never contacts origin at all**. Origin session records put p50 upload size at
+0.09 MB with 92% `image/jpeg`, so the majority of direct PUTs take the inline
+path and are absent from origin's direct-PUT counts by design.
+
+Such a request logs `outcome = ok`, `origin_reached = false`,
+`proxied_body = false`, `origin_status = null`, `proxy_duration_ms = null`. That
+is **normal, not a failure**, and it is not a `send_failed`. Any query comparing
+edge to origin counts must filter on `proxied_body = true` to compare like with
+like:
+
+```sql
+-- edge requests that should have a matching origin access-log entry
+SELECT count() FROM nostr.edge_upload_logs
+WHERE route = 'direct_put' AND proxied_body AND timestamp >= today();
+```
+
+Observed on 2026-08-13: one `PUT /upload` in a five-minute window against 2963
+total routed requests, i.e. roughly 12/hour or ~290/day of direct PUTs at the
+edge. That is consistent with the 241–523/day origin figure, but it is a
+five-minute sample and should not be treated as a rate measurement.
+
+Other origin-side baselines for comparison: ~96–98% of direct PUTs return 200;
+408s run 1–6/day, 400s 4–10/day, 413s 1–5/day; client aborts mid-upload
+("prematurely closed connection") run 6–14/day. Resumable sessions run
+62–103/day at 96.8–100% completion. Upload sizes are p50 0.09 MB, p99 7.94 MB,
+max 18.47 MB; 92% `image/jpeg`, 8% `video/mp4`.
+
+## Worked queries
+
+These assume the ClickHouse table above. Until the subscriber exists, the same
+questions can be answered by pulling from the subscription and aggregating
+locally.
+
+### 1. What fraction of edge upload attempts fail?
+
+```sql
+SELECT
+    route,
+    outcome,
+    count()                                        AS n,
+    round(100 * count() / sum(count()) OVER (PARTITION BY route), 2) AS pct
+FROM nostr.edge_upload_logs
+WHERE timestamp >= now() - INTERVAL 7 DAY
+GROUP BY route, outcome
+ORDER BY route, n DESC;
+```
+
+Compare the `direct_put` non-`ok` share against the ~4–6% failure rate the
+origin-side counters report. **An edge failure rate materially above the origin
+rate is the finding this whole pipeline exists to produce**: it is the share of
+attempts that origin never saw.
+
+For a like-for-like comparison against origin, add `AND proxied_body` — without
+it the denominator includes inline uploads that origin never sees by design, and
+the edge failure rate comes out artificially *low*.
+
+### 2. How many die before ever reaching origin?
+
+This is the population that has no record anywhere else.
+
+```sql
+SELECT
+    toDate(timestamp)                              AS day,
+    countIf(outcome = 'send_failed')               AS never_reached_origin,
+    count()                                        AS attempts,
+    round(100 * countIf(outcome = 'send_failed') / count(), 3) AS pct_invisible
+FROM nostr.edge_upload_logs
+WHERE route = 'direct_put'
+  AND timestamp >= now() - INTERVAL 30 DAY
+GROUP BY day
+ORDER BY day;
+```
+
+Break the failures down by cause:
+
+```sql
+SELECT send_error, count() AS n, round(avg(proxy_duration_ms)) AS avg_ms
+FROM nostr.edge_upload_logs
+WHERE outcome = 'send_failed'
+  AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY send_error
+ORDER BY n DESC;
+```
+
+### 3. What does the duration distribution look like against the 120s ceiling?
+
+Fastly's request timeout is 120s. Whether real uploads approach it is the open
+question this investigation keeps circling.
+
+```sql
+SELECT
+    outcome,
+    count()                                   AS n,
+    quantile(0.50)(duration_ms)               AS p50,
+    quantile(0.95)(duration_ms)               AS p95,
+    quantile(0.99)(duration_ms)               AS p99,
+    max(duration_ms)                          AS max_ms,
+    countIf(duration_ms > 110000)             AS within_10s_of_ceiling,
+    countIf(duration_ms >= 120000)            AS at_or_past_ceiling
+FROM nostr.edge_upload_logs
+WHERE route = 'direct_put'
+  AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY outcome
+ORDER BY n DESC;
+```
+
+A cluster of `send_failed` rows with `proxy_duration_ms` near 120000 is direct
+evidence of edge timeouts. A `p99` far below it rules the theory out. Either
+result settles the question.
+
+**Caveat on this query.** It can only count requests whose handler returned. If
+Fastly terminates the guest outright at the timeout, or the client disconnects
+mid-upload and the instance is torn down, no line is emitted at all. So
+`at_or_past_ceiling` is a **floor**, not a measurement — the true number of
+timeout deaths is at least this, possibly higher. Cross-check against origin's
+"prematurely closed connection" count (6–14/day) and against total attempts: a
+`direct_put` line count *below* the origin-side count of direct PUTs reaching
+origin would indicate exactly this kind of silent loss.
+
+### 4. Does failure concentrate in large uploads or particular networks?
+
+```sql
+SELECT
+    multiIf(content_length < 262144,   '<256KB',
+            content_length < 1048576,  '256KB-1MB',
+            content_length < 8388608,  '1-8MB',
+            content_length < 33554432, '8-32MB',
+                                       '>32MB')    AS size_bucket,
+    count()                                        AS attempts,
+    countIf(outcome != 'ok')                       AS failures,
+    round(100 * countIf(outcome != 'ok') / count(), 2) AS pct_failed,
+    quantile(0.95)(duration_ms)                    AS p95_ms
+FROM nostr.edge_upload_logs
+WHERE route = 'direct_put'
+  AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY size_bucket
+ORDER BY min(content_length);
+```
+
+Origin session records put p50 at 0.09 MB and p99 at 7.94 MB, so most traffic
+lands in the smallest two buckets; a failure rate that climbs with size is the
+"bad connections" hypothesis showing up in data.
+
+By country, to separate "one network is bad" from "everything is bad":
+
+```sql
+SELECT client_geo_country, count() AS attempts,
+       round(100 * countIf(outcome != 'ok') / count(), 2) AS pct_failed
+FROM nostr.edge_upload_logs
+WHERE route = 'direct_put'
+  AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY client_geo_country
+HAVING attempts > 50
+ORDER BY pct_failed DESC;
+```
+
+## Related
+
+- `docs/runbooks/cdn-view-counting.md` — the existing Fastly → Pub/Sub →
+  ClickHouse pipeline this one is modelled on (different service:
+  `ML7R82HKfmTaqTpHExIDVN`, the VCL service)
+- divine-iac-core PR #1618 — origin-side log-based metrics and Grafana dashboard,
+  which this sits in front of
+- `docs/runbooks/deployment.md` — deploy traps

--- a/docs/runbooks/edge-upload-observability.md
+++ b/docs/runbooks/edge-upload-observability.md
@@ -108,10 +108,17 @@ chmod 600 "$KEY_FILE"
 
 Create the `edge_upload_logs` Google Cloud Pub/Sub endpoint in the Fastly
 dashboard using the JSON file's `client_email` and `private_key` fields, then
-activate that service version. Delete the local key immediately; the trap does
-so when the shell exits. Do not pass the private key to `fastly logging
-googlepubsub create`: that command accepts the key only as an argument, which
-exposes it in process metadata.
+activate that service version. Immediately delete the local key and disarm the
+normal-exit cleanup after it succeeds:
+
+```bash
+rm -f "$KEY_FILE"
+trap - EXIT
+```
+
+The EXIT trap remains the abnormal-path backstop until those commands run. Do
+not pass the private key to `fastly logging googlepubsub create`: that command
+accepts the key only as an argument, which exposes it in process metadata.
 
 The endpoint name **must** be `edge_upload_logs`; it is matched by
 `UPLOAD_LOG_ENDPOINT` in `src/upload_log.rs`.
@@ -211,6 +218,14 @@ ENGINE = MergeTree
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (route, outcome, timestamp);
 ```
+
+The subscriber must normalize messages before `JSONEachRow` insertion. Schema 2
+already carries `occurred_at_ms`. For retained schema-1 messages, which predate
+that field, set `occurred_at_ms` from the Pub/Sub message's server-assigned
+publish time. Do not insert a missing value as zero or use ClickHouse insertion
+time: either choice moves delayed backlog into the wrong query window. Reject
+unknown future schema versions rather than silently applying the schema-1
+fallback.
 
 ## Schema
 

--- a/docs/runbooks/edge-upload-observability.md
+++ b/docs/runbooks/edge-upload-observability.md
@@ -75,6 +75,7 @@ fastly logging googlepubsub list --service-id pOvEEWykEbpnylqst1KTrR --version a
 ### Recreating it from scratch
 
 ```bash
+umask 077
 PROJECT=rich-compiler-479518-d2
 SERVICE=pOvEEWykEbpnylqst1KTrR
 
@@ -95,24 +96,22 @@ gcloud pubsub topics add-iam-policy-binding edge-upload-logs \
   --role="roles/pubsub.publisher" \
   --project="$PROJECT"
 
-gcloud iam service-accounts keys create /tmp/edge-upload-logs-key.json \
+KEY_FILE=$(mktemp)
+trap 'rm -f "$KEY_FILE"' EXIT
+
+gcloud iam service-accounts keys create "$KEY_FILE" \
   --iam-account="fastly-edge-upload-logs@${PROJECT}.iam.gserviceaccount.com" \
   --project="$PROJECT"
 
-python3 -c "import json;k=json.load(open('/tmp/edge-upload-logs-key.json'));open('/tmp/pk.pem','w').write(k['private_key'])"
-
-fastly logging googlepubsub create \
-  --service-id "$SERVICE" \
-  --version active --autoclone \
-  --name edge_upload_logs \
-  --project-id "$PROJECT" \
-  --topic edge-upload-logs \
-  --user "fastly-edge-upload-logs@${PROJECT}.iam.gserviceaccount.com" \
-  --secret-key="$(cat /tmp/pk.pem)" \
-  --non-interactive
-
-rm -f /tmp/edge-upload-logs-key.json /tmp/pk.pem
+chmod 600 "$KEY_FILE"
 ```
+
+Create the `edge_upload_logs` Google Cloud Pub/Sub endpoint in the Fastly
+dashboard using the JSON file's `client_email` and `private_key` fields, then
+activate that service version. Delete the local key immediately; the trap does
+so when the shell exits. Do not pass the private key to `fastly logging
+googlepubsub create`: that command accepts the key only as an argument, which
+exposes it in process metadata.
 
 The endpoint name **must** be `edge_upload_logs`; it is matched by
 `UPLOAD_LOG_ENDPOINT` in `src/upload_log.rs`.
@@ -123,11 +122,8 @@ to this one topic.
 
 ### Traps
 
-- **`--secret-key` must use the `=` form.** The PEM body begins with `-----`, and
-  the CLI's argument parser reads a space-separated value starting with dashes as
-  a flag. `--secret-key "$(cat pk.pem)"` fails with
-  `expected argument for flag '--secret-key'`; `--secret-key="$(cat pk.pem)"`
-  works.
+- **Do not use the CLI's `--secret-key` flag.** It has no file or stdin form, so
+  the private key would be visible in process metadata.
 - **`fastly logging googlepubsub describe` prints the full private key** to
   stdout, in both the default and `--json` output. Never paste its output into a
   PR, an issue, a ticket, or a shared transcript. Use `list` when you only need
@@ -191,7 +187,8 @@ Proposed table for whoever picks this up:
 ```sql
 CREATE TABLE nostr.edge_upload_logs
 (
-    timestamp         DateTime DEFAULT now(),
+    occurred_at_ms    UInt64,
+    timestamp         DateTime64(3) MATERIALIZED fromUnixTimestamp64Milli(toInt64(occurred_at_ms)),
     schema            UInt32,
     route             LowCardinality(String),
     outcome           LowCardinality(String),
@@ -225,6 +222,7 @@ the stream without per-row key checks.
 | field | type | meaning |
 |---|---|---|
 | `schema` | int | Field-set version. Bumped on incompatible changes. Currently `2`; version 1 named `origin_responded` as `origin_reached`. |
+| `occurred_at_ms` | int | Request occurrence time in Unix epoch milliseconds; use this rather than delayed sink insertion time |
 | `route` | string | `direct_put`, `resumable_init`, `resumable_complete` |
 | `outcome` | string | see below |
 | `req_id` | string | Correlation ID, also sent to origin as `X-Request-Id` |

--- a/docs/runbooks/edge-upload-observability.md
+++ b/docs/runbooks/edge-upload-observability.md
@@ -271,6 +271,14 @@ following a `Nostr` or `Bearer` scheme keyword with `[redacted]`. The control
 character stripping is not cosmetic: a raw newline in an error message would
 split one record into two on a line-delimited sink.
 
+No auth error message currently echoes the `Authorization` header — they are all
+fixed strings — so the credential redaction is defence in depth rather than a fix
+for a known leak. The field that genuinely carries external content is
+`error_message` on `origin_status_error`: `extract_upload_service_error_message`
+falls back to the raw origin response body when it cannot parse an `error` field
+out of it. That body is upstream text this service does not control, which is why
+it is capped and scrubbed rather than logged verbatim.
+
 ## Correlation with origin logs
 
 The edge sends its `req_id` to origin as an `X-Request-Id` header on all three

--- a/docs/runbooks/edge-upload-observability.md
+++ b/docs/runbooks/edge-upload-observability.md
@@ -32,7 +32,7 @@ change that case had **zero** record anywhere.
 
 | flow | route | through Fastly? | logged here? |
 |---|---|---|---|
-| direct `PUT /upload` | via `media.divine.video`, full body proxied | yes | **yes** (`direct_put`) |
+| direct `PUT /upload` | via `media.divine.video`; body proxied to origin only above 500 KB or for video, otherwise stored inline by the edge | yes | **yes** (`direct_put`) |
 | resumable `POST /upload/init` | via `media.divine.video` | yes | **yes** (`resumable_init`) |
 | resumable `POST /upload/{id}/complete` | via `media.divine.video` | yes | **yes** (`resumable_complete`) |
 | resumable chunk `PUT /sessions/{id}` | client → `upload.divine.video` direct | **no** | no — bypasses the edge entirely |
@@ -61,9 +61,14 @@ are dashboard-managed. The logging endpoint is the same. Consequences:
   just stops
 
 There is no automated backstop for this today. The mitigation in code is that
-every line is also written to stderr, so `fastly log-tail` keeps working as a
-fallback and the loss is discoverable rather than invisible. That is a fallback,
-not a fix: stderr is ephemeral.
+every line is also written to stderr, so `fastly log-tail` still shows the lines.
+
+**Do not over-trust that mitigation.** `log-tail` is both ephemeral *and* lossy —
+measured, see the note under Verification. It is enough to confirm the guest is
+still emitting, and not enough to notice that the sink stopped receiving. If the
+endpoint is deleted, the realistic detection path is someone querying the sink
+and finding a gap, which is exactly the delayed, manual detection this warning
+exists to flag.
 
 To check the endpoint still exists on the active version:
 

--- a/docs/runbooks/edge-upload-observability.md
+++ b/docs/runbooks/edge-upload-observability.md
@@ -365,24 +365,25 @@ SELECT count() FROM nostr.edge_upload_logs
 WHERE route = 'direct_put' AND proxied_body AND timestamp >= today();
 ```
 
-Observed on 2026-08-13: one `PUT /upload` in a five-minute window against 2963
-total routed requests, i.e. roughly 12/hour or ~290/day of direct PUTs at the
-edge. That is consistent with the 241–523/day origin figure, but it is a
-five-minute sample taken through `log-tail` — which is itself lossy, see below —
-and should not be treated as a rate measurement.
+Measured over the first 13.3 hours (450 records, 2026-08-13 10:17Z–23:33Z):
 
-Both branches of the threshold were seen in real traffic the same day, which is
-worth knowing when reading the data:
+| | count | per day |
+|---|---|---|
+| `direct_put` total | 329 | ~595 |
+| `direct_put` proxied (`proxied_body = true`) | 176 | ~319 |
+| `direct_put` inline | 153 | ~276 |
+| `resumable_init` | 58 | ~105 |
+| `resumable_complete` | 63 | ~114 |
 
-| observed | `content_length` | `content_type` | `proxied_body` | `origin_status` | `proxy_duration_ms` |
-|---|---|---|---|---|---|
-| proxied because video | 5016 | `video/mp4` | true | 200 | 757 |
-| proxied because video | 5016 | `video/mp4` | true | 200 | 617 |
-| inline, under threshold | 100126 | `image/jpeg` | false | null | null |
+The **319/day proxied** figure sits inside the 241–523/day origin baseline, while
+the 595/day total does not — which is the expected result once the inline path is
+excluded, and is the cross-check that the instrumentation is counting the right
+things. `resumable_init` at ~105/day likewise matches the 62–103/day origin
+figure for resumable sessions.
 
-Note the 5 KB `video/mp4` files: the video MIME check fires at *any* size, so
-small videos proxy while much larger images do not. Size alone does not predict
-which path a request took — read `proxied_body`.
+Note that the video MIME check fires at *any* size, so 5 KB `video/mp4` files
+proxy while a 100 KB `image/jpeg` does not. Size alone does not predict which
+path a request took — read `proxied_body`.
 
 Other origin-side baselines for comparison: ~96–98% of direct PUTs return 200;
 408s run 1–6/day, 400s 4–10/day, 413s 1–5/day; client aborts mid-upload

--- a/docs/runbooks/edge-upload-observability.md
+++ b/docs/runbooks/edge-upload-observability.md
@@ -18,15 +18,12 @@ record of doing so. Every measurement channel was missing at once:
 - this service logged only via `eprintln!`, which reaches `fastly log-tail` and
   nothing else
 
-Origin-side counters (divine-iac-core PR #1618) show ~94–96% of upload attempts
-succeeding, which does not match the volume of user complaints. The leading
-explanation is that failures at the edge are invisible: anything Fastly rejects
-or times out never reaches origin and therefore appears in no origin metric.
-
-The single most important field is `send_error`. When the proxy `send` to origin
-fails, the request never reached `divine-upload-server`, so it appears in no
-origin access log and in none of PR #1618's log-based metrics. Before this
-change that case had **zero** record anywhere.
+Origin-side counters cannot account for requests that fail at the edge before a
+complete origin response is received. The single most important field is
+`send_error`: it records those edge-visible failures independently of origin
+logging. A send error does not prove whether origin received or processed some
+or all of the request; correlate it with origin logs before drawing that
+conclusion.
 
 ## Scope
 
@@ -44,8 +41,7 @@ forwards only `Host`, `Authorization`, `Content-Type`, `Content-Length`,
 `Dart/3.12 (dart:io)` on chunk PUTs (client direct) and `-` on direct PUTs
 (edge-proxied).
 
-Sampling is not applied. Volume is a few hundred requests per day; every request
-is logged.
+Sampling is not applied; every request on the listed routes is logged.
 
 ## Where the config lives — read this before trusting the data
 
@@ -203,7 +199,7 @@ CREATE TABLE nostr.edge_upload_logs
     content_length    Nullable(UInt64),
     content_type      LowCardinality(Nullable(String)),
     proxied_body      Bool,
-    origin_reached    Bool,
+    origin_responded  Bool,
     origin_status     Nullable(UInt16),
     send_error        Nullable(String),
     proxy_duration_ms Nullable(UInt64),
@@ -228,16 +224,16 @@ the stream without per-row key checks.
 
 | field | type | meaning |
 |---|---|---|
-| `schema` | int | Field-set version. Bumped on incompatible changes. Currently `1`. |
+| `schema` | int | Field-set version. Bumped on incompatible changes. Currently `2`; version 1 named `origin_responded` as `origin_reached`. |
 | `route` | string | `direct_put`, `resumable_init`, `resumable_complete` |
 | `outcome` | string | see below |
 | `req_id` | string | Correlation ID, also sent to origin as `X-Request-Id` |
 | `content_length` | int? | **Declared** size, not measured — the body is never buffered. On `resumable_init` this is the declared *upload* size from the JSON body, not the control message's own length. |
 | `content_type` | string? | Separates video uploads from avatars and thumbnails |
 | `proxied_body` | bool | Whether a request body was streamed through the edge to origin |
-| `origin_reached` | bool | Whether origin was asked and answered |
+| `origin_responded` | bool | Whether origin returned a complete HTTP response. `false` does not prove origin received none of the request. |
 | `origin_status` | int? | Origin's HTTP status, when it replied at all |
-| `send_error` | string? | The error from `.send()`. **Populated only when origin was never reached.** |
+| `send_error` | string? | The error from `.send()` when no complete origin response was received |
 | `proxy_duration_ms` | int? | Wall time around the origin send, present whenever a send was attempted — including when it failed |
 | `duration_ms` | int | Wall time for the whole request at the edge |
 | `response_status` | int | What the edge returned to the client |
@@ -250,11 +246,11 @@ the stream without per-row key checks.
 
 | outcome | meaning |
 |---|---|
-| `ok` | Edge returned a success status. On `direct_put` this includes uploads handled entirely at the edge, which have `origin_reached = false` — see the inline-path note under Verification. |
-| `send_failed` | The send to origin failed. **The request never reached origin**, so nothing origin-side accounts for it. |
+| `ok` | Edge returned a success status. On `direct_put` this includes uploads handled entirely at the edge, which have `origin_responded = false` — see the inline-path note under Verification. |
+| `send_failed` | The send did not yield a complete origin response. Origin may still have received or processed the request. |
 | `origin_status_error` | Origin replied with a non-success status |
 | `validation_rejected` | Edge returned a 4xx of its own |
-| `edge_error` | Edge returned a 5xx of its own. With `origin_reached = true` this is a *post-origin* failure: the upload landed but the edge failed afterwards. |
+| `edge_error` | Edge returned a 5xx of its own. With `origin_responded = true` this is a *post-response* failure: origin replied successfully but the edge failed afterwards. |
 
 Classification is ordered: a failed send outranks everything, then a non-2xx
 origin status, then the edge's own status. This matters because both a failed
@@ -333,27 +329,21 @@ fastly log-tail --service-id pOvEEWykEbpnylqst1KTrR | grep '\[UPLOAD\]'
 `POST /upload/{id}/complete` requests issued during an active `log-tail` produced
 **no output at all** — not even the `[BLOSSOM ROUTE]` line that `handle_request`
 emits unconditionally for every request before any routing runs. All five were
-present in Pub/Sub. The tail samples across POPs and drops under load; the
-service handles thousands of requests per minute, of which uploads are a
-handful.
+present in Pub/Sub. The tail samples across POPs and can drop lines under load.
 
 Use `log-tail` to answer "is the guest emitting the shape I expect?", which it
 does well and immediately. Use Pub/Sub to answer "how many?", which `log-tail`
 cannot answer at all. An absence in `log-tail` is not evidence of anything.
 
-### Sanity-check the volume — and mind the inline path
-
-Direct `PUT /upload` reaching *origin* runs 241–523/day. Edge `direct_put` lines
-should be **materially higher**, and not only because of edge failures.
+### Mind the inline path when comparing datasets
 
 `handle_upload` proxies to the upload service only when the upload is larger
 than 500 KB *or* has a video MIME type (`UPLOAD_SERVICE_THRESHOLD`,
 `src/main.rs`). Everything else is buffered and stored by the edge itself and
-**never contacts origin at all**. Origin session records put p50 upload size at
-0.09 MB with 92% `image/jpeg`, so the majority of direct PUTs take the inline
-path and are absent from origin's direct-PUT counts by design.
+**never contacts origin at all**, so those requests are absent from origin's
+direct-PUT counts by design.
 
-Such a request logs `outcome = ok`, `origin_reached = false`,
+Such a request logs `outcome = ok`, `origin_responded = false`,
 `proxied_body = false`, `origin_status = null`, `proxy_duration_ms = null`. That
 is **normal, not a failure**, and it is not a `send_failed`. Any query comparing
 edge to origin counts must filter on `proxied_body = true` to compare like with
@@ -365,31 +355,9 @@ SELECT count() FROM nostr.edge_upload_logs
 WHERE route = 'direct_put' AND proxied_body AND timestamp >= today();
 ```
 
-Measured over the first 13.3 hours (450 records, 2026-08-13 10:17Z–23:33Z):
-
-| | count | per day |
-|---|---|---|
-| `direct_put` total | 329 | ~595 |
-| `direct_put` proxied (`proxied_body = true`) | 176 | ~319 |
-| `direct_put` inline | 153 | ~276 |
-| `resumable_init` | 58 | ~105 |
-| `resumable_complete` | 63 | ~114 |
-
-The **319/day proxied** figure sits inside the 241–523/day origin baseline, while
-the 595/day total does not — which is the expected result once the inline path is
-excluded, and is the cross-check that the instrumentation is counting the right
-things. `resumable_init` at ~105/day likewise matches the 62–103/day origin
-figure for resumable sessions.
-
 Note that the video MIME check fires at *any* size, so 5 KB `video/mp4` files
 proxy while a 100 KB `image/jpeg` does not. Size alone does not predict which
 path a request took — read `proxied_body`.
-
-Other origin-side baselines for comparison: ~96–98% of direct PUTs return 200;
-408s run 1–6/day, 400s 4–10/day, 413s 1–5/day; client aborts mid-upload
-("prematurely closed connection") run 6–14/day. Resumable sessions run
-62–103/day at 96.8–100% completion. Upload sizes are p50 0.09 MB, p99 7.94 MB,
-max 18.47 MB; 92% `image/jpeg`, 8% `video/mp4`.
 
 ## Worked queries
 
@@ -411,25 +379,23 @@ GROUP BY route, outcome
 ORDER BY route, n DESC;
 ```
 
-Compare the `direct_put` non-`ok` share against the ~4–6% failure rate the
-origin-side counters report. **An edge failure rate materially above the origin
-rate is the finding this whole pipeline exists to produce**: it is the share of
-attempts that origin never saw.
+Compare the `direct_put` non-`ok` share with origin-side counters, while treating
+the two datasets as overlapping rather than disjoint. A send error may have a
+corresponding partial or complete origin request even though the edge received
+no complete response.
 
 For a like-for-like comparison against origin, add `AND proxied_body` — without
 it the denominator includes inline uploads that origin never sees by design, and
 the edge failure rate comes out artificially *low*.
 
-### 2. How many die before ever reaching origin?
-
-This is the population that has no record anywhere else.
+### 2. How many receive no complete origin response?
 
 ```sql
 SELECT
     toDate(timestamp)                              AS day,
-    countIf(outcome = 'send_failed')               AS never_reached_origin,
+    countIf(outcome = 'send_failed')               AS no_complete_origin_response,
     count()                                        AS attempts,
-    round(100 * countIf(outcome = 'send_failed') / count(), 3) AS pct_invisible
+    round(100 * countIf(outcome = 'send_failed') / count(), 3) AS pct_send_failed
 FROM nostr.edge_upload_logs
 WHERE route = 'direct_put'
   AND timestamp >= now() - INTERVAL 30 DAY
@@ -470,18 +436,16 @@ GROUP BY outcome
 ORDER BY n DESC;
 ```
 
-A cluster of `send_failed` rows with `proxy_duration_ms` near 120000 is direct
-evidence of edge timeouts. A `p99` far below it rules the theory out. Either
-result settles the question.
+A cluster of `send_failed` rows with `proxy_duration_ms` near 120000 is evidence
+that the edge did not receive complete responses before its timeout. It does not
+by itself establish whether the client, edge-to-origin stream, or origin stalled.
 
 **Caveat on this query.** It can only count requests whose handler returned. If
 Fastly terminates the guest outright at the timeout, or the client disconnects
 mid-upload and the instance is torn down, no line is emitted at all. So
-`at_or_past_ceiling` is a **floor**, not a measurement — the true number of
-timeout deaths is at least this, possibly higher. Cross-check against origin's
-"prematurely closed connection" count (6–14/day) and against total attempts: a
-`direct_put` line count *below* the origin-side count of direct PUTs reaching
-origin would indicate exactly this kind of silent loss.
+`at_or_past_ceiling` is a **floor**, not a complete measurement. Cross-check it
+against origin logs and total attempts to look for requests missing from the
+edge dataset.
 
 ### 4. Does failure concentrate in large uploads or particular networks?
 
@@ -503,9 +467,8 @@ GROUP BY size_bucket
 ORDER BY min(content_length);
 ```
 
-Origin session records put p50 at 0.09 MB and p99 at 7.94 MB, so most traffic
-lands in the smallest two buckets; a failure rate that climbs with size is the
-"bad connections" hypothesis showing up in data.
+A failure rate that climbs with size is evidence for investigating slow or
+interrupted request streams, not proof of which hop caused them.
 
 By country, to separate "one network is bad" from "everything is bad":
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,7 @@ use fastly::kv_store::KVStore;
 use fastly::{Error, Request, Response};
 use sha2::{Digest, Sha256};
 use std::time::Duration;
+use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// TTL for cached HLS manifests (1 hour) — immutable once transcoding completes
@@ -289,12 +290,12 @@ fn with_upload_log<F>(req: Request, route: UploadRoute, handler: F) -> Result<Re
 where
     F: FnOnce(Request, &mut UploadLogRecord) -> Result<Response>,
 {
-    let started = upload_log::now_millis();
+    let started = Instant::now();
     let mut record = upload_log::start_record(&req, route, req_id::for_request(&req));
 
     let result = handler(req, &mut record);
 
-    record.duration_ms = upload_log::now_millis().saturating_sub(started);
+    record.duration_ms = duration_millis(started.elapsed());
     match &result {
         Ok(resp) => record_response(&mut record, resp.get_status().as_u16()),
         Err(e) => record_failure(&mut record, e),
@@ -311,9 +312,9 @@ where
 /// log-based metrics, will ever account for it. The timing is captured before
 /// the match so it survives that path too.
 fn send_to_upload_service(proxy_req: Request, record: &mut UploadLogRecord) -> Result<Response> {
-    let started = upload_log::now_millis();
+    let started = Instant::now();
     let sent = proxy_req.send(UPLOAD_SERVICE_BACKEND);
-    let elapsed = upload_log::now_millis().saturating_sub(started);
+    let elapsed = duration_millis(started.elapsed());
 
     match sent {
         Ok(resp) => {
@@ -333,6 +334,10 @@ fn send_to_upload_service(proxy_req: Request, record: &mut UploadLogRecord) -> R
             )))
         }
     }
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    duration.as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 fn classify_audio_reuse_availability(result: &Result<bool>) -> AudioReuseAvailability {
@@ -3977,6 +3982,11 @@ fn handle_upload_complete(
             ));
         }
     }
+
+    // The request body is a small control message; log the completed upload's
+    // declared media size and type so completion rows match init rows.
+    record.content_length = Some(complete_response.size);
+    record.content_type = Some(complete_response.content_type.clone());
 
     publish_upload_service_upload(
         auth,

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,10 +307,10 @@ where
 
 /// Send a prepared request to the upload service, recording the attempt.
 ///
-/// A failed `send` is the case with no record anywhere else: the request never
-/// reached origin, so no origin access log, and none of the origin-side
-/// log-based metrics, will ever account for it. The timing is captured before
-/// the match so it survives that path too.
+/// A failed `send` means the edge received no complete origin response. Origin
+/// may still have received or processed some or all of the request, so this is
+/// deliberately not described as evidence that origin was never reached. The
+/// timing is captured before the match so it survives that path too.
 fn send_to_upload_service(proxy_req: Request, record: &mut UploadLogRecord) -> Result<Response> {
     let started = Instant::now();
     let sent = proxy_req.send(UPLOAD_SERVICE_BACKEND);

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod metadata;
 mod rate_limit;
 mod req_id;
 mod storage;
+mod upload_log;
 mod viewer_auth;
 
 use crate::auth::{diagnose_viewer_auth, validate_auth, validate_hash_match, viewer_pubkey};
@@ -49,6 +50,10 @@ use crate::storage::{
 use crate::viewer_auth::{ViewerAuthDiagnostics, ViewerAuthState};
 use blossom_core::cache_policy::{
     immutable_blob_cache_headers, mutable_derivative_cache_headers,
+};
+use blossom_core::upload_log::{
+    record_failure, record_response, record_send_attempt, OriginSendResult, UploadLogRecord,
+    UploadRoute,
 };
 use fastly_blossom::resumable_complete::parse_resumable_complete_request_body;
 
@@ -142,16 +147,20 @@ fn handle_request(req: Request) -> Result<Response> {
         (Method::HEAD, p) if is_hash_path(p) => handle_head_blob(p),
 
         // BUD-02: Upload
-        (Method::PUT, "/upload") => handle_upload(req),
+        (Method::PUT, "/upload") => with_upload_log(req, UploadRoute::DirectPut, handle_upload),
         // BUD-06: Upload requirements/pre-validation
         (Method::HEAD, "/upload") => handle_upload_requirements(req),
         // Synchronous audio transcription — thin forward to the upload service's
         // authenticated /transcribe proxy (which calls the transcoder).
         (Method::POST, "/transcribe") => handle_transcribe_proxy(req),
         // Divine resumable control plane
-        (Method::POST, "/upload/init") => handle_upload_init(req),
+        (Method::POST, "/upload/init") => {
+            with_upload_log(req, UploadRoute::ResumableInit, handle_upload_init)
+        }
         (Method::POST, p) if p.starts_with("/upload/") && p.ends_with("/complete") => {
-            handle_upload_complete(req, p)
+            with_upload_log(req, UploadRoute::ResumableComplete, |req, record| {
+                handle_upload_complete(req, p, record)
+            })
         }
 
         // BUD-02: Delete
@@ -267,6 +276,63 @@ fn media_viewer_context(
 
 fn log_media_outcome(route: &str, diagnostics: &ViewerAuthDiagnostics, outcome: &str) {
     eprintln!("{}", format_media_auth_log(route, diagnostics, outcome));
+}
+
+/// Run an edge-proxied upload handler and emit exactly one structured log line
+/// for it, whatever the outcome.
+///
+/// The wrapper owns emission rather than the handlers because handlers have
+/// many early returns via `?`. Logging inside them would mean one emit site per
+/// return, and the failure paths — the entire reason this exists — are the ones
+/// most likely to be missed.
+fn with_upload_log<F>(req: Request, route: UploadRoute, handler: F) -> Result<Response>
+where
+    F: FnOnce(Request, &mut UploadLogRecord) -> Result<Response>,
+{
+    let started = upload_log::now_millis();
+    let mut record = upload_log::start_record(&req, route, req_id::for_request(&req));
+
+    let result = handler(req, &mut record);
+
+    record.duration_ms = upload_log::now_millis().saturating_sub(started);
+    match &result {
+        Ok(resp) => record_response(&mut record, resp.get_status().as_u16()),
+        Err(e) => record_failure(&mut record, e),
+    }
+
+    upload_log::emit(&record);
+    result
+}
+
+/// Send a prepared request to the upload service, recording the attempt.
+///
+/// A failed `send` is the case with no record anywhere else: the request never
+/// reached origin, so no origin access log, and none of the origin-side
+/// log-based metrics, will ever account for it. The timing is captured before
+/// the match so it survives that path too.
+fn send_to_upload_service(proxy_req: Request, record: &mut UploadLogRecord) -> Result<Response> {
+    let started = upload_log::now_millis();
+    let sent = proxy_req.send(UPLOAD_SERVICE_BACKEND);
+    let elapsed = upload_log::now_millis().saturating_sub(started);
+
+    match sent {
+        Ok(resp) => {
+            record_send_attempt(
+                record,
+                OriginSendResult::Replied(resp.get_status().as_u16()),
+                elapsed,
+            );
+            Ok(resp)
+        }
+        Err(e) => {
+            let message = e.to_string();
+            record_send_attempt(record, OriginSendResult::Failed(&message), elapsed);
+            Err(BlossomError::Internal(format!(
+                "Failed to proxy to upload service: {}",
+                message
+            )))
+        }
+    }
 }
 
 fn classify_audio_reuse_availability(result: &Result<bool>) -> AudioReuseAvailability {
@@ -3148,7 +3214,7 @@ fn trigger_moderation_scan(sha256: &str, pubkey: &str) {
 }
 
 /// PUT /upload - Upload blob
-fn handle_upload(mut req: Request) -> Result<Response> {
+fn handle_upload(mut req: Request, record: &mut UploadLogRecord) -> Result<Response> {
     // Validate auth
     let auth = validate_auth(&req, AuthAction::Upload)?;
 
@@ -3186,7 +3252,14 @@ fn handle_upload(mut req: Request) -> Result<Response> {
     if !crate::storage::is_local_mode()
         && (content_length > UPLOAD_SERVICE_THRESHOLD || is_video_mime_type(&content_type))
     {
-        return handle_upload_service_proxy(req, auth, content_type, content_length, base_url);
+        return handle_upload_service_proxy(
+            req,
+            auth,
+            content_type,
+            content_length,
+            base_url,
+            record,
+        );
     }
 
     // For small files (or all files in local mode), buffer in memory
@@ -3714,7 +3787,7 @@ fn publish_upload_service_upload(
     Ok(resp)
 }
 
-fn handle_upload_init(mut req: Request) -> Result<Response> {
+fn handle_upload_init(mut req: Request, record: &mut UploadLogRecord) -> Result<Response> {
     let auth = validate_auth(&req, AuthAction::Upload)?;
     let auth_header = extract_authorization_header(&req)?;
     let base_url = get_base_url(&req);
@@ -3726,6 +3799,12 @@ fn handle_upload_init(mut req: Request) -> Result<Response> {
 
     let init_request: ResumableUploadInitRequest = serde_json::from_str(&body)
         .map_err(|e| BlossomError::BadRequest(format!("Invalid JSON: {}", e)))?;
+
+    // Overwrite the header-derived values: on this route the request body is a
+    // small JSON control message, so its own Content-Length says nothing useful.
+    // The declared upload size is what makes init lines comparable to direct_put.
+    record.content_length = Some(init_request.size);
+    record.content_type = Some(init_request.content_type.clone());
 
     if init_request.size == 0 {
         return Err(BlossomError::BadRequest(
@@ -3792,11 +3871,10 @@ fn handle_upload_init(mut req: Request) -> Result<Response> {
     proxy_req.set_header(header::AUTHORIZATION, &auth_header);
     proxy_req.set_header(header::CONTENT_TYPE, "application/json");
     proxy_req.set_header(header::CONTENT_LENGTH, body.len().to_string());
+    proxy_req.set_header(upload_log::CORRELATION_HEADER, &record.req_id);
     proxy_req.set_body(body);
 
-    let mut proxy_resp = proxy_req
-        .send(UPLOAD_SERVICE_BACKEND)
-        .map_err(|e| BlossomError::Internal(format!("Failed to proxy to Cloud Run: {}", e)))?;
+    let mut proxy_resp = send_to_upload_service(proxy_req, record)?;
     if !proxy_resp.get_status().is_success() {
         let status = proxy_resp.get_status();
         let body = proxy_resp.take_body().into_string();
@@ -3805,7 +3883,9 @@ fn handle_upload_init(mut req: Request) -> Result<Response> {
 
     let response_body = proxy_resp.take_body().into_string();
     let init_response: ResumableUploadInitResponse = serde_json::from_str(&response_body)
-        .map_err(|e| BlossomError::Internal(format!("Invalid Cloud Run init response: {}", e)))?;
+        .map_err(|e| {
+            BlossomError::Internal(format!("Invalid upload service init response: {}", e))
+        })?;
 
     let mut resp = json_response(StatusCode::OK, &init_response);
     add_upload_capability_headers(&mut resp, &control_host);
@@ -3835,7 +3915,11 @@ fn upload_from_resumable_completion(
     }
 }
 
-fn handle_upload_complete(mut req: Request, path: &str) -> Result<Response> {
+fn handle_upload_complete(
+    mut req: Request,
+    path: &str,
+    record: &mut UploadLogRecord,
+) -> Result<Response> {
     let auth = validate_auth(&req, AuthAction::Upload)?;
     let auth_header = extract_authorization_header(&req)?;
     let base_url = get_base_url(&req);
@@ -3866,15 +3950,14 @@ fn handle_upload_complete(mut req: Request, path: &str) -> Result<Response> {
     );
     proxy_req.set_header("Host", UPLOAD_SERVICE_HOST);
     proxy_req.set_header(header::AUTHORIZATION, &auth_header);
+    proxy_req.set_header(upload_log::CORRELATION_HEADER, &record.req_id);
     if expected_request_hash.is_some() {
         proxy_req.set_header(header::CONTENT_TYPE, "application/json");
         proxy_req.set_header(header::CONTENT_LENGTH, request_body.len().to_string());
         proxy_req.set_body(request_body);
     }
 
-    let mut proxy_resp = proxy_req
-        .send(UPLOAD_SERVICE_BACKEND)
-        .map_err(|e| BlossomError::Internal(format!("Failed to proxy to Cloud Run: {}", e)))?;
+    let mut proxy_resp = send_to_upload_service(proxy_req, record)?;
     if !proxy_resp.get_status().is_success() {
         let status = proxy_resp.get_status();
         let body = proxy_resp.take_body().into_string();
@@ -3884,7 +3967,7 @@ fn handle_upload_complete(mut req: Request, path: &str) -> Result<Response> {
     let response_body = proxy_resp.take_body().into_string();
     let complete_response: ResumableUploadCompleteResponse = serde_json::from_str(&response_body)
         .map_err(|e| {
-        BlossomError::Internal(format!("Invalid Cloud Run completion response: {}", e))
+        BlossomError::Internal(format!("Invalid upload service completion response: {}", e))
     })?;
 
     if let Some(ref request_hash) = expected_request_hash {
@@ -4009,6 +4092,7 @@ fn handle_upload_service_proxy(
     content_type: String,
     content_length: u64,
     base_url: String,
+    record: &mut UploadLogRecord,
 ) -> Result<Response> {
     let auth_header = extract_authorization_header(&req)?;
 
@@ -4024,14 +4108,13 @@ fn handle_upload_service_proxy(
     proxy_req.set_header(header::AUTHORIZATION, &auth_header);
     proxy_req.set_header(header::CONTENT_TYPE, &content_type);
     proxy_req.set_header(header::CONTENT_LENGTH, content_length.to_string());
+    proxy_req.set_header(upload_log::CORRELATION_HEADER, &record.req_id);
     proxy_req.set_body(body);
+    record.proxied_body = true;
 
-    // Send to Cloud Run
-    let mut proxy_resp = proxy_req
-        .send(UPLOAD_SERVICE_BACKEND)
-        .map_err(|e| BlossomError::Internal(format!("Failed to proxy to Cloud Run: {}", e)))?;
+    let mut proxy_resp = send_to_upload_service(proxy_req, record)?;
 
-    // Check for errors from Cloud Run
+    // Check for errors from the upload service
     if !proxy_resp.get_status().is_success() {
         let status = proxy_resp.get_status();
         let body = proxy_resp.take_body().into_string();

--- a/src/upload_log.rs
+++ b/src/upload_log.rs
@@ -5,6 +5,7 @@ use blossom_core::upload_log::{format_upload_log, UploadLogRecord, UploadRoute};
 use fastly::http::header;
 use fastly::Request;
 use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Name of the Fastly logging endpoint that carries these lines.
 ///
@@ -27,7 +28,11 @@ pub(crate) fn start_record(
     route: UploadRoute,
     req_id: String,
 ) -> UploadLogRecord {
-    let mut record = UploadLogRecord::new(route, req_id);
+    let occurred_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0);
+    let mut record = UploadLogRecord::new(route, req_id, occurred_at_ms);
 
     record.content_length = req
         .get_header(header::CONTENT_LENGTH)

--- a/src/upload_log.rs
+++ b/src/upload_log.rs
@@ -1,0 +1,77 @@
+// ABOUTME: Fastly glue that builds and emits upload log records to the durable endpoint
+// ABOUTME: Keeps request-shaped concerns out of the pure formatter in blossom-core
+
+use blossom_core::upload_log::{format_upload_log, UploadLogRecord, UploadRoute};
+use fastly::http::header;
+use fastly::Request;
+use std::io::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Name of the Fastly logging endpoint that carries these lines.
+///
+/// The endpoint itself lives in Fastly service configuration, not in this
+/// repo, so it is invisible to git and absent from any service rebuilt from
+/// scratch. Writes to a missing endpoint are dropped silently by the platform.
+/// See `docs/runbooks/edge-upload-observability.md` for how to recreate it.
+pub(crate) const UPLOAD_LOG_ENDPOINT: &str = "edge_upload_logs";
+
+/// Header used to correlate an edge log line with the origin's access log.
+pub(crate) const CORRELATION_HEADER: &str = "X-Request-Id";
+
+/// Milliseconds since the epoch.
+///
+/// `SystemTime` rather than `Instant` to match `req_id.rs`, which is the only
+/// other clock user in this crate.
+pub(crate) fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Seed a record from the inbound request.
+///
+/// Reads declared headers only. It must never touch the body: buffering a
+/// request body here to measure it would defeat the streaming proxy on exactly
+/// the large uploads this instrumentation exists to observe.
+pub(crate) fn start_record(
+    req: &Request,
+    route: UploadRoute,
+    req_id: String,
+) -> UploadLogRecord {
+    let mut record = UploadLogRecord::new(route, req_id);
+
+    record.content_length = req
+        .get_header(header::CONTENT_LENGTH)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok());
+
+    record.content_type = req
+        .get_header(header::CONTENT_TYPE)
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.to_string());
+
+    // Country code only: enough to tell "uploads fail on one network" from
+    // "uploads fail everywhere", without carrying anything identifying.
+    if let Some(ip) = req.get_client_ip_addr() {
+        record.client_ip_present = true;
+        record.client_geo_country =
+            fastly::geo::geo_lookup(ip).map(|geo| geo.country_code().to_string());
+    }
+
+    record
+}
+
+/// Write one record to the durable sink.
+///
+/// Also mirrored to stderr. That is deliberate redundancy, not duplication:
+/// the endpoint is dashboard-managed config that this repo cannot assert on,
+/// and if it is ever deleted the platform drops writes without erroring. The
+/// stderr copy keeps `fastly log-tail` working as a fallback and makes the
+/// loss observable rather than silent.
+pub(crate) fn emit(record: &UploadLogRecord) {
+    let line = format_upload_log(record);
+    let mut endpoint = fastly::log::Endpoint::from_name(UPLOAD_LOG_ENDPOINT);
+    let _ = writeln!(endpoint, "{}", line);
+    eprintln!("[UPLOAD] {}", line);
+}

--- a/src/upload_log.rs
+++ b/src/upload_log.rs
@@ -5,7 +5,6 @@ use blossom_core::upload_log::{format_upload_log, UploadLogRecord, UploadRoute};
 use fastly::http::header;
 use fastly::Request;
 use std::io::Write;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Name of the Fastly logging endpoint that carries these lines.
 ///
@@ -17,17 +16,6 @@ pub(crate) const UPLOAD_LOG_ENDPOINT: &str = "edge_upload_logs";
 
 /// Header used to correlate an edge log line with the origin's access log.
 pub(crate) const CORRELATION_HEADER: &str = "X-Request-Id";
-
-/// Milliseconds since the epoch.
-///
-/// `SystemTime` rather than `Instant` to match `req_id.rs`, which is the only
-/// other clock user in this crate.
-pub(crate) fn now_millis() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
-}
 
 /// Seed a record from the inbound request.
 ///
@@ -67,11 +55,12 @@ pub(crate) fn start_record(
 /// Also mirrored to stderr. That is deliberate redundancy, not duplication:
 /// the endpoint is dashboard-managed config that this repo cannot assert on,
 /// and if it is ever deleted the platform drops writes without erroring. The
-/// stderr copy keeps `fastly log-tail` working as a fallback and makes the
-/// loss observable rather than silent.
+/// stderr copy keeps `fastly log-tail` useful for confirming that the guest is
+/// still emitting, though Pub/Sub remains the only durable count.
 pub(crate) fn emit(record: &UploadLogRecord) {
     let line = format_upload_log(record);
-    let mut endpoint = fastly::log::Endpoint::from_name(UPLOAD_LOG_ENDPOINT);
-    let _ = writeln!(endpoint, "{}", line);
+    if let Ok(mut endpoint) = fastly::log::Endpoint::try_from_name(UPLOAD_LOG_ENDPOINT) {
+        let _ = writeln!(endpoint, "{}", line);
+    }
     eprintln!("[UPLOAD] {}", line);
 }


### PR DESCRIPTION
## Summary

Adds one structured JSON upload-observability record for each edge request on:

- `PUT /upload`
- `POST /upload/init`
- `POST /upload/{id}/complete`

Records are sent to the configured Fastly Google Cloud Pub/Sub logging endpoint
and mirrored to stderr. Resumable chunk uploads are excluded because clients
send them directly to the upload service.

## Motivation

Origin logs cannot fully describe failures seen by the edge. This adds an
independent edge record, including send errors, response status, request-time
durations, route, declared media metadata, and a correlation ID. A send error
means the edge received no complete origin response; it does not by itself prove
whether origin received or processed the request.

## Implementation

- Keeps record formatting and outcome classification in `blossom-core` so the
  logic runs in the repository's executed unit-test suite.
- Emits from a router wrapper so early handler returns are recorded.
- Forwards `X-Request-Id` to the upload service on the three proxied routes.
- Uses monotonic clocks for durations and request occurrence time for delayed
  sink delivery.
- Sanitizes and bounds free-text fields and does not read request bodies or
  authorization headers for logging.
- Documents sink recreation, key handling, schema migration, and query examples
  in `docs/runbooks/edge-upload-observability.md`.

## Follow-up

Issue #201 tracks upload behavior improvements separately. The Pub/Sub to
ClickHouse subscriber and origin access-log correlation are also separate work.

## Validation

- `cargo check --tests --locked`
- `cargo test -p blossom-core --locked`
- `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked`
- `cargo test --manifest-path cloud-run-transcoder/Cargo.toml --locked`
- `cargo clippy --locked --all-targets --all-features`
- `cargo check --target wasm32-wasip1 --locked`
- Both repository Python unittest suites

No visual change.
