### PR TITLE
fix(media): reject mirror responses that disagree with the addressed size

### DIFF
--- a/blossom-core/src/read_through.rs
+++ b/blossom-core/src/read_through.rs
@@ -68,6 +68,77 @@ impl WriteBackDecision {
     }
 }
 
+/// Whether a response from the mirror can be trusted to be the addressed object.
+///
+/// The mirror is a copy of content-addressed data, so its declared length must
+/// agree with the size recorded for the hash. An S3-compatible origin can answer
+/// a `Range` request for a missing key with an error document under a `2xx`
+/// status; the body is then XML, but the serving route stamps the stored MIME
+/// type over it and the client receives a video-labelled error page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MirrorResponseCheck {
+    /// Declared length agrees with the addressed size.
+    Trusted,
+    /// The mirror did not declare a usable length.
+    SizeUnknown,
+    /// No addressed size to compare against.
+    ExpectedSizeUnknown,
+    /// The mirror declared a length the addressed object does not have.
+    LengthMismatch,
+}
+
+impl MirrorResponseCheck {
+    pub fn is_trusted(&self) -> bool {
+        matches!(self, MirrorResponseCheck::Trusted)
+    }
+
+    /// Stable short label for logging.
+    pub fn reason(&self) -> &'static str {
+        match self {
+            MirrorResponseCheck::Trusted => "trusted",
+            MirrorResponseCheck::SizeUnknown => "size_unknown",
+            MirrorResponseCheck::ExpectedSizeUnknown => "expected_size_unknown",
+            MirrorResponseCheck::LengthMismatch => "length_mismatch",
+        }
+    }
+}
+
+/// Read the complete-length field out of a `Content-Range` header value.
+///
+/// `None` for the unsatisfied form (`bytes 0-99/*`) and for anything that does
+/// not end in a decimal length.
+pub fn parse_content_range_total(value: &str) -> Option<u64> {
+    value.rsplit_once('/')?.1.trim().parse().ok()
+}
+
+/// Check a mirror response against the size recorded for its hash.
+///
+/// Every non-`Trusted` outcome costs one fetch from the authoritative origin and
+/// nothing else, so this fails closed: an unverifiable response is not served.
+pub fn check_mirror_response(
+    status: u16,
+    content_length: Option<u64>,
+    content_range: Option<&str>,
+    expected_size: Option<u64>,
+) -> MirrorResponseCheck {
+    let expected = match expected_size {
+        Some(size) => size,
+        None => return MirrorResponseCheck::ExpectedSizeUnknown,
+    };
+
+    let declared = if status == 206 {
+        content_range.and_then(parse_content_range_total)
+    } else {
+        content_length
+    };
+
+    match declared {
+        None => MirrorResponseCheck::SizeUnknown,
+        Some(size) if size == expected => MirrorResponseCheck::Trusted,
+        Some(_) => MirrorResponseCheck::LengthMismatch,
+    }
+}
+
 /// Decide whether a just-fetched object may be copied into the mirror.
 ///
 /// Every guard is a hard requirement: only a complete, length-declared,
