### PR TITLE
fix(cache): align pending blob GET cache policy

### DIFF
--- a/blossom-core/src/cache_policy.rs
+++ b/blossom-core/src/cache_policy.rs
@@ -71,11 +71,23 @@ pub fn status_requires_private_response(status: BlobStatus) -> bool {
     blob_cache_policy(status) == BlobCachePolicy::PrivateNoStore
 }
 
+/// The headers a serving route must send for a cache policy. Production routes
+/// apply this mapping instead of re-stating it, so the policy-to-headers
+/// decision is covered by the executing blossom-core tests.
+pub fn cache_headers_for_policy<'a>(policy: BlobCachePolicy, hash: &'a str) -> CacheHeaders<'a> {
+    match policy {
+        BlobCachePolicy::ImmutablePublic => immutable_blob_cache_headers(hash),
+        BlobCachePolicy::RevocablePublic => mutable_derivative_cache_headers(hash),
+        BlobCachePolicy::PrivateNoStore => private_no_store_cache_headers(hash),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        blob_cache_policy, immutable_blob_cache_headers, mutable_derivative_cache_headers,
-        private_no_store_cache_headers, status_requires_private_response, BlobCachePolicy,
+        blob_cache_policy, cache_headers_for_policy, immutable_blob_cache_headers,
+        mutable_derivative_cache_headers, private_no_store_cache_headers,
+        status_requires_private_response, BlobCachePolicy,
     };
     use crate::types::BlobStatus;
 
@@ -142,11 +154,7 @@ mod tests {
                 "no-store",
             ),
         ] {
-            let headers = match policy {
-                BlobCachePolicy::ImmutablePublic => immutable_blob_cache_headers("abc123"),
-                BlobCachePolicy::RevocablePublic => mutable_derivative_cache_headers("abc123"),
-                BlobCachePolicy::PrivateNoStore => private_no_store_cache_headers("abc123"),
-            };
+            let headers = cache_headers_for_policy(policy, "abc123");
 
             assert_eq!(headers.cache_control, cache_control);
             assert_eq!(headers.surrogate_control, surrogate_control);

--- a/blossom-core/src/cache_policy.rs
+++ b/blossom-core/src/cache_policy.rs
@@ -1,8 +1,6 @@
 // ABOUTME: Shared cache policy for immutable blobs and repairable derivatives.
 // ABOUTME: Keeps browser and edge cache lifetimes testable outside Fastly Compute.
 
-use crate::types::BlobStatus;
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PublicCacheHeaders<'a> {
     pub cache_control: &'static str,
@@ -26,16 +24,9 @@ pub fn mutable_derivative_cache_headers(hash: &str) -> PublicCacheHeaders<'_> {
     }
 }
 
-pub fn blob_response_is_private(status: BlobStatus) -> bool {
-    status.requires_private_cache()
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{
-        blob_response_is_private, immutable_blob_cache_headers, mutable_derivative_cache_headers,
-    };
-    use crate::types::BlobStatus;
+    use super::{immutable_blob_cache_headers, mutable_derivative_cache_headers};
 
     fn max_age(cache_control: &str) -> u64 {
         cache_control
@@ -76,13 +67,5 @@ mod tests {
 
         assert_eq!(headers.surrogate_control, "max-age=31536000");
         assert_eq!(headers.surrogate_key, "abc123");
-    }
-
-    #[test]
-    fn pending_blob_gets_the_same_public_cache_policy_as_other_public_routes() {
-        assert!(!blob_response_is_private(BlobStatus::Active));
-        assert!(!blob_response_is_private(BlobStatus::Pending));
-        assert!(blob_response_is_private(BlobStatus::Restricted));
-        assert!(blob_response_is_private(BlobStatus::AgeRestricted));
     }
 }

--- a/blossom-core/src/cache_policy.rs
+++ b/blossom-core/src/cache_policy.rs
@@ -1,6 +1,8 @@
 // ABOUTME: Shared cache policy for immutable blobs and repairable derivatives.
 // ABOUTME: Keeps browser and edge cache lifetimes testable outside Fastly Compute.
 
+use crate::types::BlobStatus;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PublicCacheHeaders<'a> {
     pub cache_control: &'static str,
@@ -24,9 +26,38 @@ pub fn mutable_derivative_cache_headers(hash: &str) -> PublicCacheHeaders<'_> {
     }
 }
 
