### PR TITLE
fix(legacy-media): backfill Bunny Stream GUID blobs

### DIFF
--- a/scripts/migration/DIVINE_VIDEO_ARCHITECTURE.md
+++ b/scripts/migration/DIVINE_VIDEO_ARCHITECTURE.md
@@ -115,7 +115,9 @@ which calls the upload service with `expected_hash` and creates the metadata
 needed for public `media.divine.video/{sha256}` reads. The script is dry-run by
 default; pass `--execute` only when ready to write verified bytes and metadata.
 The `--target upload-service` mode is storage-only and should be used only when
-metadata already exists or will be backfilled separately.
+metadata already exists or will be backfilled separately. Each target uses a
+separate default progress file so a storage-only run cannot suppress a later
+Blossom metadata backfill.
 For auth-protected legacy sources, add `--local-upload-fallback` so the script
 fetches with Blossom `get` auth, verifies the SHA-256 locally, then writes
 through Blossom `/upload`.

--- a/scripts/migration/DIVINE_VIDEO_ARCHITECTURE.md
+++ b/scripts/migration/DIVINE_VIDEO_ARCHITECTURE.md
@@ -118,6 +118,9 @@ The `--target upload-service` mode is storage-only and should be used only when
 metadata already exists or will be backfilled separately. Each target uses a
 separate default progress file so a storage-only run cannot suppress a later
 Blossom metadata backfill.
+Blossom writes require `NOSTR_NSEC` to be injected by the operator's credential
+manager. Newly created metadata is owned by that durable migration identity;
+do not use an ephemeral key or place an nsec in command-line arguments.
 For auth-protected legacy sources, add `--local-upload-fallback` so the script
 fetches with Blossom `get` auth, verifies the SHA-256 locally, then writes
 through Blossom `/upload`.

--- a/scripts/migration/DIVINE_VIDEO_ARCHITECTURE.md
+++ b/scripts/migration/DIVINE_VIDEO_ARCHITECTURE.md
@@ -97,13 +97,28 @@ Blobs may exist on multiple legacy servers:
 | Server | Notes |
 |--------|-------|
 | `https://cdn.divine.video` | Primary old CDN |
-| `https://stream.divine.video` | Streaming server |
+| `https://stream.divine.video` | Retired Bunny Stream hostname; legacy GUID paths must be mapped from event `imeta` `x` tags and backfilled to Blossom, not served live. |
 | `https://blossom.divine.video` | Old blossom server |
 
 ### URL Patterns
 - `/{sha256}` - Raw hash
 - `/{sha256}.mp4` - With extension
 - `/{sha256}.jpg` - Thumbnails
+
+### Bunny Stream GUID Backfill
+
+Some retired Bunny Stream events reference GUID-shaped `stream.divine.video`
+paths while carrying the canonical Blossom SHA-256 in the same `imeta` tag's
+`x` field. Use `scripts/migration/backfill_bunny_stream_guid_blobs.py` to
+extract those mappings and mirror them through Blossom's `/mirror` endpoint,
+which calls the upload service with `expected_hash` and creates the metadata
+needed for public `media.divine.video/{sha256}` reads. The script is dry-run by
+default; pass `--execute` only when ready to write verified bytes and metadata.
+The `--target upload-service` mode is storage-only and should be used only when
+metadata already exists or will be backfilled separately.
+For auth-protected legacy sources, add `--local-upload-fallback` so the script
+fetches with Blossom `get` auth, verifies the SHA-256 locally, then writes
+through Blossom `/upload`.
 
 ## Blossom Protocol Authentication
 

--- a/scripts/migration/DIVINE_VIDEO_ARCHITECTURE.md
+++ b/scripts/migration/DIVINE_VIDEO_ARCHITECTURE.md
@@ -120,7 +120,9 @@ separate default progress file so a storage-only run cannot suppress a later
 Blossom metadata backfill.
 Blossom writes require `NOSTR_NSEC` to be injected by the operator's credential
 manager. Newly created metadata is owned by that durable migration identity;
-do not use an ephemeral key or place an nsec in command-line arguments.
+original event authors are not automatically added to `/list` or granted delete
+ownership. Do not use an ephemeral key or place an nsec in command-line
+arguments.
 For auth-protected legacy sources, add `--local-upload-fallback` so the script
 fetches with Blossom `get` auth, verifies the SHA-256 locally, then writes
 through Blossom `/upload`.
@@ -287,7 +289,7 @@ For migration scripts:
 export GCS_ACCESS_KEY="GOOG1..."
 export GCS_SECRET_KEY="..."
 export GCS_BUCKET="divine-blossom-media-staging"
