### PR TITLE
fix(deploy): refuse production transcoder deploys with the wrong bucket

### DIFF
--- a/cloud-run-transcoder/deploy.sh
+++ b/cloud-run-transcoder/deploy.sh
@@ -42,6 +42,16 @@ IMAGE_TAG="${IMAGE_TAG:-$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/nu
 IMAGE="gcr.io/${PROJECT_ID}/${SERVICE_NAME}:${IMAGE_TAG}"
 
 GCS_BUCKET="${GCS_BUCKET:-divine-blossom-media}"
+PRODUCTION_PROJECT_ID="rich-compiler-479518-d2"
+PRODUCTION_SERVICE_NAME="divine-transcoder"
+PRODUCTION_GCS_BUCKET="divine-blossom-media"
+if [ "${PROJECT_ID}" = "${PRODUCTION_PROJECT_ID}" ] && \
+  [ "${SERVICE_NAME}" = "${PRODUCTION_SERVICE_NAME}" ] && \
+  [ "${GCS_BUCKET}" != "${PRODUCTION_GCS_BUCKET}" ]; then
+  echo "Refusing production deploy: GCS_BUCKET must be ${PRODUCTION_GCS_BUCKET} for ${PRODUCTION_SERVICE_NAME} in ${PRODUCTION_PROJECT_ID}." >&2
+  echo "Unset the exported GCS_BUCKET and retry." >&2
+  exit 1
+fi
 WEBHOOK_URL="${WEBHOOK_URL:-https://media.divine.video/admin/transcode-status}"
 TRANSCRIPT_WEBHOOK_URL="${TRANSCRIPT_WEBHOOK_URL:-https://media.divine.video/admin/transcript-status}"
 TRANSCRIPTION_PROVIDER="${TRANSCRIPTION_PROVIDER:-gemini}"

--- a/cloud-run-transcoder/tests/test_deploy_guard.py
+++ b/cloud-run-transcoder/tests/test_deploy_guard.py
@@ -64,7 +64,7 @@ class TranscoderDeployGuardTest(unittest.TestCase):
 
     def test_nonproduction_service_can_use_nonproduction_bucket(self) -> None:
         result, calls = self.run_deploy(
-            project_id="rich-compiler-479518-d2",
+            project_id="example-staging-project",
             service_name="divine-transcoder-staging",
             gcs_bucket="divine-blossom-media-staging",
         )

