### PR TITLE
fix(vcl): drop the invented Cache-Control fallback

### DIFF
--- a/vcl/fetch.vcl
+++ b/vcl/fetch.vcl
@@ -43,12 +43,15 @@ if (beresp.status == 200 || beresp.status == 206) {
   # which is the case this helps most.
   set beresp.do_stream = true;
 
-  # Compute owns browser policy: blobs are immutable, but repairable derivatives
-  # have a shorter browser TTL. Retain the immutable default for legacy responses
-  # that do not provide an explicit policy.
-  if (!beresp.http.Cache-Control) {
-    set beresp.http.Cache-Control = "public, max-age=31536000, immutable";
-  }
+  # No Cache-Control fallback here on purpose. This block used to stamp
+  # `public, max-age=31536000, immutable` onto any response that arrived without
+  # a policy, which meant a response the origin had not classified was published
+  # to browsers as immutable for a year -- uninvalidatable, since browser caches
+  # cannot be purged. Compute sets an explicit policy on every response it means
+  # to be cacheable, so a missing header signals an origin that did not decide,
+  # and the edge must not decide on its behalf.
+  #
+  # Removed on Fastly's review (Kay Sawada, 2026-08-18, service version 16).
 
 } else if (beresp.status == 202) {
   # 202 Accepted = transcoding/transcription in progress

--- a/vcl/fetch.vcl
+++ b/vcl/fetch.vcl
@@ -43,15 +43,13 @@ if (beresp.status == 200 || beresp.status == 206) {
   # which is the case this helps most.
   set beresp.do_stream = true;
 
-  # No Cache-Control fallback here on purpose. This block used to stamp
-  # `public, max-age=31536000, immutable` onto any response that arrived without
-  # a policy, which meant a response the origin had not classified was published
-  # to browsers as immutable for a year -- uninvalidatable, since browser caches
-  # cannot be purged. Compute sets an explicit policy on every response it means
-  # to be cacheable, so a missing header signals an origin that did not decide,
-  # and the edge must not decide on its behalf.
+  # No Cache-Control fallback here on purpose. Compute owns browser policy, so a
+  # missing header must not be rewritten as public and immutable for a year.
+  # Browser caches cannot be purged after such a response is delivered.
   #
-  # Removed on Fastly's review (Kay Sawada, 2026-08-18, service version 16).
+  # This removal affects browser policy only. The successful-response branch
+  # above still assigns an edge TTL when Surrogate-Control is absent.
+  # TODO(#210): make an unclassified edge response fail closed as well.
 
 } else if (beresp.status == 202) {
   # 202 Accepted = transcoding/transcription in progress


### PR DESCRIPTION
## Summary

Removes the outer VCL fallback that invented a one-year immutable browser cache policy when the origin supplied no `Cache-Control` header.

## Motivation

Compute owns browser cache policy. When the origin does not classify a response, the outer edge must not publish it to browser caches as immutable because browser caches cannot be invalidated afterward.

The corresponding VCL change is already active; this PR brings the repository back in sync with deployed behavior. The separate edge-TTL fail-closed work remains tracked in #210.

## Linked issue

Refs #210.
Refs #208.

## Manual validation

- `cargo test --manifest-path blossom-core/Cargo.toml --locked` — 176 passed
- GitHub CI test, semantic-title, and CLA checks passed on the original head
- no visual change

## Rollout

The browser-policy fallback removal is already active. This PR does not deploy or activate VCL.