### PR TITLE
docs(deploy): correct a false claim in the guard test comment

### DIFF
--- a/cloud-run-transcoder/tests/test_deploy_guard.py
+++ b/cloud-run-transcoder/tests/test_deploy_guard.py
@@ -54,9 +54,9 @@ class TranscoderDeployGuardTest(unittest.TestCase):
     def test_production_deploy_rejects_nonproduction_bucket_before_build(self) -> None:
         # Reproduces the deploy that redirected the production transcoder to a
         # non-production bucket and broke transcoding for four and a half hours.
-        # divine-blossom-media-staging is the real staging bucket, in the
-        # dv-platform-staging project, so this is the value an operator shell
-        # could actually have exported.
+        # This is the staging bucket value exported during the incident, so the
+        # test reproduces an input the guard must reject instead of using an
+        # arbitrary value.
         result, calls = self.run_deploy(
             project_id="rich-compiler-479518-d2",
             service_name="divine-transcoder",

--- a/cloud-run-transcoder/tests/test_deploy_guard.py
+++ b/cloud-run-transcoder/tests/test_deploy_guard.py
@@ -54,10 +54,9 @@ class TranscoderDeployGuardTest(unittest.TestCase):
     def test_production_deploy_rejects_nonproduction_bucket_before_build(self) -> None:
         # Reproduces the deploy that redirected the production transcoder to a
         # non-production bucket and broke transcoding for four and a half hours.
-        # The bucket name here is deliberately fictional: the guard rejects any
-        # value that is not the production bucket, so naming a real one would
-        # add a live infrastructure identifier to a public repository without
-        # making the test any stronger.
+        # divine-blossom-media-staging is the real staging bucket, in the
+        # dv-platform-staging project, so this is the value an operator shell
+        # could actually have exported.
         result, calls = self.run_deploy(
             project_id="rich-compiler-479518-d2",
             service_name="divine-transcoder",


### PR DESCRIPTION
## Summary

The comment added in #229 says `divine-blossom-media-staging` is a deliberately fictional bucket name.
That is false: the deployment runbook records this exact staging bucket value as the one exported during the incident.
This corrects the comment without making a claim about current infrastructure state.

## Motivation

The fixture reproduces the incident input rather than using an arbitrary value.
Calling it fictional could lead a later reader to replace the value and weaken the regression test's connection to the incident.
The test value and behavior are unchanged.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` from `cloud-run-transcoder/`: 32 passed
- Comment only; no behavior or visual change