@@ -117,6 +188,91 @@ pub fn object_path(bucket: &str, key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- Mirror response trust (issue #198) ---
+    //
+    // The reported failure: a Range request for a bare blob returned a 249-byte
+    // S3 `NoSuchKey` XML document as `206 Partial Content` with
+    // `Content-Range: bytes 0-99/249`, while the object is 855345 bytes. The
+    // caller then stamped `Content-Type: video/mp4` from KV metadata over it, so
+    // the client received XML labelled as video.
+
+    #[test]
+    fn full_mirror_response_matching_the_addressed_size_is_trusted() {
+        assert_eq!(
+            check_mirror_response(200, Some(855_345), None, Some(855_345)),
+            MirrorResponseCheck::Trusted
+        );
+    }
+
+    #[test]
+    fn full_mirror_response_shorter_than_the_addressed_size_is_rejected() {
+        assert_eq!(
+            check_mirror_response(200, Some(249), None, Some(855_345)),
+            MirrorResponseCheck::LengthMismatch
+        );
+    }
+
+    #[test]
+    fn partial_mirror_response_whose_total_matches_is_trusted() {
+        assert_eq!(
+            check_mirror_response(206, Some(100), Some("bytes 0-99/855345"), Some(855_345)),
+            MirrorResponseCheck::Trusted
+        );
+    }
+
+    #[test]
+    fn partial_mirror_response_reporting_the_error_body_size_is_rejected() {
+        assert_eq!(
+            check_mirror_response(206, Some(100), Some("bytes 0-99/249"), Some(855_345)),
+            MirrorResponseCheck::LengthMismatch
+        );
+    }
+
+    #[test]
+    fn mirror_response_without_a_declared_size_is_rejected() {
+        assert_eq!(
+            check_mirror_response(200, None, None, Some(855_345)),
+            MirrorResponseCheck::SizeUnknown
+        );
+        assert_eq!(
+            check_mirror_response(206, Some(100), None, Some(855_345)),
+            MirrorResponseCheck::SizeUnknown
+        );
+        assert_eq!(
+            check_mirror_response(206, Some(100), Some("bytes 0-99/*"), Some(855_345)),
+            MirrorResponseCheck::SizeUnknown
+        );
+    }
+
+    #[test]
+    fn mirror_response_is_rejected_when_the_addressed_size_is_unknown() {
+        // No metadata means nothing to check the mirror against. Fail closed and
+        // let the authoritative origin answer; the only cost is a mirror miss.
+        assert_eq!(
+            check_mirror_response(200, Some(855_345), None, None),
+            MirrorResponseCheck::ExpectedSizeUnknown
+        );
+    }
+
+    #[test]
+    fn content_range_total_is_parsed_from_the_standard_form() {
+        assert_eq!(parse_content_range_total("bytes 0-99/855345"), Some(855_345));
+        assert_eq!(
+            parse_content_range_total("bytes 500335-565870/565871"),
+            Some(565_871)
+        );
+    }
+
+    #[test]
+    fn content_range_total_is_absent_when_unsatisfiable_or_malformed() {
+        assert_eq!(parse_content_range_total("bytes 0-99/*"), None);
+        assert_eq!(parse_content_range_total("bytes */855345"), Some(855_345));
+        assert_eq!(parse_content_range_total("garbage"), None);
+        assert_eq!(parse_content_range_total(""), None);
+        assert_eq!(parse_content_range_total("bytes 0-99/notanumber"), None);
+    }
+
 
     #[test]
     fn absent_flag_is_disabled() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -620,7 +620,11 @@ fn handle_get_blob(req: Request, path: &str) -> Result<Response> {
 
     // Serve from the FOS mirror when it has the object, otherwise GCS (with
     // CDN fallback) and lazily copy the object into the mirror.
-    let result = download_blob_read_through(&hash, range.as_deref())?;
+    let result = download_blob_read_through(
+        &hash,
+        range.as_deref(),
+        metadata.as_ref().map(|meta| meta.size),
+    )?;
     let mut resp = result.response;
 
     // Surface provenance metadata if present on the origin object. GCS returns

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,7 +3,8 @@
 
 use crate::error::{BlossomError, Result};
 use blossom_core::read_through::{
-    object_path, parse_bool_flag, write_back_decision, MAX_WRITE_BACK_BYTES, SOURCE_FOS, SOURCE_GCS,
+    check_mirror_response, object_path, parse_bool_flag, write_back_decision, MAX_WRITE_BACK_BYTES,
+    SOURCE_FOS, SOURCE_GCS,
 };
 use fastly::http::{Method, StatusCode};
 use fastly::{Body, Request, Response};
@@ -448,16 +449,50 @@ fn download_blob_from_fos(hash: &str, range: Option<&str>) -> Result<Response> {
 /// Try to serve a blob from the FOS mirror.
 ///
 /// `None` means "not served from the mirror" for every possible reason:
-/// missing credentials or backend, transport failure, timeout, 404, or any
-/// other non-success status. The caller falls back to GCS.
-fn try_download_blob_from_fos(hash: &str, range: Option<&str>) -> Option<Response> {
-    match download_blob_from_fos(hash, range) {
-        Ok(resp) => Some(resp),
+/// missing credentials or backend, transport failure, timeout, 404, any other
+/// non-success status, or a body whose declared length does not match the size
+/// recorded for the hash. The caller falls back to GCS.
+///
+/// The length check exists because a `2xx` from the mirror is not by itself
+/// evidence that the mirror holds the object: an S3-compatible origin can answer
+/// a `Range` request for a missing key with an error document under `206`, and
+/// the serving route stamps the stored MIME type over whatever body arrives.
+fn try_download_blob_from_fos(
+    hash: &str,
+    range: Option<&str>,
+    expected_size: Option<u64>,
+) -> Option<Response> {
+    let resp = match download_blob_from_fos(hash, range) {
+        Ok(resp) => resp,
         Err(e) => {
             eprintln!("[FOS] miss hash={} reason={}", hash, e);
-            None
+            return None;
         }
+    };
+
+    let status = resp.get_status().as_u16();
+    let content_length = resp.get_content_length().map(|len| len as u64);
+    let content_range = resp
+        .get_header_str("Content-Range")
+        .map(|value| value.to_string());
+
+    let check = check_mirror_response(
+        status,
+        content_length,
+        content_range.as_deref(),
+        expected_size,
+    );
+    if !check.is_trusted() {
+        eprintln!(
+            "[FOS] miss hash={} reason=untrusted_response check={} status={}",
+            hash,
+            check.reason(),
+            status
+        );
+        return None;
     }
+
+    Some(resp)
 }
 
 /// A body read that stopped either at EOF or at the memory ceiling.
@@ -554,9 +589,10 @@ fn try_write_back_to_fos(hash: &str, bytes: &[u8], content_type: &str) {
 pub fn download_blob_read_through(
     hash: &str,
     range: Option<&str>,
+    expected_size: Option<u64>,
 ) -> Result<FallbackDownloadResult> {
     if fos_read_enabled() {
-        if let Some(response) = try_download_blob_from_fos(hash, range) {
+        if let Some(response) = try_download_blob_from_fos(hash, range, expected_size) {
             return Ok(FallbackDownloadResult {
                 response,
                 source: SOURCE_FOS.to_string(),


### PR DESCRIPTION
## Summary

A `2xx` from the Fastly Object Storage mirror was treated as proof that the mirror held the object. `download_blob_from_fos` accepted any `200`/`206` without looking at the body, and `handle_get_blob` then set `Content-Type` from KV metadata over whatever arrived.

This adds `check_mirror_response` in `blossom-core`: the mirror stores content-addressed data, so its declared length must agree with the size recorded for the hash — `Content-Length` for a full body, the `Content-Range` complete-length for a partial one. A mismatch is treated as a mirror miss and the request falls through to GCS.

## Motivation

Issue #198 recorded the failure on three separate blobs: a 249-byte `NoSuchKey` XML document served as `206 Partial Content` with `Content-Range: bytes 0-99/249` and `Content-Type: video/mp4`, against objects of 855345, 768323 and 852009 bytes. A client cannot distinguish that from a very short video. AVFoundation range-requests everything, so on iOS it always received the error body.

Refs #198. That issue also reported the origin ignoring `Range` on the bare blob — a separate defect, and a different cause (the `vcl_miss` Range strip on an object that was never cacheable), fixed by #205. This PR addresses only the error-body half.

## Design notes

- **Fails closed.** An undeclared length, an unsatisfied `bytes 0-99/*` range, or a caller with no metadata to check against all reject. The only cost of a false rejection is one fetch from the authoritative origin.
- **The metadata-less case is admin-only.** `handle_get_blob` 404s a non-admin request before the download when metadata is absent, so `expected_size: None` reaches the mirror only on the admin bypass path. Mirror offload for ordinary traffic is unaffected.
- **A rejection heals the mirror.** The GCS fallback that follows is digest-verified before write-back (`try_write_back_to_fos`), so a full-body request overwrites the bad object under the same key. A range request does not — `write_back_decision` rejects `had_range` — so healing needs one uncached full GET.

## Validation

Run locally on this branch:

- `cargo test -p blossom-core --locked` — 184 passed (175 before, 9 new)
- `cargo check --tests --locked` — clean
- `cargo clippy --locked --all-targets --all-features` — exits 0; warning count unchanged against `main` (31 → 31), none in the changed code

Not run locally, and why:

- `cargo test --manifest-path cloud-run-upload/Cargo.toml` and the transcoder/Python suites — untouched by this change; CI covers them.
- **The wiring in `src/storage.rs` and `src/main.rs` has no automated test.** The Fastly binary's tests fail at native link time on unresolved host symbols (`_header_insert`, `_status_get`), so nothing local or in CI executes that adapter. The decision logic it calls is fully covered in `blossom-core`; the header extraction and the early return are covered by review only. #175 (Viceroy in CI) is the standing fix for that gap.
- **I could not reproduce the original `/249` response.** It does not occur today on the blob named in #198. The mechanism is established by reading the deployed code, not by observing the failure — so this is a fix for a demonstrated code path, not a verified repro. If FOS has since changed its behaviour on missing keys, this becomes belt-and-braces rather than a live fix, and it is still worth having: the mirror is a copy, and an unverified copy of content-addressed data should not be served.

## Manual validation plan

1. Confirm a bare-blob GET and a `Range` GET on a mirrored object still return the object, with `x-cache` behaviour unchanged.
2. Confirm byte offload does not drop after rollout — a bug here shows up as every mirror read falling through to GCS.
3. Watch for `[FOS] miss ... reason=untrusted_response` in Compute logs. A steady stream of `length_mismatch` means real mirror corruption; a steady stream of `size_unknown` means the mirror is not declaring lengths and the check needs revisiting.

No visual change.