### PR TITLE
feat(scripts): make the edge error sinks readable

### DIFF
--- a/scripts/tail-edge-errors.sh
+++ b/scripts/tail-edge-errors.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# ABOUTME: Summarises the edge and Compute error records Fastly publishes to Pub/Sub.
+# ABOUTME: Read-only -- pulls without acking, so records stay for the next reader.
+#
+# Both diagnostic sinks write to Pub/Sub and nothing consumes them, so the records
+# sit unread for the 7-day retention and then expire. This makes reading them a
+# single command instead of a research exercise.
+#
+#   vcl-error-diagnostics  Fastly-generated 5xx -- backend timeouts, unreachable
+#                          origin. These never reached Compute.
+#   compute-diagnostics    Errors Compute returned itself, with a route and an
+#                          error category.
+#
+# Messages are pulled WITHOUT --auto-ack, so they return to the subscription after
+# the ack deadline and remain available. Safe to run repeatedly; it does not drain
+# the backlog for whoever looks next.
+#
+# Usage:
+#   scripts/tail-edge-errors.sh            # both sinks, 100 records each
+#   scripts/tail-edge-errors.sh 500        # deeper pull
+#
+# Requires gcloud authenticated against the project holding the topics.
+
+set -euo pipefail
+
+PROJECT="${PUBSUB_PROJECT:-rich-compiler-479518-d2}"
+LIMIT="${1:-100}"
+
+summarise() {
+  local sub="$1" label="$2"
+  echo "=== ${label} (${sub}) ==="
+  gcloud pubsub subscriptions pull "$sub" --project "$PROJECT" \
+    --limit "$LIMIT" --format=json 2>/dev/null \
+  | python3 -c "
+import json,sys,base64,collections
+raw=sys.stdin.read()
+try: msgs=json.loads(raw)
+except Exception:
+    print('  could not read subscription -- check gcloud auth and project access'); sys.exit()
+if not msgs:
+    print('  no records'); sys.exit()
+recs=[]
+for m in msgs:
+    b=m.get('message',{}).get('data','')
+    try: b=base64.b64decode(b).decode()
+    except Exception: continue
+    try: recs.append(json.loads(b))
+    except Exception: pass
+print(f'  {len(recs)} record(s)')
+def tally(field):
+    c=collections.Counter(r.get(field) for r in recs if r.get(field) is not None)
+    return ', '.join(f'{k}={v}' for k,v in c.most_common()) or '-'
+for f in ('status','error_category','route','backend','pop','method'):
+    if any(f in r for r in recs):
+        print(f'  {f:<15}{tally(f)}')
+durs=sorted(int(r[k]) for r in recs for k in ('elapsed_ms','duration_ms') if str(r.get(k,'')).isdigit())
+if durs:
+    p=lambda q: durs[min(len(durs)-1,int(q*len(durs)))]
+    print(f'  duration_ms    min={durs[0]} p50={p(0.5)} p90={p(0.9)} max={durs[-1]}')
+ids=[r.get('request_id') for r in recs if r.get('request_id')]
+if ids: print(f'  request_ids    {len(set(ids))} distinct (correlate across sinks)')
+"
+  echo
+}
+
+echo "project ${PROJECT}, up to ${LIMIT} records per sink"
+echo "records are NOT acked -- they remain available for the next reader"
+echo
+summarise vcl-error-diagnostics-sub "Fastly-generated 5xx (never reached Compute)"
+summarise compute-diagnostics-sub   "Errors returned by Compute"


### PR DESCRIPTION
## Summary

Adds `scripts/tail-edge-errors.sh`, which summarises both Fastly diagnostic Pub/Sub sinks in one command.

## Motivation

Both sinks work — I verified this end to end, having previously and wrongly reported them as inert:

| sink | service | status |
|---|---|---|
| `vcl-error-diagnostics` | outer VCL | topic, subscription, IAM all correct; records arriving |
| `compute-diagnostics` | Compute | same; records arriving |

Neither has a consumer. `cdn-view-logs` has `cdn-view-subscriber` and `edge_upload_logs` has `edge-upload-log-subscriber`; these two have nothing. Records sit for the 7-day retention and expire unread.

Reading them meant finding the endpoint, discovering the topic and project, deriving the subscription name, and base64-decoding payloads. This makes it one command — which is what matters during an incident.

## What running it surfaced

Errors nobody had looked at:

- **500 `metadata_error`** on the `blob` and `transcript` routes
- **502 `storage_error`** on the `origin` backend
- **503 at 15431ms** — the upload first-byte timeout tracked in #227, independently confirming that diagnosis from the service's own telemetry

The `metadata_error` 500s are worth someone's attention. I have not investigated them.

## Safety

Pulls **without** `--auto-ack`, so records return to the subscription after the ack deadline and remain available for the next reader. Safe to run repeatedly; it does not drain the backlog.

## What this is not

A reader, not a fix. The durable answer is a consumer landing these in ClickHouse, following the `edge-upload-log-subscriber` pattern. I did not build that — it is new infrastructure and this was written hours before a traffic event.

## What I could NOT verify

- **Sample sizes are small** (1 and 3 records). That reflects what was in the subscriptions at the time, not a measured error rate. Do not read a rate from this output.
- **Whether every error produces a record.** `error.vcl` fires only on Fastly-generated 5xx; a 5xx that Compute returns takes the other sink. If counts ever look short, that split is the first thing to check.
- Behaviour under a large backlog — only ever run against a near-empty queue.

## Manual validation

- `bash -n scripts/tail-edge-errors.sh`
- Executed against production; output in the section above
- Re-ran to confirm records are still present, i.e. not acked away

## Linked issue

Related to #227 (the 503 it surfaces). No issue for the missing consumer yet — happy to open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)