--- a/cloud-run-transcoder/tests/test_deploy_guard.py
+++ b/cloud-run-transcoder/tests/test_deploy_guard.py
@@ -1,0 +1,78 @@
+"""Safety contracts for the production transcoder deploy script."""
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import unittest
+
+
+TRANSCODER_DIR = Path(__file__).resolve().parents[1]
+DEPLOY_SCRIPT = TRANSCODER_DIR / "deploy.sh"
+
+
+class TranscoderDeployGuardTest(unittest.TestCase):
+    def run_deploy(
+        self, *, project_id: str, service_name: str, gcs_bucket: str
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            calls_path = temp_path / "gcloud-calls"
+            gcloud_path = temp_path / "gcloud"
+            gcloud_path.write_text(
+                '#!/bin/sh\nprintf "%s\\n" "$*" >> "$GCLOUD_CALLS"\nexit 0\n',
+                encoding="utf-8",
+            )
+            gcloud_path.chmod(gcloud_path.stat().st_mode | stat.S_IXUSR)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{temp_path}:{env['PATH']}",
+                    "GCLOUD_CALLS": str(calls_path),
+                    "PROJECT_ID": project_id,
+                    "GCP_PROJECT_ID": project_id,
+                    "SERVICE_NAME": service_name,
+                    "SERVICE_ACCOUNT": "runtime@example.invalid",
+                    "IMAGE_TAG": "test",
+                    "GCS_BUCKET": gcs_bucket,
+                }
+            )
+
+            result = subprocess.run(
+                ["bash", str(DEPLOY_SCRIPT)],
+                cwd=TRANSCODER_DIR,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            calls = calls_path.read_text(encoding="utf-8") if calls_path.exists() else ""
+            return result, calls
+
+    def test_production_deploy_rejects_nonproduction_bucket_before_build(self) -> None:
+        result, calls = self.run_deploy(
+            project_id="rich-compiler-479518-d2",
+            service_name="divine-transcoder",
+            gcs_bucket="divine-blossom-media-staging",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Refusing production deploy", result.stderr)
+        self.assertNotIn("builds submit", calls)
+
+    def test_nonproduction_service_can_use_nonproduction_bucket(self) -> None:
+        result, calls = self.run_deploy(
+            project_id="rich-compiler-479518-d2",
+            service_name="divine-transcoder-staging",
+            gcs_bucket="divine-blossom-media-staging",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("builds submit", calls)
+        self.assertIn("run deploy divine-transcoder-staging", calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud-run-transcoder/tests/test_deploy_guard.py
+++ b/cloud-run-transcoder/tests/test_deploy_guard.py
@@ -52,6 +52,12 @@ class TranscoderDeployGuardTest(unittest.TestCase):
             return result, calls
 
     def test_production_deploy_rejects_nonproduction_bucket_before_build(self) -> None:
+        # Reproduces the deploy that redirected the production transcoder to a
+        # non-production bucket and broke transcoding for four and a half hours.
+        # The bucket name here is deliberately fictional: the guard rejects any
+        # value that is not the production bucket, so naming a real one would
+        # add a live infrastructure identifier to a public repository without
+        # making the test any stronger.
         result, calls = self.run_deploy(
             project_id="rich-compiler-479518-d2",
             service_name="divine-transcoder",

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -139,11 +139,11 @@ half hours.
 Do not export deploy-time variables (`GCS_BUCKET`, `PROJECT_ID`, and friends)
 from a shell profile. Set them inline on the one command that needs them.
 
-Nothing in this repository checks a deploy's resolved variables against what is
-running, so there is no automated backstop for this trap today. The
-configuration check above will not catch it either: that check deliberately
-reads names and not values, so a `GCS_BUCKET` aimed at the staging bucket looks
-identical to one aimed at production.
+The transcoder deploy script has one narrow automated backstop: before starting
+Cloud Build, it refuses to deploy the production service in the production
+project with any bucket other than `divine-blossom-media`. The configuration
+check above would not catch this by itself because it deliberately reads names
+and not values. Other resolved deploy variables are still unchecked.
 
 What does catch it is checking your own shell before you deploy. Read the
 variable names straight out of the scripts so the list cannot drift, and test
@@ -172,7 +172,7 @@ an exported `MAX_INSTANCES` or `CONCURRENCY` silently reshapes production
 capacity exactly the way the exported `GCS_BUCKET` silently redirected storage.
 Deriving the list is what keeps this check honest as the scripts grow.
 
-Whoever adds an automated guard: it has to compare *fully resolved* values, and
+Whoever adds the broader automated guard: it has to compare *fully resolved* values, and
 it has to run after the script resolves its variables and before it builds
 anything. A check that parses the *defaults* out of the script text cannot catch
 this failure mode, because the whole failure is the default not applying.

--- a/docs/runbooks/deployment.md
+++ b/docs/runbooks/deployment.md
@@ -172,10 +172,10 @@ an exported `MAX_INSTANCES` or `CONCURRENCY` silently reshapes production
 capacity exactly the way the exported `GCS_BUCKET` silently redirected storage.
 Deriving the list is what keeps this check honest as the scripts grow.
 
-Whoever adds the broader automated guard: it has to compare *fully resolved* values, and
-it has to run after the script resolves its variables and before it builds
-anything. A check that parses the *defaults* out of the script text cannot catch
-this failure mode, because the whole failure is the default not applying.
+Whoever adds the broader automated guard: it has to compare *fully resolved*
+values, and it has to run after the script resolves its variables and before it
+builds anything. A check that parses the *defaults* out of the script text cannot
+catch this failure mode, because the whole failure is the default not applying.
 (Reading variable *names* out of the script, as the shell check above does, is a
 different and safe operation: what it looks for lives in the operator's
 environment, not in the script's text.)


### PR DESCRIPTION
## Summary

- refuse production `divine-transcoder` deploys when the resolved GCS bucket is not the production media bucket
- fail before Cloud Build so a contaminated shell cannot publish or activate a bad revision
- add executable regression coverage for both the refusal and an allowed non-production service
- update the deployment runbook with the enforced invariant and remaining exported-variable risk

## Motivation

The deploy script accepts exported variables as overrides. A stale non-production bucket in an operator shell can therefore redirect the production transcoder and cause derivative/transcription failures. The guard enforces the production project/service/bucket relationship at the source.

Closes #228.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 32 passed
- `bash -n deploy.sh`
- `shellcheck deploy.sh`
- `git diff --check`

## Manual validation plan

Run the deploy script with stubbed `gcloud` under the production project/service and a non-production bucket; confirm it exits before `gcloud builds submit`. Repeat with a non-production service and confirm the build/deploy commands remain reachable.

No visual change.