### PR TITLE
test(scripts): cover the moderation-status cache policy in the VCL smoke test

### DIFF
--- a/scripts/smoke-test-vcl.sh
+++ b/scripts/smoke-test-vcl.sh
@@ -3,7 +3,10 @@
 # ABOUTME: Tests all critical paths after domain switch
 
 DOMAIN="${1:-media.divine.video}"
-HASH="832e9a4d6b9de70ceffb134ddd77b96b9b9de371457892092aa6aa853cd3f8a1"
+# Fixture blob. Override with $2 to smoke a blob in a different moderation
+# status -- the cache-policy section below derives its expectations from the
+# response, so it is valid for Active and Pending alike.
+HASH="${2:-832e9a4d6b9de70ceffb134ddd77b96b9b9de371457892092aa6aa853cd3f8a1}"
 PASS=0
 FAIL=0
 
@@ -29,7 +32,7 @@ R1=$(curl -s -D /tmp/smoke_h1 -o /dev/null -w "%{http_code}" "https://$DOMAIN/$H
 H1=$(cat /tmp/smoke_h1)
 check "200 OK" "200" "$R1"
 check "Content-Type video" "video/mp4" "$H1"
-check "Cache-Control immutable" "immutable" "$H1"
+check "Cache-Control public" "public" "$H1"
 if echo "$H1" | grep -qi "access-control-allow-origin"; then
   echo "  PASS: CORS headers"; PASS=$((PASS + 1))
 else
@@ -107,6 +110,76 @@ else
   echo "  PASS: No Surrogate-Key leaked"
   PASS=$((PASS + 1))
 fi
+echo ""
+
+# 9b. Cache policy agrees across every route that serves the same blob
+#
+# The bug this guards against (#205, #206): GET returned `private, no-store` for
+# a Pending blob while HEAD and the derivative routes treated the same blob as
+# publicly cacheable. That made ~72% of production video objects uncacheable
+# while every individual route looked self-consistent.
+#
+# Expectations are derived from the response rather than hard-coded, so this
+# holds for any moderation status that serves 200 to an anonymous caller:
+#   Active  -> public, max-age=31536000, immutable
+#   Pending -> public, max-age=86400      (revocable: purgeable at the edge,
+#                                          short enough in browsers that a later
+#                                          moderation decision reaches clients)
+echo "[9b] Cache policy consistent across routes"
+
+policy_of() {
+  # Collapse a Cache-Control value to a policy class.
+  case "$1" in
+    *private*|*no-store*) echo "private" ;;
+    *immutable*)          echo "immutable-public" ;;
+    *public*)             echo "revocable-public" ;;
+    *)                    echo "unknown" ;;
+  esac
+}
+
+cc_of() {
+  curl -s -I --max-time 20 "$1" 2>/dev/null \
+    | grep -i '^cache-control:' | cut -d' ' -f2- | tr -d '\r'
+}
+
+CC_GET=$(curl -s -D - -o /dev/null --max-time 30 "https://$DOMAIN/$HASH" 2>/dev/null \
+  | grep -i '^cache-control:' | cut -d' ' -f2- | tr -d '\r')
+CC_HEAD=$(cc_of "https://$DOMAIN/$HASH")
+CC_THUMB=$(cc_of "https://$DOMAIN/$HASH.jpg")
+
+P_GET=$(policy_of "$CC_GET")
+P_HEAD=$(policy_of "$CC_HEAD")
+P_THUMB=$(policy_of "$CC_THUMB")
+
+echo "  INFO: GET=$CC_GET"
+echo "  INFO: HEAD=$CC_HEAD"
+echo "  INFO: thumbnail=$CC_THUMB"
+
+if [ "$P_GET" = "$P_HEAD" ] && [ "$P_GET" = "$P_THUMB" ]; then
+  echo "  PASS: GET, HEAD and thumbnail agree ($P_GET)"; PASS=$((PASS + 1))
+else
+  echo "  FAIL: routes disagree (GET=$P_GET HEAD=$P_HEAD thumbnail=$P_THUMB)"
+  FAIL=$((FAIL + 1))
+fi
+
+# A blob this fixture can fetch anonymously must be publicly cacheable. A
+# private policy here means the edge stores nothing and every play is an
+# origin fetch.
+if [ "$P_GET" = "private" ] || [ "$P_GET" = "unknown" ]; then
+  echo "  FAIL: anonymously readable blob is not publicly cacheable ($CC_GET)"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: anonymously readable blob is publicly cacheable"
+  PASS=$((PASS + 1))
+fi
+
+# Whichever class it is, the max-age must match it. Immutable content is
+# content-addressed and pinned for a year; revocable content must not outlive a
+# day in caches that cannot be purged.
+case "$P_GET" in
+  immutable-public) check "immutable blob pinned for a year" "max-age=31536000" "$CC_GET" ;;
+  revocable-public) check "revocable blob capped at a day" "max-age=86400" "$CC_GET" ;;
+esac
 echo ""
 
 # 10. Stats summary


### PR DESCRIPTION
## Summary

`scripts/smoke-test-vcl.sh` passed 16/16 throughout the period when a Pending blob's `GET` returned `private, no-store` while its `HEAD` and thumbnail returned `public, immutable`. It could not catch that: its fixture blob is Active, and it asserted the literal token `immutable` on the bare blob, which is only correct for Active.

This replaces that assertion with a status-aware section whose expectations are derived from the response rather than hard-coded, so one fixture is valid for any status that serves 200 to an anonymous caller.

Three assertions:
- **Every route serving a given blob must agree on the policy class** (GET, HEAD, thumbnail). The disagreement between routes *was* the bug, so this is the direct regression guard.
- **A blob readable anonymously must be publicly cacheable.** A private policy means the edge stores nothing and every play is an origin fetch.
- **The max-age must match the class**: immutable → `max-age=31536000`, revocable → `max-age=86400`.

A second positional argument selects the fixture blob, so both statuses can be smoked without editing the script.

## Motivation

Refs #206 / #205. That bug made roughly 72% of sampled production video objects uncacheable at the edge (measured in `docs/measurements/2026-08-18-cold-fill-baseline.md`, submitted separately) while every individual route looked self-consistent. The suite that was supposed to catch cache-layer regressions reported all-green the entire time.

## Validation

- **Replayed against the pre-fix headers recorded from v338** — `GET: private, no-store`, `HEAD`/thumbnail `public, max-age=31536000, immutable`. Both new assertions fail, i.e. the test catches the bug it was written for. I could not run the old binary directly, so this is the recorded header values fed through the script's own classifier, not a replay against a live v338.
- **Against production on v339**: 19/19 with the default Active fixture, 19/19 with a Pending fixture.
- `bash -n scripts/smoke-test-vcl.sh` clean.

Not verified:
- **No coverage of the private statuses.** Restricted, Banned, Deleted and admin responses are the cases where a wrong answer is a disclosure rather than a slowdown, and this script cannot reach them — they need a credential and a moderated fixture. `blossom-core` covers them as unit tests; nothing covers them end-to-end against the live service. That gap is unchanged by this PR.
- The script is not run by CI. It is a manual post-deploy check, and remains one.

## Manual validation plan

Run after the next Compute deploy, against both fixtures:

```
bash scripts/smoke-test-vcl.sh media.divine.video           # Active fixture
bash scripts/smoke-test-vcl.sh media.divine.video <pending-hash>
```

No visual change.