-export NOSTR_NSEC=""  # Optional - auto-generates if not set
+# Inject NOSTR_NSEC with the credential manager for the GUID backfill script.
 ```
 
 ## Python Dependencies

--- a/scripts/migration/backfill_bunny_stream_guid_blobs.py
+++ b/scripts/migration/backfill_bunny_stream_guid_blobs.py
@@ -9,6 +9,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import os
 import re
 import time
 from dataclasses import dataclass, replace
@@ -205,10 +206,14 @@ async def fetch_all_events(relay_url: str, since: int | None, until: int | None)
             while True:
                 try:
                     msg = await asyncio.wait_for(ws.recv(), timeout=30)
-                except asyncio.TimeoutError:
-                    break
-                except ConnectionClosed:
-                    break
+                except asyncio.TimeoutError as exc:
+                    raise RuntimeError(
+                        f"Relay timed out before EOSE on page {page}; backfill aborted"
+                    ) from exc
+                except ConnectionClosed as exc:
+                    raise RuntimeError(
+                        f"Relay disconnected before EOSE on page {page}; backfill aborted"
+                    ) from exc
 
                 data = json.loads(msg)
                 if data[0] == "EVENT":
@@ -248,6 +253,13 @@ def save_progress(path: Path, done: set[str]) -> None:
     path.write_text(json.dumps(sorted(done), indent=2) + "\n")
 
 
+def select_pending_candidates(
+    candidates: list[BackfillCandidate], done: set[str], limit: int | None
+) -> list[BackfillCandidate]:
+    pending = [candidate for candidate in candidates if candidate.sha256 not in done]
+    return pending[:limit] if limit else pending
+
+
 async def migrate_candidate(session, migrate_url: str, candidate: BackfillCandidate) -> tuple[str, str]:
     for source_url in candidate.source_urls:
         payload = {
@@ -273,7 +285,14 @@ async def migrate_candidate(session, migrate_url: str, candidate: BackfillCandid
     return "not_found", last_error if "last_error" in locals() else "no source URLs"
 
 
-def load_nostr_keys(nsec: str | None):
+def load_nostr_keys():
+    nsec = os.environ.get("NOSTR_NSEC")
+    if not nsec:
+        raise SystemExit(
+            "NOSTR_NSEC is required for Blossom writes. Inject it with the operator's "
+            "credential manager instead of passing secret material on the command line."
+        )
+
     try:
         from nostr_sdk import Keys
     except ModuleNotFoundError as exc:
@@ -282,9 +301,7 @@ def load_nostr_keys(nsec: str | None):
             "with `python3 -m pip install aiohttp websockets nostr-sdk`."
         ) from exc
 
-    if nsec:
-        return Keys.parse(nsec)
-    return Keys.generate()
+    return Keys.parse(nsec)
 
 
 def create_blossom_auth_header(keys, action: str, sha256: str) -> str:
@@ -388,15 +405,12 @@ async def run_backfill(args) -> None:
         for candidate in extract_candidates(event)
     )
     total_candidates = len(candidates)
-    if args.limit:
-        candidates = candidates[: args.limit]
-
     done = load_progress(args.progress_file)
-    pending = [candidate for candidate in candidates if candidate.sha256 not in done]
+    pending = select_pending_candidates(candidates, done, args.limit)
 
     print(
         f"events={len(events)} candidates={total_candidates} "
-        f"selected={len(candidates)} done={len(done)} pending={len(pending)}"
+        f"selected={len(pending)} done={len(done)} pending={len(pending)}"
     )
     if not args.execute:
         for candidate in pending[:10]:
@@ -414,7 +428,7 @@ async def run_backfill(args) -> None:
             "with `python3 -m pip install aiohttp websockets`."
         ) from exc
 
-    keys = load_nostr_keys(args.nsec) if args.target == "blossom" else None
+    keys = load_nostr_keys() if args.target == "blossom" else None
     stats = {"ok": 0, "migrated": 0, "already_present": 0, "not_found": 0, "failed": 0}
     connector = aiohttp.TCPConnector(limit=args.concurrency)
     async with aiohttp.ClientSession(connector=connector) as session:
@@ -464,7 +478,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--mirror-url", default=MIRROR_URL)
     parser.add_argument("--upload-url", default=UPLOAD_URL)
     parser.add_argument("--migrate-url", default=MIGRATE_URL)
-    parser.add_argument("--nsec", help="Nostr nsec for Blossom upload auth. Defaults to a generated migration key.")
     parser.add_argument(
         "--local-upload-fallback",
         action="store_true",

--- a/scripts/migration/backfill_bunny_stream_guid_blobs.py
+++ b/scripts/migration/backfill_bunny_stream_guid_blobs.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+# ABOUTME: Backfill legacy Bunny Stream GUID media whose event imeta tags carry Blossom hashes.
+# ABOUTME: Mirrors through Blossom so verified bytes and public metadata are restored together.
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import re
+import time
+import base64
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Iterable
+from urllib.parse import urlparse
+
+
+RELAY_URL = "wss://relay.divine.video"
+MIRROR_URL = "https://media.divine.video/mirror"
+UPLOAD_URL = "https://media.divine.video/upload"
+MIGRATE_URL = "https://upload.divine.video/migrate"
+CDN_BASE_URL = "https://cdn.divine.video"
+PROGRESS_FILE = Path("bunny_stream_guid_backfill_progress.json")
+KINDS = [34235, 34236]
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+GUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class BackfillCandidate:
+    sha256: str
+    guid: str
+    event_id: str
+    pubkey: str
+    created_at: int
+    source_urls: tuple[str, ...]
+
+
+def parse_imeta_tag(tag: list) -> dict:
+    """Parse both known imeta tag encodings and preserve repeated URL fields."""
+    result = {}
+    urls = []
+    images = []
+    entries = tag[1:]
+
+    if entries and isinstance(entries[0], str) and " " in entries[0]:
+        for entry in entries:
+            if not isinstance(entry, str) or " " not in entry:
+                continue
+            key, value = entry.split(" ", 1)
+            if key == "url":
+                urls.append(value)
+            elif key == "image":
+                images.append(value)
+                result[key] = value
+            else:
+                result[key] = value
+    else:
+        i = 0
+        while i < len(entries) - 1:
+            key = entries[i]
+            value = entries[i + 1]
+            if key == "url":
+                urls.append(value)
+            elif key == "image":
+                images.append(value)
+                result[key] = value
+            else:
+                result[key] = value
+            i += 2
+
+    result["urls"] = urls
+    result["images"] = images
+    if urls:
+        result["url"] = urls[0]
+    return result
+
+
+def normalize_sha256(value: str | None) -> str | None:
+    if not value:
+        return None
+    value = value.lower()
+    if SHA256_RE.match(value):
+        return value
+    return None
+
+
+def filename_sha256(url: str) -> str | None:
+    filename = urlparse(url).path.rsplit("/", 1)[-1].split(".", 1)[0].lower()
+    return normalize_sha256(filename)
+
+
+def stream_guid_from_url(url: str) -> str | None:
+    parsed = urlparse(url)
+    if parsed.hostname != "stream.divine.video":
+        return None
+    first_segment = parsed.path.strip("/").split("/", 1)[0]
+    if GUID_RE.match(first_segment):
+        return first_segment.lower()
+    return None
+
+
+def source_urls_for_sha(imeta: dict, sha256: str) -> tuple[str, ...]:
+    urls = []
+    for url in imeta.get("urls", []):
+        parsed = urlparse(url)
+        if parsed.hostname == "cdn.divine.video" and filename_sha256(url) == sha256:
+            urls.append(url)
+
+    urls.extend([
+        f"{CDN_BASE_URL}/{sha256}",
+        f"{CDN_BASE_URL}/{sha256}.mp4",
+    ])
+
+    deduped = []
+    seen = set()
+    for url in urls:
+        if url not in seen:
+            deduped.append(url)
+            seen.add(url)
+    return tuple(deduped)
+
+
+def extract_candidates(event: dict) -> list[BackfillCandidate]:
+    candidates = []
+    for tag in event.get("tags", []):
+        if not tag or tag[0] != "imeta":
+            continue
+
+        imeta = parse_imeta_tag(tag)
+        sha256 = normalize_sha256(imeta.get("x"))
+        if not sha256:
+            continue
+
+        media_urls = [*imeta.get("urls", []), *imeta.get("images", [])]
+        guid = next((g for g in (stream_guid_from_url(url) for url in media_urls) if g), None)
+        if not guid:
+            continue
+
+        candidates.append(
+            BackfillCandidate(
+                sha256=sha256,
+                guid=guid,
+                event_id=event.get("id", ""),
+                pubkey=event.get("pubkey", ""),
+                created_at=int(event.get("created_at", 0)),
+                source_urls=source_urls_for_sha(imeta, sha256),
+            )
+        )
+    return candidates
+
+
+def dedupe_candidates(candidates: Iterable[BackfillCandidate]) -> list[BackfillCandidate]:
+    by_hash: dict[str, BackfillCandidate] = {}
+    for candidate in candidates:
+        existing = by_hash.get(candidate.sha256)
+        if existing is None:
+            by_hash[candidate.sha256] = candidate
+            continue
+
+        merged_urls = tuple(dict.fromkeys([*existing.source_urls, *candidate.source_urls]))
+        by_hash[candidate.sha256] = replace(existing, source_urls=merged_urls)
+
+    return sorted(by_hash.values(), key=lambda c: (c.created_at, c.sha256))
+
+
+async def fetch_all_events(relay_url: str, since: int | None, until: int | None) -> list[dict]:
+    try:
+        import websockets
+        from websockets.exceptions import ConnectionClosed
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            "Missing dependency: websockets. Install migration script dependencies "
+            "with `python3 -m pip install aiohttp websockets`."
+        ) from exc
+
+    all_events = []
+    seen_ids = set()
+    batch_limit = 5000
+    page_until = until
+
+    async with websockets.connect(relay_url) as ws:
+        page = 0
+        while True:
+            page += 1
+            filter_obj = {"kinds": KINDS, "limit": batch_limit}
+            if since is not None:
+                filter_obj["since"] = since
+            if page_until is not None:
+                filter_obj["until"] = page_until
+
+            sub_id = f"bunny_guid_backfill_{page}"
+            await ws.send(json.dumps(["REQ", sub_id, filter_obj]))
+
+            batch_events = []
+            oldest_timestamp = None
+            while True:
+                try:
+                    msg = await asyncio.wait_for(ws.recv(), timeout=30)
+                except asyncio.TimeoutError:
+                    break
+                except ConnectionClosed:
+                    break
+
+                data = json.loads(msg)
+                if data[0] == "EVENT":
+                    event = data[2]
+                    event_id = event.get("id")
+                    if event_id and event_id in seen_ids:
+                        continue
+                    if event_id:
+                        seen_ids.add(event_id)
+                    batch_events.append(event)
+                    created_at = event.get("created_at", 0)
+                    if oldest_timestamp is None or created_at < oldest_timestamp:
+                        oldest_timestamp = created_at
+                elif data[0] == "EOSE":
+                    break
+                elif data[0] == "NOTICE":
+                    print(f"Relay notice: {data[1]}")
+
+            await ws.send(json.dumps(["CLOSE", sub_id]))
+            all_events.extend(batch_events)
+
+            if len(batch_events) < batch_limit or oldest_timestamp is None:
+                break
+            page_until = oldest_timestamp - 1
+
+    return all_events
+
+
+def load_progress(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    with path.open() as f:
+        return set(json.load(f))
+
+
+def save_progress(path: Path, done: set[str]) -> None:
+    path.write_text(json.dumps(sorted(done), indent=2) + "\n")
+
+
+async def migrate_candidate(session, migrate_url: str, candidate: BackfillCandidate) -> tuple[str, str]:
+    for source_url in candidate.source_urls:
+        payload = {
+            "source_url": source_url,
+            "expected_hash": candidate.sha256,
+        }
+        if candidate.pubkey:
+            payload["owner"] = candidate.pubkey
+
+        async with session.post(migrate_url, json=payload) as resp:
+            text = await resp.text()
+            if resp.status != 200:
+                last_error = f"{source_url} -> HTTP {resp.status}: {text[:200]}"
+                continue
+
+            body = json.loads(text)
+            if body.get("sha256") != candidate.sha256:
+                return "failed", f"{source_url} -> migrate returned wrong hash {body.get('sha256')}"
+            if body.get("migrated"):
+                return "migrated", source_url
+            return "already_present", source_url
+
+    return "not_found", last_error if "last_error" in locals() else "no source URLs"
+
+
+def load_nostr_keys(nsec: str | None):
+    try:
+        from nostr_sdk import Keys
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            "Missing dependency: nostr-sdk. Install migration script dependencies "
+            "with `python3 -m pip install aiohttp websockets nostr-sdk`."
+        ) from exc
+
+    if nsec:
+        return Keys.parse(nsec)
+    return Keys.generate()
+
+
+def create_blossom_auth_header(keys, action: str, sha256: str) -> str:
+    from nostr_sdk import EventBuilder, Kind, Tag
+
+    expiration = int(time.time()) + 300
+    builder = EventBuilder(Kind(24242), "").tags([
+        Tag.parse(["t", action]),
+        Tag.parse(["x", sha256]),
+        Tag.parse(["expiration", str(expiration)]),
+    ])
+    if hasattr(builder, "sign_with_keys"):
+        event = builder.sign_with_keys(keys)
+    else:
+        event = keys.sign_event(builder.finalize_unsigned(keys.public_key()))
+    return "Nostr " + base64.b64encode(event.as_json().encode()).decode()
+
+
+def should_try_local_upload(detail: str) -> bool:
+    return "MIGRATION_NSEC" in detail or "requires auth" in detail
+
+
+async def upload_bytes_from_source(
+    session,
+    upload_url: str,
+    keys,
+    candidate: BackfillCandidate,
+    source_url: str,
+) -> tuple[str, str]:
+    get_headers = {
+        "Authorization": create_blossom_auth_header(keys, "get", candidate.sha256),
+    }
+    async with session.get(source_url, headers=get_headers) as resp:
+        if resp.status != 200:
+            text = await resp.text()
+            return "not_found", f"{source_url} authenticated GET -> HTTP {resp.status}: {text[:200]}"
+        content_type = resp.headers.get("Content-Type", "application/octet-stream")
+        body = await resp.read()
+
+    actual_hash = hashlib.sha256(body).hexdigest()
+    if actual_hash != candidate.sha256:
+        return "failed", f"{source_url} local hash mismatch: expected {candidate.sha256}, got {actual_hash}"
+
+    upload_headers = {
+        "Authorization": create_blossom_auth_header(keys, "upload", candidate.sha256),
+        "Content-Type": content_type,
+    }
+    async with session.put(upload_url, data=body, headers=upload_headers) as resp:
+        text = await resp.text()
+        if resp.status not in (200, 201):
+            return "failed", f"{upload_url} -> HTTP {resp.status}: {text[:200]}"
+        descriptor = json.loads(text)
+        if descriptor.get("sha256") != candidate.sha256:
+            return "failed", f"{upload_url} -> upload returned wrong hash {descriptor.get('sha256')}"
+        return "ok", f"{source_url} -> local authenticated upload"
+
+
+async def mirror_candidate(
+    session,
+    mirror_url: str,
+    upload_url: str,
+    keys,
+    candidate: BackfillCandidate,
+    local_upload_fallback: bool,
+) -> tuple[str, str]:
+    fallback_sources = []
+    for source_url in candidate.source_urls:
+        headers = {
+            "Authorization": create_blossom_auth_header(keys, "upload", candidate.sha256),
+            "Content-Type": "application/json",
+        }
+        async with session.put(mirror_url, json={"url": source_url}, headers=headers) as resp:
+            text = await resp.text()
+            if resp.status != 200:
+                last_error = f"{source_url} -> HTTP {resp.status}: {text[:200]}"
+                if should_try_local_upload(last_error):
+                    fallback_sources.append(source_url)
+                continue
+
+            body = json.loads(text)
+            if body.get("sha256") != candidate.sha256:
+                return "failed", f"{source_url} -> mirror returned wrong hash {body.get('sha256')}"
+            return "ok", source_url
+
+    if local_upload_fallback:
+        for source_url in fallback_sources:
+            status, detail = await upload_bytes_from_source(
+                session, upload_url, keys, candidate, source_url
+            )
+            if status == "ok":
+                return status, detail
+
+    return "not_found", last_error if "last_error" in locals() else "no source URLs"
+
+
+async def run_backfill(args) -> None:
+    events = await fetch_all_events(args.relay_url, args.since, args.until)
+    candidates = dedupe_candidates(
+        candidate
+        for event in events
+        for candidate in extract_candidates(event)
+    )
+    total_candidates = len(candidates)
+    if args.limit:
+        candidates = candidates[: args.limit]
+
+    done = load_progress(args.progress_file)
+    pending = [candidate for candidate in candidates if candidate.sha256 not in done]
+
+    print(
+        f"events={len(events)} candidates={total_candidates} "
+        f"selected={len(candidates)} done={len(done)} pending={len(pending)}"
+    )
+    if not args.execute:
+        for candidate in pending[:10]:
+            print(f"dry-run {candidate.sha256} guid={candidate.guid} source={candidate.source_urls[0]}")
+        if len(pending) > 10:
+            print(f"dry-run ... {len(pending) - 10} more")
+        print("Dry run only. Pass --execute to call the selected write endpoint.")
+        return
+
+    try:
+        import aiohttp
+    except ModuleNotFoundError as exc:
+        raise SystemExit(
+            "Missing dependency: aiohttp. Install migration script dependencies "
+            "with `python3 -m pip install aiohttp websockets`."
+        ) from exc
+
+    keys = load_nostr_keys(args.nsec) if args.target == "blossom" else None
+    stats = {"ok": 0, "migrated": 0, "already_present": 0, "not_found": 0, "failed": 0}
+    connector = aiohttp.TCPConnector(limit=args.concurrency)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        for offset in range(0, len(pending), args.concurrency):
+            batch = pending[offset: offset + args.concurrency]
+            if args.target == "blossom":
+                results = await asyncio.gather(
+                    *(
+                        mirror_candidate(
+                            session,
+                            args.mirror_url,
+                            args.upload_url,
+                            keys,
+                            candidate,
+                            args.local_upload_fallback,
+                        )
+                        for candidate in batch
+                    )
+                )
+            else:
+                results = await asyncio.gather(
+                    *(migrate_candidate(session, args.migrate_url, candidate) for candidate in batch)
+                )
+            for candidate, (status, detail) in zip(batch, results):
+                stats[status] += 1
+                if status in ("ok", "migrated", "already_present"):
+                    done.add(candidate.sha256)
+                if args.verbose or status not in ("ok", "migrated", "already_present"):
+                    print(f"{status} {candidate.sha256} {detail}")
+            save_progress(args.progress_file, done)
+
+    print("complete " + " ".join(f"{key}={value}" for key, value in stats.items()))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill Blossom blobs for Bunny Stream GUID-era events."
+    )
+    parser.add_argument("--execute", action="store_true", help="Call the selected write endpoint. Default is dry-run.")
+    parser.add_argument(
+        "--target",
+        choices=["blossom", "upload-service"],
+        default="blossom",
+        help="Use Blossom /mirror for storage plus metadata, or upload-service /migrate for storage only.",
+    )
+    parser.add_argument("--relay-url", default=RELAY_URL)
+    parser.add_argument("--mirror-url", default=MIRROR_URL)
+    parser.add_argument("--upload-url", default=UPLOAD_URL)
+    parser.add_argument("--migrate-url", default=MIGRATE_URL)
+    parser.add_argument("--nsec", help="Nostr nsec for Blossom upload auth. Defaults to a generated migration key.")
+    parser.add_argument(
+        "--local-upload-fallback",
+        action="store_true",
+        help="For auth-protected legacy sources, fetch locally with Nostr get auth, verify SHA, then PUT /upload.",
+    )
+    parser.add_argument("--progress-file", type=Path, default=PROGRESS_FILE)
+    parser.add_argument("--since", type=int, help="Relay since timestamp.")
+    parser.add_argument("--until", type=int, help="Relay until timestamp.")
+    parser.add_argument("--limit", type=int, help="Only process the first N deduped candidates.")
+    parser.add_argument("--concurrency", type=int, default=5)
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    asyncio.run(run_backfill(parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migration/backfill_bunny_stream_guid_blobs.py
+++ b/scripts/migration/backfill_bunny_stream_guid_blobs.py
@@ -250,7 +250,13 @@ def load_progress(path: Path) -> set[str]:
 
 
 def save_progress(path: Path, done: set[str]) -> None:
-    path.write_text(json.dumps(sorted(done), indent=2) + "\n")
+    temporary_path = path.with_suffix(path.suffix + ".tmp")
+    with temporary_path.open("w") as f:
+        json.dump(sorted(done), f, indent=2)
+        f.write("\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(temporary_path, path)
 
 
 def select_pending_candidates(
@@ -494,6 +500,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         args.progress_file = PROGRESS_FILES[args.target]
     if args.concurrency < 1:
         parser.error("--concurrency must be at least 1")
+    if args.limit is not None and args.limit < 1:
+        parser.error("--limit must be at least 1")
     return args
 
 

--- a/scripts/migration/backfill_bunny_stream_guid_blobs.py
+++ b/scripts/migration/backfill_bunny_stream_guid_blobs.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import hashlib
 import json
 import re
 import time
-import base64
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Iterable
@@ -22,7 +22,10 @@ MIRROR_URL = "https://media.divine.video/mirror"
 UPLOAD_URL = "https://media.divine.video/upload"
 MIGRATE_URL = "https://upload.divine.video/migrate"
 CDN_BASE_URL = "https://cdn.divine.video"
-PROGRESS_FILE = Path("bunny_stream_guid_backfill_progress.json")
+PROGRESS_FILES = {
+    "blossom": Path("bunny_stream_guid_backfill_progress.json"),
+    "upload-service": Path("bunny_stream_guid_upload_service_backfill_progress.json"),
+}
 KINDS = [34235, 34236]
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 GUID_RE = re.compile(
@@ -446,7 +449,7 @@ async def run_backfill(args) -> None:
     print("complete " + " ".join(f"{key}={value}" for key, value in stats.items()))
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Backfill Blossom blobs for Bunny Stream GUID-era events."
     )
@@ -467,13 +470,18 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="For auth-protected legacy sources, fetch locally with Nostr get auth, verify SHA, then PUT /upload.",
     )
-    parser.add_argument("--progress-file", type=Path, default=PROGRESS_FILE)
+    parser.add_argument("--progress-file", type=Path)
     parser.add_argument("--since", type=int, help="Relay since timestamp.")
     parser.add_argument("--until", type=int, help="Relay until timestamp.")
     parser.add_argument("--limit", type=int, help="Only process the first N deduped candidates.")
     parser.add_argument("--concurrency", type=int, default=5)
     parser.add_argument("--verbose", action="store_true")
-    return parser.parse_args()
+    args = parser.parse_args(argv)
+    if args.progress_file is None:
+        args.progress_file = PROGRESS_FILES[args.target]
+    if args.concurrency < 1:
+        parser.error("--concurrency must be at least 1")
+    return args
 
 
 def main() -> None:

--- a/scripts/tests/test_backfill_bunny_stream_guid_blobs.py
+++ b/scripts/tests/test_backfill_bunny_stream_guid_blobs.py
@@ -5,8 +5,10 @@ import contextlib
 import io
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "migration"))
 
@@ -14,8 +16,10 @@ from backfill_bunny_stream_guid_blobs import (  # noqa: E402
     BackfillCandidate,
     dedupe_candidates,
     extract_candidates,
+    load_nostr_keys,
     parse_args,
     parse_imeta_tag,
+    save_progress,
     select_pending_candidates,
     stream_guid_from_url,
 )
@@ -162,10 +166,22 @@ class TestArguments(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 parse_args(["--nsec", "secret"])
 
+    def test_blossom_writes_require_injected_nsec(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(SystemExit, "NOSTR_NSEC is required"):
+                load_nostr_keys()
+
     def test_rejects_non_positive_concurrency(self):
         with contextlib.redirect_stderr(io.StringIO()):
             with self.assertRaises(SystemExit):
                 parse_args(["--concurrency", "0"])
+
+    def test_rejects_non_positive_limit(self):
+        for value in ("0", "-1"):
+            with self.subTest(value=value):
+                with contextlib.redirect_stderr(io.StringIO()):
+                    with self.assertRaises(SystemExit):
+                        parse_args(["--limit", value])
 
 
 class TestPendingSelection(unittest.TestCase):
@@ -185,6 +201,19 @@ class TestPendingSelection(unittest.TestCase):
         pending = select_pending_candidates(candidates, {candidates[0].sha256}, 1)
 
         self.assertEqual(pending, [candidates[1]])
+
+
+class TestProgress(unittest.TestCase):
+    def test_failed_atomic_replace_preserves_existing_progress(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "progress.json"
+            path.write_text('["old"]\n')
+
+            with mock.patch("os.replace", side_effect=OSError("interrupted")):
+                with self.assertRaises(OSError):
+                    save_progress(path, {"new"})
+
+            self.assertEqual(path.read_text(), '["old"]\n')
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_backfill_bunny_stream_guid_blobs.py
+++ b/scripts/tests/test_backfill_bunny_stream_guid_blobs.py
@@ -1,15 +1,19 @@
 # ABOUTME: Tests for legacy Bunny Stream GUID extraction and migrate candidate construction.
 # ABOUTME: Keeps the one-shot backfill script honest without touching the network.
 
+import contextlib
+import io
 import os
 import sys
 import unittest
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "migration"))
 
 from backfill_bunny_stream_guid_blobs import (  # noqa: E402
     dedupe_candidates,
     extract_candidates,
+    parse_args,
     parse_imeta_tag,
     stream_guid_from_url,
 )
@@ -118,6 +122,31 @@ class TestGuidParsing(unittest.TestCase):
         )
         self.assertIsNone(stream_guid_from_url(f"https://cdn.divine.video/{GUID}/thumbnail.jpg"))
         self.assertIsNone(stream_guid_from_url("https://stream.divine.video/not-a-guid/thumbnail.jpg"))
+
+
+class TestArguments(unittest.TestCase):
+    def test_write_targets_use_separate_default_progress_files(self):
+        blossom_args = parse_args([])
+        upload_service_args = parse_args(["--target", "upload-service"])
+
+        self.assertEqual(
+            blossom_args.progress_file,
+            Path("bunny_stream_guid_backfill_progress.json"),
+        )
+        self.assertEqual(
+            upload_service_args.progress_file,
+            Path("bunny_stream_guid_upload_service_backfill_progress.json"),
+        )
+
+    def test_explicit_progress_file_is_preserved(self):
+        args = parse_args(["--progress-file", "custom-progress.json"])
+
+        self.assertEqual(args.progress_file, Path("custom-progress.json"))
+
+    def test_rejects_non_positive_concurrency(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                parse_args(["--concurrency", "0"])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_backfill_bunny_stream_guid_blobs.py
+++ b/scripts/tests/test_backfill_bunny_stream_guid_blobs.py
@@ -11,10 +11,12 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "migration"))
 
 from backfill_bunny_stream_guid_blobs import (  # noqa: E402
+    BackfillCandidate,
     dedupe_candidates,
     extract_candidates,
     parse_args,
     parse_imeta_tag,
+    select_pending_candidates,
     stream_guid_from_url,
 )
 
@@ -94,6 +96,18 @@ class TestCandidateExtraction(unittest.TestCase):
 
         self.assertEqual(candidates, [])
 
+    def test_extracts_video_hash_when_guid_appears_only_in_image(self):
+        candidates = extract_candidates(self._event([
+            "imeta",
+            f"url https://cdn.divine.video/{SHA}.mp4",
+            f"image https://stream.divine.video/{GUID}/thumbnail.jpg",
+            f"x {SHA}",
+        ]))
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].sha256, SHA)
+        self.assertEqual(candidates[0].guid, GUID)
+
     def test_dedupes_by_hash_and_merges_source_urls(self):
         first = extract_candidates(self._event([
             "imeta",
@@ -143,10 +157,34 @@ class TestArguments(unittest.TestCase):
 
         self.assertEqual(args.progress_file, Path("custom-progress.json"))
 
+    def test_nsec_cannot_be_passed_on_command_line(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                parse_args(["--nsec", "secret"])
+
     def test_rejects_non_positive_concurrency(self):
         with contextlib.redirect_stderr(io.StringIO()):
             with self.assertRaises(SystemExit):
                 parse_args(["--concurrency", "0"])
+
+
+class TestPendingSelection(unittest.TestCase):
+    def test_limit_is_applied_after_completed_candidates_are_removed(self):
+        candidates = [
+            BackfillCandidate(
+                sha256=str(index).zfill(64),
+                guid=GUID,
+                event_id=str(index),
+                pubkey="pubkey",
+                created_at=index,
+                source_urls=(f"https://cdn.divine.video/{str(index).zfill(64)}",),
+            )
+            for index in range(3)
+        ]
+
+        pending = select_pending_candidates(candidates, {candidates[0].sha256}, 1)
+
+        self.assertEqual(pending, [candidates[1]])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_backfill_bunny_stream_guid_blobs.py
+++ b/scripts/tests/test_backfill_bunny_stream_guid_blobs.py
@@ -1,0 +1,124 @@
+# ABOUTME: Tests for legacy Bunny Stream GUID extraction and migrate candidate construction.
+# ABOUTME: Keeps the one-shot backfill script honest without touching the network.
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "migration"))
+
+from backfill_bunny_stream_guid_blobs import (  # noqa: E402
+    dedupe_candidates,
+    extract_candidates,
+    parse_imeta_tag,
+    stream_guid_from_url,
+)
+
+
+SHA = "7ff36c72fb2644f1ac1761d0f728b2bb989df9fac0b8c68a716f4023ef4a39e0"
+GUID = "35e9a15d-5db2-41f7-96fe-58c573ff8f21"
+
+
+class TestParseImetaTag(unittest.TestCase):
+    def test_space_separated_imeta_preserves_repeated_urls(self):
+        parsed = parse_imeta_tag([
+            "imeta",
+            f"url https://stream.divine.video/{GUID}/play_480p.mp4",
+            f"url https://cdn.divine.video/{SHA}.mp4",
+            f"image https://stream.divine.video/{GUID}/thumbnail.jpg",
+            f"x {SHA}",
+        ])
+
+        self.assertEqual(len(parsed["urls"]), 2)
+        self.assertEqual(parsed["images"], [f"https://stream.divine.video/{GUID}/thumbnail.jpg"])
+        self.assertEqual(parsed["x"], SHA)
+
+    def test_alternating_imeta_preserves_repeated_urls(self):
+        parsed = parse_imeta_tag([
+            "imeta",
+            "url", f"https://stream.divine.video/{GUID}/playlist.m3u8",
+            "url", f"https://cdn.divine.video/{SHA}.mp4",
+            "x", SHA,
+        ])
+
+        self.assertEqual(parsed["urls"], [
+            f"https://stream.divine.video/{GUID}/playlist.m3u8",
+            f"https://cdn.divine.video/{SHA}.mp4",
+        ])
+        self.assertEqual(parsed["url"], f"https://stream.divine.video/{GUID}/playlist.m3u8")
+
+
+class TestCandidateExtraction(unittest.TestCase):
+    def _event(self, tag):
+        return {
+            "id": "event-id",
+            "pubkey": "pubkey",
+            "created_at": 1750000000,
+            "tags": [tag],
+        }
+
+    def test_extracts_guid_sha_mapping_from_stream_url_and_x_tag(self):
+        candidates = extract_candidates(self._event([
+            "imeta",
+            f"url https://stream.divine.video/{GUID}/play_480p.mp4",
+            f"url https://cdn.divine.video/{SHA}.mp4",
+            f"image https://stream.divine.video/{GUID}/thumbnail.jpg",
+            f"x {SHA}",
+        ]))
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate.sha256, SHA)
+        self.assertEqual(candidate.guid, GUID)
+        self.assertEqual(candidate.source_urls[0], f"https://cdn.divine.video/{SHA}.mp4")
+        self.assertIn(f"https://cdn.divine.video/{SHA}", candidate.source_urls)
+
+    def test_skips_guid_event_without_x_hash(self):
+        candidates = extract_candidates(self._event([
+            "imeta",
+            f"url https://stream.divine.video/{GUID}/play_480p.mp4",
+        ]))
+
+        self.assertEqual(candidates, [])
+
+    def test_skips_non_stream_events(self):
+        candidates = extract_candidates(self._event([
+            "imeta",
+            f"url https://cdn.divine.video/{SHA}.mp4",
+            f"x {SHA}",
+        ]))
+
+        self.assertEqual(candidates, [])
+
+    def test_dedupes_by_hash_and_merges_source_urls(self):
+        first = extract_candidates(self._event([
+            "imeta",
+            f"url https://stream.divine.video/{GUID}/play.mp4",
+            f"x {SHA}",
+        ]))[0]
+        second = extract_candidates(self._event([
+            "imeta",
+            f"url https://stream.divine.video/{GUID}/playlist.m3u8",
+            f"url https://cdn.divine.video/{SHA}.mp4",
+            f"x {SHA}",
+        ]))[0]
+
+        merged = dedupe_candidates([first, second])
+
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0].sha256, SHA)
+        self.assertIn(f"https://cdn.divine.video/{SHA}.mp4", merged[0].source_urls)
+
+
+class TestGuidParsing(unittest.TestCase):
+    def test_extracts_only_stream_guid_path(self):
+        self.assertEqual(
+            stream_guid_from_url(f"https://stream.divine.video/{GUID}/thumbnail.jpg"),
+            GUID,
+        )
+        self.assertIsNone(stream_guid_from_url(f"https://cdn.divine.video/{GUID}/thumbnail.jpg"))
+        self.assertIsNone(stream_guid_from_url("https://stream.divine.video/not-a-guid/thumbnail.jpg"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -20,7 +20,10 @@ const FOS_BACKEND: &str = "fos_storage";
 /// Cloud Run backend for uploads/migrations
 const CLOUD_RUN_BACKEND: &str = "cloud_run_upload";
 
-/// Fallback backends removed — all content is now in GCS.
+/// Legacy CDN runtime fallback is intentionally disabled.
+///
+/// If a migration miss is discovered, backfill the verified bytes into GCS
+/// instead of reintroducing legacy hosts into the hot delivery path.
 const FALLBACK_BACKENDS: &[(&str, &str, &str)] = &[];
 
 /// Config store name


### PR DESCRIPTION
## Summary
- Add a one-shot Bunny Stream GUID backfill script that extracts GUID-to-SHA mappings from legacy Nostr imeta tags.
- Default the script to Blossom /mirror so verified bytes and Blossom metadata are restored together; keep upload-service /migrate as an explicit storage-only mode.
- Update stale migration docs and clarify that legacy CDN fallback remains intentionally disabled.

## Motivation
Closes #203.

The GUID-to-SHA mapping exists in legacy events, but redirecting stream.divine.video GUID paths is the wrong recovery path because clients need Blossom SHA objects plus metadata. The operational backfill has been run for the retained GUID-era window: 515/515 mapped hashes now have restored public Blossom media/thumbnail access.

## Manual validation
- python3 -m unittest scripts.tests.test_backfill_bunny_stream_guid_blobs
- cargo check --tests --locked
- cargo clippy --locked --all-targets --all-features
- Dry-run enumeration: 2,410 events, 515 GUID candidates for created_at [1750000000, 1775000000]
- Production backfill: 515/515 hashes restored through Blossom mirror/upload paths
- Verified representative media and thumbnail HEAD requests return HTTP 200 from media.divine.video

## Notes
- No visual UI change.
- stream.divine.video remains retired; this PR intentionally does not add a redirect handler or runtime legacy CDN dependency.