### PR TITLE
fix(cache): authorize before reusing media bytes

### DIFF
--- a/blossom-core/src/cache_policy.rs
+++ b/blossom-core/src/cache_policy.rs
@@ -10,6 +10,36 @@ pub struct CacheHeaders<'a> {
     pub surrogate_key: &'a str,
 }
 
+/// Full content-addressed objects may live in the Compute service's internal
+/// read-through cache for a year. Access control still runs before that cache
+/// is consulted; this policy applies only to the storage subrequest made after
+/// the viewer has been authorized.
+pub const IMMUTABLE_STORAGE_CACHE_TTL_SECS: u32 = 31_536_000;
+pub const IMMUTABLE_STORAGE_CACHE_SWR_SECS: u32 = 86_400;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ImmutableStorageCachePolicy {
+    Store {
+        ttl_seconds: u32,
+        stale_while_revalidate_seconds: u32,
+    },
+    DoNotStore,
+}
+
+/// Cache only a complete storage response. A partial response must never
+/// populate the shared object key, and missing/error responses must remain
+/// retryable so a later upload or origin recovery can succeed immediately.
+pub fn immutable_storage_cache_policy(status: u16) -> ImmutableStorageCachePolicy {
+    if status == 200 {
+        ImmutableStorageCachePolicy::Store {
+            ttl_seconds: IMMUTABLE_STORAGE_CACHE_TTL_SECS,
+            stale_while_revalidate_seconds: IMMUTABLE_STORAGE_CACHE_SWR_SECS,
+        }
+    } else {
+        ImmutableStorageCachePolicy::DoNotStore
+    }
+}
+
 pub fn immutable_blob_cache_headers(hash: &str) -> CacheHeaders<'_> {
     CacheHeaders {
         cache_control: "public, max-age=31536000, immutable",
@@ -86,8 +116,9 @@ pub fn cache_headers_for_policy<'a>(policy: BlobCachePolicy, hash: &'a str) -> C
 mod tests {
     use super::{
         blob_cache_policy, cache_headers_for_policy, immutable_blob_cache_headers,
-        mutable_derivative_cache_headers, private_no_store_cache_headers,
-        status_requires_private_response, BlobCachePolicy,
+        immutable_storage_cache_policy, mutable_derivative_cache_headers,
+        status_requires_private_response, BlobCachePolicy, ImmutableStorageCachePolicy,
+        IMMUTABLE_STORAGE_CACHE_SWR_SECS, IMMUTABLE_STORAGE_CACHE_TTL_SECS,
     };
     use crate::types::BlobStatus;
 
@@ -229,6 +260,30 @@ mod tests {
                 BlobCachePolicy::PrivateNoStore,
                 "{:?} must not be publicly cacheable",
                 status
+            );
+        }
+    }
+
+    #[test]
+    fn full_storage_responses_are_cached_for_a_year() {
+        assert_eq!(
+            immutable_storage_cache_policy(200),
+            ImmutableStorageCachePolicy::Store {
+                ttl_seconds: IMMUTABLE_STORAGE_CACHE_TTL_SECS,
+                stale_while_revalidate_seconds: IMMUTABLE_STORAGE_CACHE_SWR_SECS,
+            }
+        );
+        assert_eq!(IMMUTABLE_STORAGE_CACHE_TTL_SECS, 31_536_000);
+        assert_eq!(IMMUTABLE_STORAGE_CACHE_SWR_SECS, 86_400);
+    }
+
+    #[test]
+    fn partial_or_error_storage_responses_are_never_cached() {
+        for status in [206, 404, 416, 500, 503] {
+            assert_eq!(
+                immutable_storage_cache_policy(status),
+                ImmutableStorageCachePolicy::DoNotStore,
+                "status {status} must not populate the shared full-object cache"
             );
         }
     }

