### PR TITLE
fix(deploy): preserve process-blob configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,12 +176,19 @@ jobs:
 
       - name: Deploy process-blob to Cloud Run
         working-directory: cloud-functions/process-blob
+        env:
+          GCP_RUNTIME_SERVICE_ACCOUNT: ${{ secrets.GCP_RUNTIME_SERVICE_ACCOUNT }}
         run: |
+          if [ -z "$GCP_RUNTIME_SERVICE_ACCOUNT" ]; then
+            echo "GCP_RUNTIME_SERVICE_ACCOUNT is required"
+            exit 1
+          fi
+
           gcloud run deploy process-blob \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
             --region=us-central1 \
             --source=. \
-            --service-account="${{ secrets.GCP_RUNTIME_SERVICE_ACCOUNT }}" \
+            --service-account="$GCP_RUNTIME_SERVICE_ACCOUNT" \
             --memory=1Gi \
             --timeout=300s \
             --no-allow-unauthenticated \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,8 @@ jobs:
             --project="${{ secrets.GCP_PROJECT_ID }}" \
             --region=us-central1 \
             --source=. \
+            --service-account="${{ secrets.GCP_RUNTIME_SERVICE_ACCOUNT }}" \
             --memory=1Gi \
             --timeout=300s \
             --no-allow-unauthenticated \
-            --set-env-vars="C2PA_MODE=off,METADATA_WEBHOOK_URL=${{ secrets.METADATA_WEBHOOK_URL }},METADATA_WEBHOOK_SECRET=${{ secrets.METADATA_WEBHOOK_SECRET }}"
+            --update-env-vars="C2PA_MODE=off,METADATA_WEBHOOK_URL=${{ secrets.METADATA_WEBHOOK_URL }},METADATA_WEBHOOK_SECRET=${{ secrets.METADATA_WEBHOOK_SECRET }}"

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -122,9 +122,9 @@ treatment; see issue #171.
 The CI `process-blob` job also sets the service's runtime identity explicitly:
 it deploys with `--service-account="$GCP_RUNTIME_SERVICE_ACCOUNT"`, read from
 the `GCP_RUNTIME_SERVICE_ACCOUNT` repository secret, and the step fails before