+/// Cache policy for responses whose cacheability is driven by the blob's
+/// moderation status. The match is exhaustive so a future `BlobStatus`
+/// variant fails to compile until a policy is chosen for it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BlobCachePolicy {
+    /// Content is moderated and content-addressed: immutable, one-year public caching.
+    ImmutablePublic,
+    /// Public while moderation runs, but revocable: short browser TTL with a
+    /// long edge TTL that `purge_edge_cache` can invalidate by Surrogate-Key.
+    RevocablePublic,
+    /// Must not be stored in shared caches.
+    PrivateNoStore,
+}
+
+pub fn blob_cache_policy(status: BlobStatus) -> BlobCachePolicy {
+    match status {
+        BlobStatus::Active => BlobCachePolicy::ImmutablePublic,
+        BlobStatus::Pending => BlobCachePolicy::RevocablePublic,
+        BlobStatus::Restricted
+        | BlobStatus::AgeRestricted
+        | BlobStatus::Banned
+        | BlobStatus::Deleted => BlobCachePolicy::PrivateNoStore,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{immutable_blob_cache_headers, mutable_derivative_cache_headers};
+    use super::{
+        blob_cache_policy, immutable_blob_cache_headers, mutable_derivative_cache_headers,
+        BlobCachePolicy,
+    };
+    use crate::types::BlobStatus;
 
     fn max_age(cache_control: &str) -> u64 {
         cache_control
@@ -67,5 +98,38 @@ mod tests {
 
         assert_eq!(headers.surrogate_control, "max-age=31536000");
         assert_eq!(headers.surrogate_key, "abc123");
+    }
+
+    #[test]
+    fn active_media_stays_immutable() {
+        assert_eq!(
+            blob_cache_policy(BlobStatus::Active),
+            BlobCachePolicy::ImmutablePublic
+        );
+    }
+
+    #[test]
+    fn pending_media_is_public_but_revocable() {
+        assert_eq!(
+            blob_cache_policy(BlobStatus::Pending),
+            BlobCachePolicy::RevocablePublic
+        );
+    }
+
+    #[test]
+    fn moderated_media_is_never_publicly_cacheable() {
+        for status in [
+            BlobStatus::Restricted,
+            BlobStatus::AgeRestricted,
+            BlobStatus::Banned,
+            BlobStatus::Deleted,
+        ] {
+            assert_eq!(
+                blob_cache_policy(status),
+                BlobCachePolicy::PrivateNoStore,
+                "{:?} must not be publicly cacheable",
+                status
+            );
+        }
     }
 }

--- a/blossom-core/src/cache_policy.rs
+++ b/blossom-core/src/cache_policy.rs
@@ -4,24 +4,35 @@
 use crate::types::BlobStatus;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PublicCacheHeaders<'a> {
+pub struct CacheHeaders<'a> {
     pub cache_control: &'static str,
     pub surrogate_control: &'static str,
     pub surrogate_key: &'a str,
 }
 
-pub fn immutable_blob_cache_headers(hash: &str) -> PublicCacheHeaders<'_> {
-    PublicCacheHeaders {
+pub fn immutable_blob_cache_headers(hash: &str) -> CacheHeaders<'_> {
+    CacheHeaders {
         cache_control: "public, max-age=31536000, immutable",
         surrogate_control: "max-age=31536000",
         surrogate_key: hash,
     }
 }
 
-pub fn mutable_derivative_cache_headers(hash: &str) -> PublicCacheHeaders<'_> {
-    PublicCacheHeaders {
+pub fn mutable_derivative_cache_headers(hash: &str) -> CacheHeaders<'_> {
+    CacheHeaders {
         cache_control: "public, max-age=86400",
         surrogate_control: "max-age=31536000",
+        surrogate_key: hash,
+    }
+}
+
+/// Headers for responses that must not be stored in browser or shared caches.
+/// The Surrogate-Key is still carried so a moderation purge can evict any edge
+/// copy cached before the status changed.
+pub fn private_no_store_cache_headers(hash: &str) -> CacheHeaders<'_> {
+    CacheHeaders {
+        cache_control: "private, no-store",
+        surrogate_control: "no-store",
         surrogate_key: hash,
     }
 }
@@ -51,11 +62,20 @@ pub fn blob_cache_policy(status: BlobStatus) -> BlobCachePolicy {
     }
 }
 
+/// Whether a response for this status must stay private. Routes that serve
+/// derivative content (HLS, variants, transcripts) branch on this so every
+/// status decision flows through the single exhaustive [`blob_cache_policy`]
+/// match: a future `BlobStatus` variant fails to compile there instead of
+/// silently inheriting public derivative caching.
+pub fn status_requires_private_response(status: BlobStatus) -> bool {
+    blob_cache_policy(status) == BlobCachePolicy::PrivateNoStore
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         blob_cache_policy, immutable_blob_cache_headers, mutable_derivative_cache_headers,
-        BlobCachePolicy,
+        private_no_store_cache_headers, status_requires_private_response, BlobCachePolicy,
     };
     use crate::types::BlobStatus;
 
@@ -98,6 +118,54 @@ mod tests {
 
         assert_eq!(headers.surrogate_control, "max-age=31536000");
         assert_eq!(headers.surrogate_key, "abc123");
+    }
+
+    #[test]
+    fn every_cache_policy_sends_the_headers_its_name_promises() {
+        // The edge binary's tests are compile-only in CI, so these literals
+        // are the executing coverage for the header strings each policy must
+        // send on every serving route.
+        for (policy, cache_control, surrogate_control) in [
+            (
+                BlobCachePolicy::ImmutablePublic,
+                "public, max-age=31536000, immutable",
+                "max-age=31536000",
+            ),
+            (
+                BlobCachePolicy::RevocablePublic,
+                "public, max-age=86400",
+                "max-age=31536000",
+            ),
+            (
+                BlobCachePolicy::PrivateNoStore,
+                "private, no-store",
+                "no-store",
+            ),
+        ] {
+            let headers = match policy {
+                BlobCachePolicy::ImmutablePublic => immutable_blob_cache_headers("abc123"),
+                BlobCachePolicy::RevocablePublic => mutable_derivative_cache_headers("abc123"),
+                BlobCachePolicy::PrivateNoStore => private_no_store_cache_headers("abc123"),
+            };
+
+            assert_eq!(headers.cache_control, cache_control);
+            assert_eq!(headers.surrogate_control, surrogate_control);
+            assert_eq!(headers.surrogate_key, "abc123");
+        }
+    }
+
+    #[test]
+    fn moderated_statuses_route_derivatives_through_the_policy_match() {
+        for status in [
+            BlobStatus::Restricted,
+            BlobStatus::AgeRestricted,
+            BlobStatus::Banned,
+            BlobStatus::Deleted,
+        ] {
+            assert!(status_requires_private_response(status));
+        }
+        assert!(!status_requires_private_response(BlobStatus::Active));
+        assert!(!status_requires_private_response(BlobStatus::Pending));
     }
 
     #[test]