--- a/scripts/test-authenticated-storage-cache.sh
+++ b/scripts/test-authenticated-storage-cache.sh
@@ -41,11 +41,20 @@ FIRST_CODE=$(nak curl -sS -D "$FIRST_HEADERS" -o /dev/null -w '%{http_code}' "$U
 grep -qi '^cache-control:.*\(private\|no-store\)' "$FIRST_HEADERS" || \
   fail "authorized response is missing private/no-store browser policy"
 
-SECOND_CODE=$(nak curl -sS -D "$SECOND_HEADERS" -o /dev/null -w '%{http_code}' "$URL")
-[ "$SECOND_CODE" = "200" ] || fail "second valid NIP-98 request returned $SECOND_CODE, expected 200"
-
-grep -qi '^x-divine-storage-cache:.*HIT' "$SECOND_HEADERS" || \
-  fail "second authorized request was not served from the internal storage cache"
+CACHE_HIT=false
+ATTEMPT=0
+while [ "$ATTEMPT" -lt 5 ]; do
+  ATTEMPT=$((ATTEMPT + 1))
+  REPEAT_CODE=$(nak curl -sS -D "$SECOND_HEADERS" -o /dev/null -w '%{http_code}' "$URL")
+  [ "$REPEAT_CODE" = "200" ] || \
+    fail "authorized repeat $ATTEMPT returned $REPEAT_CODE, expected 200"
+  if grep -qi '^x-divine-storage-cache:.*HIT' "$SECOND_HEADERS"; then
+    CACHE_HIT=true
+    break
+  fi
+done
+[ "$CACHE_HIT" = "true" ] || \
+  fail "internal storage cache did not produce a HIT within 5 authorized repeats"
 
 RANGE_CODE=$(nak curl -sS -D "$RANGE_HEADERS" -o /dev/null -w '%{http_code}' \
   -H 'Range: bytes=0-1023' "$URL")

--- a/scripts/test-authenticated-storage-cache.sh
+++ b/scripts/test-authenticated-storage-cache.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# ABOUTME: Verifies age-gated media authorizes before using the internal storage cache.
+# ABOUTME: Uses ephemeral NIP-98 signers; no user private key or reusable token is required.
+
+set -eu
+
+DOMAIN="${DOMAIN:-media.divine.video}"
+AGE_RESTRICTED_HASH="${AGE_RESTRICTED_HASH:-}"
+
+if ! command -v nak >/dev/null 2>&1; then
+  echo "FAIL: nak is required (https://github.com/fiatjaf/nak)" >&2
+  exit 2
+fi
+
+if ! printf '%s' "$AGE_RESTRICTED_HASH" | grep -Eq '^[0-9a-fA-F]{64}$'; then
+  echo "FAIL: set AGE_RESTRICTED_HASH to a maintained 64-hex age-gated fixture" >&2
+  exit 2
+fi
+
+URL="https://${DOMAIN}/${AGE_RESTRICTED_HASH}"
+FIRST_HEADERS=$(mktemp)
+SECOND_HEADERS=$(mktemp)
+trap 'rm -f "$FIRST_HEADERS" "$SECOND_HEADERS"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+ANON_CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$URL")
+[ "$ANON_CODE" = "401" ] || fail "anonymous request returned $ANON_CODE, expected 401"
+
+FORGED_CODE=$(curl -sS -o /dev/null -w '%{http_code}' \
+  -H 'Authorization: Nostr c21va2U=' "$URL")
+[ "$FORGED_CODE" = "401" ] || fail "forged NIP-98 request returned $FORGED_CODE, expected 401"
+
+FIRST_CODE=$(nak curl -sS -D "$FIRST_HEADERS" -o /dev/null -w '%{http_code}' "$URL")
+[ "$FIRST_CODE" = "200" ] || fail "valid NIP-98 request returned $FIRST_CODE, expected 200"
+
+grep -qi '^cache-control:.*\(private\|no-store\)' "$FIRST_HEADERS" || \
+  fail "authorized response is missing private/no-store browser policy"
+
+SECOND_CODE=$(nak curl -sS -D "$SECOND_HEADERS" -o /dev/null -w '%{http_code}' "$URL")
+[ "$SECOND_CODE" = "200" ] || fail "second valid NIP-98 request returned $SECOND_CODE, expected 200"
+
+grep -qi '^x-divine-storage-cache:.*HIT' "$SECOND_HEADERS" || \
+  fail "second authorized request was not served from the internal storage cache"
+
+ANON_AFTER_WARM_CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$URL")
+[ "$ANON_AFTER_WARM_CODE" = "401" ] || \
+  fail "anonymous request returned $ANON_AFTER_WARM_CODE after cache warm, expected 401"
+
+echo "PASS: NIP-98 is checked before an authorized internal storage-cache HIT"

--- a/scripts/test-authenticated-storage-cache.sh
+++ b/scripts/test-authenticated-storage-cache.sh
@@ -20,7 +20,8 @@ fi
 URL="https://${DOMAIN}/${AGE_RESTRICTED_HASH}"
 FIRST_HEADERS=$(mktemp)
 SECOND_HEADERS=$(mktemp)
-trap 'rm -f "$FIRST_HEADERS" "$SECOND_HEADERS"' EXIT
+RANGE_HEADERS=$(mktemp)
+trap 'rm -f "$FIRST_HEADERS" "$SECOND_HEADERS" "$RANGE_HEADERS"' EXIT
 
 fail() {
   echo "FAIL: $1" >&2
@@ -45,6 +46,14 @@ SECOND_CODE=$(nak curl -sS -D "$SECOND_HEADERS" -o /dev/null -w '%{http_code}' "
 
 grep -qi '^x-divine-storage-cache:.*HIT' "$SECOND_HEADERS" || \
   fail "second authorized request was not served from the internal storage cache"
+
+RANGE_CODE=$(nak curl -sS -D "$RANGE_HEADERS" -o /dev/null -w '%{http_code}' \
+  -H 'Range: bytes=0-1023' "$URL")
+[ "$RANGE_CODE" = "206" ] || fail "authorized range request returned $RANGE_CODE, expected 206"
+grep -qi '^content-range: bytes 0-1023/' "$RANGE_HEADERS" || \
+  fail "authorized range response is missing the requested Content-Range"
+grep -qi '^x-divine-storage-cache:.*HIT' "$RANGE_HEADERS" || \
+  fail "authorized range request was not synthesized from the internal cached object"
 
 ANON_AFTER_WARM_CODE=$(curl -sS -o /dev/null -w '%{http_code}' "$URL")
 [ "$ANON_AFTER_WARM_CODE" = "401" ] || \

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -2,6 +2,7 @@
 // ABOUTME: Implements AWS v4 signing plus read-through delivery from the FOS mirror
 
 use crate::error::{BlossomError, Result};
+use blossom_core::cache_policy::{immutable_storage_cache_policy, ImmutableStorageCachePolicy};
 use blossom_core::read_through::{
     object_path, parse_bool_flag, write_back_decision, MAX_WRITE_BACK_BYTES, SOURCE_FOS, SOURCE_GCS,
 };
@@ -9,7 +10,7 @@ use fastly::http::{Method, StatusCode};
 use fastly::{Body, Request, Response};
 use hmac::{Hmac, Mac};
 use sha2::{Digest, Sha256};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Backend name (must match fastly.toml)
 const GCS_BACKEND: &str = "gcs_storage";
@@ -56,6 +57,11 @@ const FOS_BUCKET: &str = "divine-media-delivery";
 /// Config keys for the two independent read-through feature flags.
 const FOS_READ_FLAG: &str = "fos_read_enabled";
 const FOS_WRITE_BACK_FLAG: &str = "fos_write_back_enabled";
+
+/// Header copied from the storage subrequest before the outer VCL service
+/// replaces `X-Cache` with its own cache result. This is intentionally only a
+/// cache-state label (HIT/MISS), never a credential or storage identifier.
+pub const STORAGE_CACHE_HEADER: &str = "X-Divine-Storage-Cache";
 
 /// Multipart upload threshold (5MB)
 const MULTIPART_THRESHOLD: u64 = 5 * 1024 * 1024;
@@ -289,10 +295,12 @@ pub fn download_blob(hash: &str, range: Option<&str>) -> Result<Response> {
 
     // Sign the request
     sign_request(&mut req, &config, Some("UNSIGNED-PAYLOAD".into()))?;
+    enable_immutable_storage_cache(&mut req, hash);
 
-    let resp = req
+    let mut resp = req
         .send(GCS_BACKEND)
         .map_err(|e| BlossomError::StorageError(format!("Failed to download: {}", e)))?;
+    preserve_storage_cache_state(&mut resp);
 
     let status = resp.get_status();
     match status {
@@ -430,10 +438,12 @@ fn download_blob_from_fos(hash: &str, range: Option<&str>) -> Result<Response> {
     }
 
     sign_request(&mut req, &config, Some("UNSIGNED-PAYLOAD".into()))?;
+    enable_immutable_storage_cache(&mut req, hash);
 
-    let resp = req
+    let mut resp = req
         .send(FOS_BACKEND)
         .map_err(|e| BlossomError::StorageError(format!("FOS request failed: {}", e)))?;
+    preserve_storage_cache_state(&mut resp);
 
     let status = resp.get_status();
     match status {
@@ -442,6 +452,43 @@ fn download_blob_from_fos(hash: &str, range: Option<&str>) -> Result<Response> {
             "FOS returned status: {}",
             status
         ))),
+    }
+}
+
+/// Configure Fastly's HTTP read-through cache for a storage GET.
+///
+/// The caller reaches this function only after the media route has evaluated
+/// metadata access using a cryptographically validated NIP-98/BUD-01 event.
+/// The cache key is the storage URL/host, not the viewer credential, so every
+/// authorized request can reuse the same immutable bytes while authorization
+/// is still rechecked on every outer request.
+fn enable_immutable_storage_cache(req: &mut Request, hash: &str) {
+    let surrogate_key = hash.to_ascii_lowercase();
+
+    req.set_after_send(move |candidate| {
+        match immutable_storage_cache_policy(candidate.get_status().as_u16()) {
+            ImmutableStorageCachePolicy::Store {
+                ttl_seconds,
+                stale_while_revalidate_seconds,
+            } => {
+                candidate.set_cacheable();
+                candidate.set_ttl(Duration::from_secs(ttl_seconds.into()));
+                candidate.set_stale_while_revalidate(Duration::from_secs(
+                    stale_while_revalidate_seconds.into(),
+                ));
+                candidate.set_surrogate_keys([surrogate_key.as_str()]);
+            }
+            ImmutableStorageCachePolicy::DoNotStore => {
+                candidate.set_uncacheable(false);
+            }
+        }
+        Ok(())
+    });
+}
+
+fn preserve_storage_cache_state(resp: &mut Response) {
+    if let Some(cache_state) = resp.get_header_str("X-Cache").map(str::to_owned) {
+        resp.set_header(STORAGE_CACHE_HEADER, cache_state);
     }
 }
 

--- a/vcl/recv.vcl
+++ b/vcl/recv.vcl
@@ -30,11 +30,13 @@ if (req.http.Authorization) {
   return(pass);
 }
 
-# Cache hash-based content paths: /{64-char-hex}[.ext], /{hash}.hls, /{hash}/hls/*, /{hash}.vtt, /{hash}/{quality}
-# Match paths starting with / followed by 64 hex chars
-if (req.url ~ "^/[0-9a-fA-F]{64}") {
-  return(lookup);
+# Cache hash-based content paths: /{64-char-hex}[.ext], /{hash}.hls,
+# /{hash}/hls/*, /{hash}.vtt, /{hash}/{quality}. Everything else (uploads,
+# admin, API, list, etc.) passes to Compute.
+if (req.url !~ "^/[0-9a-fA-F]{64}") {
+  return(pass);
 }
 
-# Everything else (uploads, admin, API, list, etc.) passes to Compute
-return(pass);
+# Deliberately fall through for cacheable hash paths. Fastly's generated
+# vcl_recv code selects the configured shield after this snippet, then performs
+# the default lookup. Returning lookup here would bypass that shield selection.


### PR DESCRIPTION
## Summary

- keep credentialed media requests on the Compute pass path so NIP-98/BUD-01 validation runs on every request
- cache only the immutable storage subrequest after access is allowed, with full-response-only admission, streaming/range support, and hash-based purge keys
- expose the internal storage cache state for operational verification
- let public hash paths fall through to Fastly's generated shield selection before lookup
- add an end-to-end age-gated cache-boundary and range test using ephemeral NIP-98 signers

## Motivation

Protected media should reuse immutable bytes without allowing a cache hit to bypass viewer authorization. Keying an outer shared cache only on the presence of `Authorization` is insufficient because forged headers and different authenticated identities would share the same entry. This keeps authorization in front and moves byte reuse behind the validated access decision.

Linked issue: none; production cache/shielding follow-up.

## Validation

- `cargo test --manifest-path blossom-core/Cargo.toml --locked` (178 passed)
- `cargo check --tests --locked`
- `cargo build --target wasm32-wasip1 --release --locked`
- `shellcheck scripts/test-authenticated-storage-cache.sh`
- public VCL smoke suite: 16 passed, 0 failed
- live protected-media boundary: anonymous 401; forged NIP-98 401; valid ephemeral NIP-98 200; authorized repeat storage-cache HIT; cached range 206; anonymous remains 401 after warm
- live cold public probe traversed the configured shield before the delivery POP

## Deployment / manual follow-up

The combined package is active on Compute service version 344 and the recv snippet is active on VCL service version 18. Monitor pass rate, byte hit ratio, 5xx, and storage-cache HITs after merge. The hand-managed VCL service must remain aligned with `vcl/recv.vcl`.

No visual change.