-`gcloud` runs when that secret is unset. The secret does not exist yet, so the
-deploy job cannot succeed until it is created and the paired IaC change
-(divine-iac-coreconfig#1767) is applied.
+`gcloud` runs when that secret is unset. The deploy job cannot succeed until
+the secret is created and the paired IaC change (divine-iac-coreconfig#1767)
+is applied.
 
 ## Exported shell variables override script defaults
 

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -105,19 +105,18 @@ service](#a-traffic-rollback-pins-the-service) for that case, and read the
 serving revision when the question is what production is answering with rather
 than what the next deploy will merge onto.
 
-Do not assume that safety applies to the other deploy paths yet:
+Current configuration-preservation status by deploy path:
 
 - `cloud-run-upload/deploy.sh` still uses `--set-env-vars` and `--set-secrets`.
 - `cloud-run-asr-parakeet/deploy.sh` still uses `--set-env-vars`.
 - `scripts/deploy-cloud-function.sh` still uses `--set-env-vars`.
-- `.github/workflows/ci.yml` still deploys `process-blob` with
-  `--set-env-vars`, so every merge to `main` can replace live `process-blob`
-  environment variables with the smaller CI set.
+- `.github/workflows/ci.yml` deploys `process-blob` with `--update-env-vars`,
+  preserving keys that the workflow does not manage.
 
 Never add new `--set-env-vars` or `--set-secrets` usage unless the command owns
 the complete live configuration. Both replace the entire configuration and
-silently drop live settings the deploy path does not name. PR #153 fixed this
-for the transcoder script only; the other deploy paths still need the same
+silently drop live settings the deploy path does not name. PR #153 fixed the
+transcoder script; the remaining manual deploy paths still need the same
 treatment; see issue #171.
 
 ## Exported shell variables override script defaults

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -77,10 +77,10 @@ GCP_PROJECT_ID=rich-compiler-479518-d2 ./scripts/deploy-cloud-function.sh
 
 ## Check live configuration before running a deploy script
 
-Only `cloud-run-transcoder/deploy.sh` currently uses `--update-env-vars` and
-`--update-secrets`, so unnamed keys are preserved for transcoder deploys. Keys it
-*does* name are overwritten with the script's defaults, which may not match what
-is running.
+`cloud-run-transcoder/deploy.sh` and the CI `process-blob` job use
+`--update-env-vars`; the transcoder script also uses `--update-secrets`. Unnamed
+keys are therefore preserved for those deploys. Keys they *do* name are
+overwritten with the deploy path's values, which may not match what is running.
 
 `gcloud run deploy` creates or updates the *service*, and `--update-env-vars`
 merges its pairs onto the service's `spec.template`. The template is therefore

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -119,6 +119,13 @@ silently drop live settings the deploy path does not name. PR #153 fixed the
 transcoder script; the remaining manual deploy paths still need the same
 treatment; see issue #171.
 
+The CI `process-blob` job also sets the service's runtime identity explicitly:
+it deploys with `--service-account="$GCP_RUNTIME_SERVICE_ACCOUNT"`, read from
+the `GCP_RUNTIME_SERVICE_ACCOUNT` repository secret, and the step fails before
+`gcloud` runs when that secret is unset. The secret does not exist yet, so the
+deploy job cannot succeed until it is created and the paired IaC change
+(divine-iac-coreconfig#1767) is applied.
+
 ## Exported shell variables override script defaults
 
 The three hand-run Cloud Run deploy scripts resolve most settings as

--- a/scripts/tests/test_process_blob_deploy_contract.py
+++ b/scripts/tests/test_process_blob_deploy_contract.py
@@ -28,8 +28,11 @@ class ProcessBlobDeployContractTest(unittest.TestCase):
 
     def test_deploy_preserves_unmanaged_environment_variables(self) -> None:
         self.assertIn("--update-env-vars=", self.job)
-        self.assertNotIn("--set-env-vars=", self.job)
-        self.assertNotIn("--set-secrets=", self.job)
+        # No trailing "=" in the rejected flags: gcloud accepts both
+        # "--set-env-vars=..." and "--set-secrets X=y:latest" spellings, and the
+        # space-separated form is what this repo's deploy scripts use.
+        self.assertNotIn("--set-env-vars", self.job)
+        self.assertNotIn("--set-secrets", self.job)
 
     def test_deploy_uses_an_explicit_runtime_identity(self) -> None:
         self.assertIn(

--- a/scripts/tests/test_process_blob_deploy_contract.py
+++ b/scripts/tests/test_process_blob_deploy_contract.py
@@ -1,0 +1,33 @@
+"""Safety contracts for the process-blob Cloud Run deployment."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/ci.yml"
+
+
+class ProcessBlobDeployContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        match = re.search(r"^  deploy-process-blob:\n(?P<body>.*)\Z", workflow, re.DOTALL | re.MULTILINE)
+        if match is None:
+            raise AssertionError("deploy-process-blob job is missing")
+        cls.job = match.group("body")
+
+    def test_deploy_preserves_unmanaged_environment_variables(self) -> None:
+        self.assertIn("--update-env-vars=", self.job)
+        self.assertNotIn("--set-env-vars=", self.job)
+
+    def test_deploy_uses_an_explicit_runtime_identity(self) -> None:
+        self.assertIn(
+            '--service-account="${{ secrets.GCP_RUNTIME_SERVICE_ACCOUNT }}"',
+            self.job,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_process_blob_deploy_contract.py
+++ b/scripts/tests/test_process_blob_deploy_contract.py
@@ -9,23 +9,49 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github/workflows/ci.yml"
 
 
+def extract_job(workflow: str, job_name: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  \S|\Z)",
+        workflow,
+        re.DOTALL | re.MULTILINE,
+    )
+    if match is None:
+        raise AssertionError(f"{job_name} job is missing")
+    return match.group("body")
+
+
 class ProcessBlobDeployContractTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        match = re.search(r"^  deploy-process-blob:\n(?P<body>.*)\Z", workflow, re.DOTALL | re.MULTILINE)
-        if match is None:
-            raise AssertionError("deploy-process-blob job is missing")
-        cls.job = match.group("body")
+        cls.job = extract_job(workflow, "deploy-process-blob")
 
     def test_deploy_preserves_unmanaged_environment_variables(self) -> None:
         self.assertIn("--update-env-vars=", self.job)
         self.assertNotIn("--set-env-vars=", self.job)
+        self.assertNotIn("--set-secrets=", self.job)
 
     def test_deploy_uses_an_explicit_runtime_identity(self) -> None:
         self.assertIn(
-            '--service-account="${{ secrets.GCP_RUNTIME_SERVICE_ACCOUNT }}"',
+            "GCP_RUNTIME_SERVICE_ACCOUNT: ${{ secrets.GCP_RUNTIME_SERVICE_ACCOUNT }}",
             self.job,
+        )
+        self.assertIn('if [ -z "$GCP_RUNTIME_SERVICE_ACCOUNT" ]; then', self.job)
+        self.assertIn('--service-account="$GCP_RUNTIME_SERVICE_ACCOUNT"', self.job)
+
+    def test_job_extraction_stops_at_the_next_job(self) -> None:
+        workflow = """jobs:
+  deploy-process-blob:
+    steps:
+      - run: expected
+  unrelated:
+    steps:
+      - run: --set-env-vars=unexpected
+"""
+
+        self.assertEqual(
+            "    steps:\n      - run: expected\n",
+            extract_job(workflow, "deploy-process-blob"),
         )
 
 


### PR DESCRIPTION
## Summary

- deploy `process-blob` with `--update-env-vars` so CI preserves environment keys it does not own
- select the Cloud Run runtime identity explicitly through `GCP_RUNTIME_SERVICE_ACCOUNT`
- add a CI contract test that rejects destructive environment replacement
- update the deployment runbook

## Motivation

The process-blob job is currently blocked at Workload Identity authentication. Once that is repaired, the existing `--set-env-vars` command could silently delete live configuration. This closes that deployment hazard before enabling the job and pairs with divinevideo/divine-iac-coreconfig#1767.

## Linked issues

- #144
- #171
- #174

## Manual validation

- `python3 -m unittest scripts/tests/test_process_blob_deploy_contract.py` (3 passed)
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (96 passed)
- parsed `.github/workflows/ci.yml` with Ruby YAML
- `git diff --check`

No visual change. This PR must not merge until the IaC change is applied and the repository identity secrets are updated.