--- a/blossom-core/src/cache_policy.rs
+++ b/blossom-core/src/cache_policy.rs
@@ -1,6 +1,8 @@
 // ABOUTME: Shared cache policy for immutable blobs and repairable derivatives.
 // ABOUTME: Keeps browser and edge cache lifetimes testable outside Fastly Compute.
 
+use crate::types::BlobStatus;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PublicCacheHeaders<'a> {
     pub cache_control: &'static str,
@@ -24,9 +26,16 @@ pub fn mutable_derivative_cache_headers(hash: &str) -> PublicCacheHeaders<'_> {
     }
 }
 
+pub fn blob_response_is_private(status: BlobStatus) -> bool {
+    status.requires_private_cache()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{immutable_blob_cache_headers, mutable_derivative_cache_headers};
+    use super::{
+        blob_response_is_private, immutable_blob_cache_headers, mutable_derivative_cache_headers,
+    };
+    use crate::types::BlobStatus;
 
     fn max_age(cache_control: &str) -> u64 {
         cache_control
@@ -67,5 +76,13 @@ mod tests {
 
         assert_eq!(headers.surrogate_control, "max-age=31536000");
         assert_eq!(headers.surrogate_key, "abc123");
+    }
+
+    #[test]
+    fn pending_blob_gets_the_same_public_cache_policy_as_other_public_routes() {
+        assert!(!blob_response_is_private(BlobStatus::Active));
+        assert!(!blob_response_is_private(BlobStatus::Pending));
+        assert!(blob_response_is_private(BlobStatus::Restricted));
+        assert!(blob_response_is_private(BlobStatus::AgeRestricted));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,8 +52,8 @@ use crate::storage::{
 };
 use crate::viewer_auth::{ViewerAuthDiagnostics, ViewerAuthState};
 use blossom_core::cache_policy::{
-    blob_cache_policy, immutable_blob_cache_headers, mutable_derivative_cache_headers,
-    private_no_store_cache_headers, status_requires_private_response, BlobCachePolicy,
+    blob_cache_policy, cache_headers_for_policy, mutable_derivative_cache_headers,
+    status_requires_private_response, BlobCachePolicy, CacheHeaders,
 };
 use blossom_core::request_diagnostics::route_category;
 use blossom_core::upload_log::{
@@ -426,11 +426,7 @@ fn add_audio_response_headers(
     resp.set_header("X-Audio-Duration", format!("{}", duration_seconds));
     resp.set_header("X-Audio-Size", size_bytes.to_string());
     resp.set_header("Accept-Ranges", "bytes");
-    match cache_policy {
-        BlobCachePolicy::ImmutablePublic => add_cache_headers(resp, source_hash),
-        BlobCachePolicy::RevocablePublic => add_derivative_cache_headers(resp, source_hash),
-        BlobCachePolicy::PrivateNoStore => add_private_cache_headers(resp, source_hash),
-    }
+    apply_cache_headers(resp, &cache_headers_for_policy(cache_policy, source_hash));
     add_cors_headers(resp);
 }
 
@@ -5953,13 +5949,7 @@ fn error_response(error: &BlossomError) -> Response {
     resp
 }
 
-/// Add CORS headers
-/// Set immutable cache headers and surrogate key for content-addressed responses.
-/// - Cache-Control: tells browsers to cache for 1 year
-/// - Surrogate-Control: tells Fastly edge to cache for 1 year (stripped before client)
-/// - Surrogate-Key: enables targeted purging via `fastly purge --key {hash}`
-fn add_cache_headers(resp: &mut Response, hash: &str) {
-    let headers = immutable_blob_cache_headers(hash);
+fn apply_cache_headers(resp: &mut Response, headers: &CacheHeaders<'_>) {
     resp.set_header("Cache-Control", headers.cache_control);
     resp.set_header("Surrogate-Control", headers.surrogate_control);
     resp.set_header("Surrogate-Key", headers.surrogate_key);
@@ -5978,32 +5968,25 @@ fn add_cache_headers(resp: &mut Response, hash: &str) {
 /// Surrogate-Key. Only the browser TTL needs to be short enough that a repair reaches
 /// clients that already cached the old version.
 fn add_derivative_cache_headers(resp: &mut Response, hash: &str) {
-    let headers = mutable_derivative_cache_headers(hash);
-    resp.set_header("Cache-Control", headers.cache_control);
-    resp.set_header("Surrogate-Control", headers.surrogate_control);
-    resp.set_header("Surrogate-Key", headers.surrogate_key);
+    apply_cache_headers(resp, &mutable_derivative_cache_headers(hash));
 }
 
 /// Apply the moderation-status cache policy to a blob response. `None` (no
 /// metadata; reachable only via admin bypass) keeps the immutable policy.
 fn add_blob_response_cache_headers(resp: &mut Response, hash: &str, status: Option<BlobStatus>) {
-    match status
+    let policy = status
         .map(blob_cache_policy)
-        .unwrap_or(BlobCachePolicy::ImmutablePublic)
-    {
-        BlobCachePolicy::ImmutablePublic => add_cache_headers(resp, hash),
-        BlobCachePolicy::RevocablePublic => add_derivative_cache_headers(resp, hash),
-        BlobCachePolicy::PrivateNoStore => add_private_cache_headers(resp, hash),
-    }
+        .unwrap_or(BlobCachePolicy::ImmutablePublic);
+    apply_cache_headers(resp, &cache_headers_for_policy(policy, hash));
 }
 
 /// Like add_cache_headers but for authenticated or admin-only content that must
 /// not be stored in shared caches.
 fn add_private_cache_headers(resp: &mut Response, hash: &str) {
-    let headers = private_no_store_cache_headers(hash);
-    resp.set_header("Cache-Control", headers.cache_control);
-    resp.set_header("Surrogate-Control", headers.surrogate_control);
-    resp.set_header("Surrogate-Key", headers.surrogate_key);
+    apply_cache_headers(
+        resp,
+        &cache_headers_for_policy(BlobCachePolicy::PrivateNoStore, hash),
+    );
 }
 
 /// Mark a response as explicitly uncacheable (used for 202 in-progress responses).

--- a/src/main.rs
+++ b/src/main.rs
@@ -5972,16 +5972,17 @@ fn add_derivative_cache_headers(resp: &mut Response, hash: &str) {
 }
 
 /// Apply the moderation-status cache policy to a blob response. `None` (no
-/// metadata; reachable only via admin bypass) keeps the immutable policy.
+/// metadata) fails closed to the private policy so no caller can silently hand
+/// out an immutable public copy for content whose status is unknown.
 fn add_blob_response_cache_headers(resp: &mut Response, hash: &str, status: Option<BlobStatus>) {
     let policy = status
         .map(blob_cache_policy)
-        .unwrap_or(BlobCachePolicy::ImmutablePublic);
+        .unwrap_or(BlobCachePolicy::PrivateNoStore);
     apply_cache_headers(resp, &cache_headers_for_policy(policy, hash));
 }
 
-/// Like add_cache_headers but for authenticated or admin-only content that must
-/// not be stored in shared caches.
+/// Cache headers for authenticated or admin-only content that must not be
+/// stored in shared caches.
 fn add_private_cache_headers(resp: &mut Response, hash: &str) {
     apply_cache_headers(
         resp,
@@ -6872,6 +6873,20 @@ mod tests {
             assert_eq!(resp.get_header_str("Surrogate-Control"), Some("no-store"));
             assert_eq!(resp.get_header_str("Surrogate-Key"), Some("abc123"));
         }
+    }
+
+    #[test]
+    fn blob_get_without_metadata_fails_closed_to_private_cache() {
+        let mut resp = Response::from_status(StatusCode::OK);
+
+        add_blob_response_cache_headers(&mut resp, "abc123", None);
+
+        assert_eq!(
+            resp.get_header_str("Cache-Control"),
+            Some("private, no-store")
+        );
+        assert_eq!(resp.get_header_str("Surrogate-Control"), Some("no-store"));
+        assert_eq!(resp.get_header_str("Surrogate-Key"), Some("abc123"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,10 @@ use crate::storage::{
     trigger_cloud_run_delete_blob, upload_blob, write_audit_log,
 };
 use crate::viewer_auth::{ViewerAuthDiagnostics, ViewerAuthState};
-use blossom_core::cache_policy::{immutable_blob_cache_headers, mutable_derivative_cache_headers};
+use blossom_core::cache_policy::{
+    blob_cache_policy, immutable_blob_cache_headers, mutable_derivative_cache_headers,
+    BlobCachePolicy,
+};
 use blossom_core::request_diagnostics::route_category;
 use blossom_core::upload_log::{
     record_failure, record_response, record_send_attempt, OriginSendResult, UploadLogRecord,
@@ -5968,13 +5971,13 @@ fn add_derivative_cache_headers(resp: &mut Response, hash: &str) {
     resp.set_header("Surrogate-Key", headers.surrogate_key);
 }
 
+/// Apply the moderation-status cache policy to a blob response. `None` (no
+/// metadata; reachable only via admin bypass) keeps the immutable policy.
 fn add_blob_response_cache_headers(resp: &mut Response, hash: &str, status: Option<BlobStatus>) {
-    match status {
-        Some(BlobStatus::Pending) => add_derivative_cache_headers(resp, hash),
-        Some(status) if status.requires_private_cache() || status.blocks_public_access() => {
-            add_private_cache_headers(resp, hash);
-        }
-        _ => add_cache_headers(resp, hash),
+    match status.map(blob_cache_policy).unwrap_or(BlobCachePolicy::ImmutablePublic) {
+        BlobCachePolicy::ImmutablePublic => add_cache_headers(resp, hash),
+        BlobCachePolicy::RevocablePublic => add_derivative_cache_headers(resp, hash),
+        BlobCachePolicy::PrivateNoStore => add_private_cache_headers(resp, hash),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,7 +413,7 @@ fn audio_reuse_denied_response() -> Response {
 fn add_audio_response_headers(
     resp: &mut Response,
     source_hash: &str,
-    private_cache: bool,
+    cache_policy: BlobCachePolicy,
     mime_type: &str,
     size_bytes: u64,
     duration_seconds: f64,
@@ -426,10 +426,10 @@ fn add_audio_response_headers(
     resp.set_header("X-Audio-Duration", format!("{}", duration_seconds));
     resp.set_header("X-Audio-Size", size_bytes.to_string());
     resp.set_header("Accept-Ranges", "bytes");
-    if private_cache {
-        add_private_cache_headers(resp, source_hash);
-    } else {
-        add_cache_headers(resp, source_hash);
+    match cache_policy {
+        BlobCachePolicy::ImmutablePublic => add_cache_headers(resp, source_hash),
+        BlobCachePolicy::RevocablePublic => add_derivative_cache_headers(resp, source_hash),
+        BlobCachePolicy::PrivateNoStore => add_private_cache_headers(resp, source_hash),
     }
     add_cors_headers(resp);
 }
@@ -517,16 +517,14 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         let is_admin = admin::validate_bearer_token(&req).is_ok();
 
         // Check parent video's moderation status - thumbnails inherit video access rules
-        let mut is_restricted = false;
+        let mut cache_status: Option<BlobStatus> = None;
         match get_blob_metadata(video_hash)? {
             Some(meta) => {
                 let (requester_pk, auth_diagnostics) = media_viewer_context(&req, "thumbnail")?;
                 match meta.access_for(requester_pk.as_deref(), is_admin) {
                     BlobAccess::Allowed => {
                         log_media_outcome("thumbnail", &auth_diagnostics, "allowed");
-                        if meta.status.requires_private_cache() {
-                            is_restricted = true;
-                        }
+                        cache_status = Some(meta.status);
                     }
                     BlobAccess::NotFound => {
                         log_media_outcome("thumbnail", &auth_diagnostics, "not_found");
@@ -549,11 +547,7 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
 
         // Try to download existing thumbnail from GCS
         let set_thumb_cache = |resp: &mut Response| {
-            if is_restricted {
-                add_private_cache_headers(resp, video_hash);
-            } else {
-                add_cache_headers(resp, video_hash);
-            }
+            add_blob_response_cache_headers(resp, video_hash, cache_status);
         };
         match download_thumbnail(&thumbnail_key) {
             Ok(mut resp) => {
@@ -712,18 +706,17 @@ fn handle_head_blob(path: &str) -> Result<Response> {
         let thumb_hash = thumbnail_key.trim_end_matches(".jpg");
 
         // HEAD has no auth context — apply non-owner access rules.
-        match get_blob_metadata(thumb_hash)? {
-            Some(meta) => match meta.access_for(None, false) {
-                BlobAccess::Allowed => {}
-                BlobAccess::NotFound => {
-                    return Err(BlossomError::NotFound("Blob not found".into()));
-                }
-                BlobAccess::AgeGated => {
-                    return Err(BlossomError::AuthRequired("age_restricted".into()));
-                }
-            },
-            None => {
+        let meta = match get_blob_metadata(thumb_hash)? {
+            Some(meta) => meta,
+            None => return Err(BlossomError::NotFound("Blob not found".into())),
+        };
+        match meta.access_for(None, false) {
+            BlobAccess::Allowed => {}
+            BlobAccess::NotFound => {
                 return Err(BlossomError::NotFound("Blob not found".into()));
+            }
+            BlobAccess::AgeGated => {
+                return Err(BlossomError::AuthRequired("age_restricted".into()));
             }
         }
 
@@ -740,7 +733,7 @@ fn handle_head_blob(path: &str) -> Result<Response> {
         let mut head_resp = Response::from_status(StatusCode::OK);
         head_resp.set_header("Content-Type", "image/jpeg");
         head_resp.set_header("Content-Length", &content_length);
-        add_cache_headers(&mut head_resp, thumb_hash);
+        add_blob_response_cache_headers(&mut head_resp, thumb_hash, Some(meta.status));
         head_resp.set_header("Accept-Ranges", "bytes");
         add_cors_headers(&mut head_resp);
         return Ok(head_resp);
@@ -772,7 +765,7 @@ fn handle_head_blob(path: &str) -> Result<Response> {
     resp.set_header(header::CONTENT_LENGTH, metadata.size.to_string());
     resp.set_header("X-Sha256", &metadata.sha256);
     resp.set_header("X-Content-Length", metadata.size.to_string());
-    add_cache_headers(&mut resp, &hash);
+    add_blob_response_cache_headers(&mut resp, &hash, Some(metadata.status));
     resp.set_header("Accept-Ranges", "bytes");
     add_cors_headers(&mut resp);
 
@@ -2216,7 +2209,13 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
         AudioReuseAvailability::LookupUnavailable => return Ok(audio_lookup_unavailable_response()),
     }
 
-    let private_cache = is_admin || metadata.status.requires_private_cache();
+    // Admin responses stay private; otherwise the source video's moderation
+    // status drives the policy (Pending source => revocable public caching).
+    let audio_cache_policy = if is_admin {
+        BlobCachePolicy::PrivateNoStore
+    } else {
+        blob_cache_policy(metadata.status)
+    };
 
     // 4. Must be a video source
     if !is_video_mime_type(&metadata.mime_type) {
@@ -2245,7 +2244,7 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
             add_audio_response_headers(
                 &mut resp,
                 &hash,
-                private_cache,
+                audio_cache_policy,
                 &mapping.mime_type,
                 mapping.size_bytes,
                 mapping.duration_seconds,
@@ -2330,7 +2329,14 @@ fn handle_get_audio(req: Request, path: &str) -> Result<Response> {
     // 8. Download and serve the audio
     let result = download_blob_with_fallback(&audio_sha256, range.as_deref())?;
     let mut resp = result.response;
-    add_audio_response_headers(&mut resp, &hash, private_cache, &mime_type, size, duration);
+    add_audio_response_headers(
+        &mut resp,
+        &hash,
+        audio_cache_policy,
+        &mime_type,
+        size,
+        duration,
+    );
     Ok(resp)
 }
 
@@ -2376,7 +2382,7 @@ fn handle_head_audio(path: &str) -> Result<Response> {
             add_audio_response_headers(
                 &mut resp,
                 &hash,
-                metadata.status.requires_private_cache(),
+                blob_cache_policy(metadata.status),
                 &mapping.mime_type,
                 mapping.size_bytes,
                 mapping.duration_seconds,
@@ -5974,7 +5980,10 @@ fn add_derivative_cache_headers(resp: &mut Response, hash: &str) {
 /// Apply the moderation-status cache policy to a blob response. `None` (no
 /// metadata; reachable only via admin bypass) keeps the immutable policy.
 fn add_blob_response_cache_headers(resp: &mut Response, hash: &str, status: Option<BlobStatus>) {
-    match status.map(blob_cache_policy).unwrap_or(BlobCachePolicy::ImmutablePublic) {
+    match status
+        .map(blob_cache_policy)
+        .unwrap_or(BlobCachePolicy::ImmutablePublic)
+    {
         BlobCachePolicy::ImmutablePublic => add_cache_headers(resp, hash),
         BlobCachePolicy::RevocablePublic => add_derivative_cache_headers(resp, hash),
         BlobCachePolicy::PrivateNoStore => add_private_cache_headers(resp, hash),
@@ -6188,13 +6197,13 @@ fn infer_mime_from_path(path: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        add_blob_response_cache_headers, backfill_batch_cursor, classify_audio_reuse_availability,
-        decide_transcode_fetch_action, decide_transcript_fetch_action,
-        derivative_reconciliation_response, error_response, ignored_generation_response,
-        is_alias_only_audio_blob, parse_transcode_status_webhook_payload,
-        parse_transcript_status_webhook_payload, parse_upload_service_response,
-        should_delete_derived_audio_blob, should_eagerly_trigger_transcription,
-        should_record_upload_service_transcode_failure,
+        add_audio_response_headers, add_blob_response_cache_headers, backfill_batch_cursor,
+        classify_audio_reuse_availability, decide_transcode_fetch_action,
+        decide_transcript_fetch_action, derivative_reconciliation_response, error_response,
+        ignored_generation_response, is_alias_only_audio_blob,
+        parse_transcode_status_webhook_payload, parse_transcript_status_webhook_payload,
+        parse_upload_service_response, should_delete_derived_audio_blob,
+        should_eagerly_trigger_transcription, should_record_upload_service_transcode_failure,
         should_record_upload_service_transcript_failure,
         should_reset_transcode_failure_on_clean_upload,
         should_reset_transcript_failure_on_clean_upload, should_set_audio_content_length,
@@ -6207,6 +6216,7 @@ mod tests {
         BlobStatus, ResumableUploadCompleteResponse, TranscodeStatus, TranscriptStatus,
     };
     use crate::error::{BlossomError, Result as BlossomResult};
+    use blossom_core::cache_policy::BlobCachePolicy;
     use fastly::http::StatusCode;
     use fastly::Response;
 
@@ -6870,6 +6880,27 @@ mod tests {
             );
             assert_eq!(resp.get_header_str("Surrogate-Control"), Some("no-store"));
             assert_eq!(resp.get_header_str("Surrogate-Key"), Some("abc123"));
+        }
+    }
+
+    #[test]
+    fn audio_responses_follow_the_source_cache_policy() {
+        for (policy, cache_control) in [
+            (
+                BlobCachePolicy::ImmutablePublic,
+                "public, max-age=31536000, immutable",
+            ),
+            (BlobCachePolicy::RevocablePublic, "public, max-age=86400"),
+            (BlobCachePolicy::PrivateNoStore, "private, no-store"),
+        ] {
+            let mut resp = Response::from_status(StatusCode::OK);
+
+            add_audio_response_headers(&mut resp, "src123", policy, "audio/mp4", 42, 1.5);
+
+            assert_eq!(resp.get_header_str("Cache-Control"), Some(cache_control));
+            // Audio responses are keyed by the source video hash so moderation
+            // purges invalidate them together with the source.
+            assert_eq!(resp.get_header_str("Surrogate-Key"), Some("src123"));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,7 @@ use crate::storage::{
     trigger_cloud_run_delete_blob, upload_blob, write_audit_log,
 };
 use crate::viewer_auth::{ViewerAuthDiagnostics, ViewerAuthState};
-use blossom_core::cache_policy::{
-    blob_response_is_private, immutable_blob_cache_headers, mutable_derivative_cache_headers,
-};
+use blossom_core::cache_policy::{immutable_blob_cache_headers, mutable_derivative_cache_headers};
 use blossom_core::request_diagnostics::route_category;
 use blossom_core::upload_log::{
     record_failure, record_response, record_send_attempt, OriginSendResult, UploadLogRecord,
@@ -682,24 +680,16 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
         resp.set_header("X-Sha256", &hash);
     }
 
-    // Content is addressed by SHA256 hash, so it's immutable - cache aggressively.
-    // Exception: restricted/admin content must not be publicly cached.
+    // Active content is addressed by SHA256 hash, so it's immutable - cache aggressively.
+    // Pending blobs are public while moderation runs, but keep browser caches revocable.
     if is_admin {
         // Admin bypass: never cache, expose moderation status
-        resp.set_header("Cache-Control", "private, no-store");
+        add_private_cache_headers(&mut resp, &hash);
         if let Some(ref meta) = metadata {
-            resp.set_header("X-Moderation-Status", &format!("{:?}", meta.status));
+            resp.set_header("X-Moderation-Status", format!("{:?}", meta.status));
         }
     } else {
-        let is_restricted = metadata
-            .as_ref()
-            .map(|m| blob_response_is_private(m.status))
-            .unwrap_or(false);
-        if is_restricted {
-            add_private_cache_headers(&mut resp, &hash);
-        } else {
-            add_cache_headers(&mut resp, &hash);
-        }
+        add_blob_response_cache_headers(&mut resp, &hash, metadata.as_ref().map(|m| m.status));
     }
 
     if let Some(c2pa) = c2pa_manifest_id {
@@ -5978,6 +5968,16 @@ fn add_derivative_cache_headers(resp: &mut Response, hash: &str) {
     resp.set_header("Surrogate-Key", headers.surrogate_key);
 }
 
+fn add_blob_response_cache_headers(resp: &mut Response, hash: &str, status: Option<BlobStatus>) {
+    match status {
+        Some(BlobStatus::Pending) => add_derivative_cache_headers(resp, hash),
+        Some(status) if status.requires_private_cache() || status.blocks_public_access() => {
+            add_private_cache_headers(resp, hash);
+        }
+        _ => add_cache_headers(resp, hash),
+    }
+}
+
 /// Like add_cache_headers but for authenticated or admin-only content that must
 /// not be stored in shared caches.
 fn add_private_cache_headers(resp: &mut Response, hash: &str) {
@@ -6185,12 +6185,13 @@ fn infer_mime_from_path(path: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::{
-        backfill_batch_cursor, classify_audio_reuse_availability, decide_transcode_fetch_action,
-        decide_transcript_fetch_action, derivative_reconciliation_response, error_response,
-        ignored_generation_response, is_alias_only_audio_blob,
-        parse_transcode_status_webhook_payload, parse_transcript_status_webhook_payload,
-        parse_upload_service_response, should_delete_derived_audio_blob,
-        should_eagerly_trigger_transcription, should_record_upload_service_transcode_failure,
+        add_blob_response_cache_headers, backfill_batch_cursor, classify_audio_reuse_availability,
+        decide_transcode_fetch_action, decide_transcript_fetch_action,
+        derivative_reconciliation_response, error_response, ignored_generation_response,
+        is_alias_only_audio_blob, parse_transcode_status_webhook_payload,
+        parse_transcript_status_webhook_payload, parse_upload_service_response,
+        should_delete_derived_audio_blob, should_eagerly_trigger_transcription,
+        should_record_upload_service_transcode_failure,
         should_record_upload_service_transcript_failure,
         should_reset_transcode_failure_on_clean_upload,
         should_reset_transcript_failure_on_clean_upload, should_set_audio_content_length,
@@ -6199,9 +6200,12 @@ mod tests {
         AudioReuseAvailability, DerivativeObservation, TranscodeFetchAction, TranscriptFetchAction,
         TranscriptPendingState,
     };
-    use crate::blossom::{ResumableUploadCompleteResponse, TranscodeStatus, TranscriptStatus};
+    use crate::blossom::{
+        BlobStatus, ResumableUploadCompleteResponse, TranscodeStatus, TranscriptStatus,
+    };
     use crate::error::{BlossomError, Result as BlossomResult};
     use fastly::http::StatusCode;
+    use fastly::Response;
 
     #[test]
     fn upload_service_response_records_failure_fields_but_clamps_broad_invalid_media_terminal() {
@@ -6809,6 +6813,61 @@ mod tests {
         assert!(exposed_headers.contains("X-Divine-Upload-Data-Host"));
         // Browser clients must be able to read the 429 throttle backoff.
         assert!(exposed_headers.contains("Retry-After"));
+    }
+
+    #[test]
+    fn pending_blob_get_uses_short_browser_cache_with_purgeable_edge_ttl() {
+        let mut resp = Response::from_status(StatusCode::OK);
+
+        add_blob_response_cache_headers(&mut resp, "abc123", Some(BlobStatus::Pending));
+
+        assert_eq!(
+            resp.get_header_str("Cache-Control"),
+            Some("public, max-age=86400")
+        );
+        assert_eq!(
+            resp.get_header_str("Surrogate-Control"),
+            Some("max-age=31536000")
+        );
+        assert_eq!(resp.get_header_str("Surrogate-Key"), Some("abc123"));
+    }
+
+    #[test]
+    fn active_blob_get_keeps_immutable_cache_policy() {
+        let mut resp = Response::from_status(StatusCode::OK);
+
+        add_blob_response_cache_headers(&mut resp, "abc123", Some(BlobStatus::Active));
+
+        assert_eq!(
+            resp.get_header_str("Cache-Control"),
+            Some("public, max-age=31536000, immutable"),
+        );
+        assert_eq!(
+            resp.get_header_str("Surrogate-Control"),
+            Some("max-age=31536000")
+        );
+        assert_eq!(resp.get_header_str("Surrogate-Key"), Some("abc123"));
+    }
+
+    #[test]
+    fn moderated_blob_get_statuses_are_not_cacheable() {
+        for status in [
+            BlobStatus::Restricted,
+            BlobStatus::AgeRestricted,
+            BlobStatus::Banned,
+            BlobStatus::Deleted,
+        ] {
+            let mut resp = Response::from_status(StatusCode::OK);
+
+            add_blob_response_cache_headers(&mut resp, "abc123", Some(status));
+
+            assert_eq!(
+                resp.get_header_str("Cache-Control"),
+                Some("private, no-store")
+            );
+            assert_eq!(resp.get_header_str("Surrogate-Control"), Some("no-store"));
+            assert_eq!(resp.get_header_str("Surrogate-Key"), Some("abc123"));
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ use crate::storage::{
 };
 use crate::viewer_auth::{ViewerAuthDiagnostics, ViewerAuthState};
 use blossom_core::cache_policy::{
-    immutable_blob_cache_headers, mutable_derivative_cache_headers,
+    blob_response_is_private, immutable_blob_cache_headers, mutable_derivative_cache_headers,
 };
 use blossom_core::request_diagnostics::route_category;
 use blossom_core::upload_log::{
@@ -693,7 +693,7 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
     } else {
         let is_restricted = metadata
             .as_ref()
-            .map(|m| m.status != BlobStatus::Active)
+            .map(|m| blob_response_is_private(m.status))
             .unwrap_or(false);
         if is_restricted {
             add_private_cache_headers(&mut resp, &hash);

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ use crate::storage::{
 use crate::viewer_auth::{ViewerAuthDiagnostics, ViewerAuthState};
 use blossom_core::cache_policy::{
     blob_cache_policy, immutable_blob_cache_headers, mutable_derivative_cache_headers,
-    BlobCachePolicy,
+    private_no_store_cache_headers, status_requires_private_response, BlobCachePolicy,
 };
 use blossom_core::request_diagnostics::route_category;
 use blossom_core::upload_log::{
@@ -839,7 +839,7 @@ fn handle_get_hls_master(req: Request, path: &str) -> Result<Response> {
                 .map(|s| s.to_string());
 
             resp.set_header("Content-Type", "application/vnd.apple.mpegurl");
-            if is_admin || meta.status.requires_private_cache() {
+            if is_admin || status_requires_private_response(meta.status) {
                 add_private_cache_headers(&mut resp, &hash);
             } else {
                 add_derivative_cache_headers(&mut resp, &hash);
@@ -1027,7 +1027,7 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
             match meta.access_for(requester_pk.as_deref(), is_admin) {
                 BlobAccess::Allowed => {
                     log_media_outcome("hls_content", &auth_diagnostics, "allowed");
-                    if meta.status.requires_private_cache() {
+                    if status_requires_private_response(meta.status) {
                         is_restricted = true;
                     }
                 }
@@ -1702,7 +1702,7 @@ fn serve_transcript_by_hash(
                 );
             }
             resp.set_header("Content-Type", "text/vtt; charset=utf-8");
-            if is_admin || metadata.status.requires_private_cache() {
+            if is_admin || status_requires_private_response(metadata.status) {
                 add_private_cache_headers(&mut resp, &hash);
             } else {
                 add_derivative_cache_headers(&mut resp, hash);
@@ -2442,7 +2442,7 @@ fn handle_get_quality_variant(req: Request, path: &str) -> Result<Response> {
     match download_hls_content(&gcs_path, range.as_deref()) {
         Ok(mut resp) => {
             resp.set_header("Content-Type", content_type);
-            if is_admin || meta.status.requires_private_cache() {
+            if is_admin || status_requires_private_response(meta.status) {
                 add_private_cache_headers(&mut resp, &hash);
             } else {
                 add_derivative_cache_headers(&mut resp, &hash);
@@ -6000,9 +6000,10 @@ fn add_blob_response_cache_headers(resp: &mut Response, hash: &str, status: Opti
 /// Like add_cache_headers but for authenticated or admin-only content that must
 /// not be stored in shared caches.
 fn add_private_cache_headers(resp: &mut Response, hash: &str) {
-    resp.set_header("Cache-Control", "private, no-store");
-    resp.set_header("Surrogate-Control", "no-store");
-    resp.set_header("Surrogate-Key", hash);
+    let headers = private_no_store_cache_headers(hash);
+    resp.set_header("Cache-Control", headers.cache_control);
+    resp.set_header("Surrogate-Control", headers.surrogate_control);
+    resp.set_header("Surrogate-Key", headers.surrogate_key);
 }
 
 /// Mark a response as explicitly uncacheable (used for 202 in-progress responses).

--- a/src/main.rs
+++ b/src/main.rs
@@ -547,7 +547,12 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
 
         // Try to download existing thumbnail from GCS
         let set_thumb_cache = |resp: &mut Response| {
-            add_blob_response_cache_headers(resp, video_hash, cache_status);
+            // Admin bypass responses stay private, mirroring handle_get_blob.
+            if is_admin {
+                add_private_cache_headers(resp, video_hash);
+            } else {
+                add_blob_response_cache_headers(resp, video_hash, cache_status);
+            }
         };
         match download_thumbnail(&thumbnail_key) {
             Ok(mut resp) => {
@@ -1077,7 +1082,9 @@ fn handle_get_hls_content(req: Request, path: &str) -> Result<Response> {
             };
 
             resp.set_header("Content-Type", content_type);
-            if is_restricted {
+            // Admin bypass responses stay private, mirroring handle_get_blob
+            // and the HLS master route.
+            if is_admin || is_restricted {
                 add_private_cache_headers(&mut resp, &hash);
             } else {
                 add_derivative_cache_headers(&mut resp, &hash);


### PR DESCRIPTION
## Summary

- make GET and HEAD cache behavior explicit for each blob moderation status
- allow Pending public media to use public, purgeable edge caching with a 1-day browser TTL
- keep immutable 1-year browser caching reserved for Active media
- preserve private/no-store caching for restricted, age-restricted, banned, deleted, and admin responses
- apply the same status-driven policy to blob HEAD, thumbnail GET/HEAD, and audio GET/HEAD (previously immutable for Pending), and keep admin-bypass thumbnail and HLS content responses private
- move the status-to-policy split into `blossom-core` (`blob_cache_policy` / `cache_headers_for_policy`) so the exhaustive match and the header literals are covered by tests that execute in CI; unknown status fails closed to private

## Motivation

A production cache-policy mismatch made GET responses for Pending public media private/no-store even though HEAD and derivative routes treated the same media as publicly cacheable. This prevented effective origin offload during elevated traffic.

Pending media is still awaiting moderation, so the GET path should not give browsers an immutable one-year copy that cannot be purged after a later moderation status change.

Closes #206.

## Validation

- `cargo test -p blossom-core --locked` (175 passed)
- `cargo check --tests --locked`
- `cargo clippy --locked --all-targets --all-features` (exits 0; existing warnings remain)
- `cargo test --manifest-path cloud-run-upload/Cargo.toml --locked` (41 passed)
- `cargo test --manifest-path cloud-run-transcoder/Cargo.toml --locked`
- `python3 -m unittest discover -s cloud-run-transcoder/tests -p 'test_*.py'` (23 OK)
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (93 OK)
- `git diff --check`

Note: `cargo test blob_get --locked` is not a usable local check for the Fastly binary; it fails at native link time on unresolved Fastly host symbols such as `_header_insert` and `_status_get`. Full `cargo fmt --check` also reports pre-existing formatting drift outside this PR, so I did not apply repo-wide formatting churn.

## Manual validation plan

1. Confirm a Pending public media GET returns `Cache-Control: public, max-age=86400`, `Surrogate-Control: max-age=31536000`, and the blob surrogate key.
2. Repeat the Pending GET and confirm a cache hit/offload in Fastly diagnostics.
3. Confirm an Active media GET keeps `Cache-Control: public, max-age=31536000, immutable`.
4. Change a test object to a restricted status and confirm the purge plus private/no-store response.
5. Monitor origin offload and error rate during rollout.

No visual change.
